### PR TITLE
Fix MediaArticlePage Scrollable Promo title colour

### DIFF
--- a/src/app/legacy/components/ScrollablePromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/components/ScrollablePromo/__snapshots__/index.test.jsx.snap
@@ -95,6 +95,8 @@ exports[`ScrollablePromo it should match a11y snapshot for list 1`] = `
 
 .emotion-2 {
   display: block;
+  font-size: 1.125rem;
+  line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -102,27 +104,41 @@ exports[`ScrollablePromo it should match a11y snapshot for list 1`] = `
   color: #3F3F42;
 }
 
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-2 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
 @media (min-width: 0rem) {
   .emotion-2 {
-    margin-right: 0.5rem;
+    margin-left: 0.5rem;
   }
 }
 
 @media (min-width: 25rem) {
   .emotion-2 {
-    margin-right: 1rem;
+    margin-left: 1rem;
   }
 }
 
 @media (min-width: 63rem) {
   .emotion-2 {
-    margin-right: 0;
+    margin-left: 0;
   }
 }
 
 .emotion-4 {
   list-style: none;
-  padding-right: 0;
+  padding-left: 0;
   margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
@@ -151,35 +167,35 @@ exports[`ScrollablePromo it should match a11y snapshot for list 1`] = `
 
 @media (min-width: 0rem) {
   .emotion-6 {
-    margin-right: 0.5rem;
+    margin-left: 0.5rem;
   }
 
   .emotion-6:first-child {
-    margin-right: 0.5rem;
+    margin-left: 0.5rem;
   }
 
   .emotion-6:last-child {
-    margin-left: 0.5rem;
+    margin-right: 0.5rem;
   }
 }
 
 @media (min-width: 25rem) {
   .emotion-6 {
-    margin-right: 1rem;
+    margin-left: 1rem;
   }
 
   .emotion-6:first-child {
-    margin-right: 1rem;
+    margin-left: 1rem;
   }
 }
 
 @media (min-width: 63rem) {
   .emotion-6 {
-    margin-right: 1rem;
+    margin-left: 1rem;
   }
 
   .emotion-6:first-child {
-    margin-right: 0;
+    margin-left: 0;
   }
 }
 
@@ -215,6 +231,8 @@ exports[`ScrollablePromo it should match a11y snapshot for list 1`] = `
   text-decoration: none;
   overflow-wrap: break-word;
   display: inline-block;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -253,6 +271,20 @@ exports[`ScrollablePromo it should match a11y snapshot for list 1`] = `
   color: #6E6E73;
 }
 
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-10 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
 .emotion-10:hover,
 .emotion-10:focus {
   -webkit-text-decoration: underline;
@@ -273,16 +305,19 @@ exports[`ScrollablePromo it should match a11y snapshot for list 1`] = `
     <strong
       class="emotion-2 emotion-3"
       data-testid="eoj-recommendations-heading"
+      dir="ltr"
       id="Show-all-links-no-images"
     >
       Show all links (no images)
     </strong>
     <ul
       class="emotion-4 emotion-5"
+      dir="ltr"
       role="list"
     >
       <li
         class="emotion-6 emotion-7"
+        dir="ltr"
       >
         <div
           class="emotion-8 emotion-9"
@@ -297,6 +332,7 @@ exports[`ScrollablePromo it should match a11y snapshot for list 1`] = `
       </li>
       <li
         class="emotion-6 emotion-7"
+        dir="ltr"
       >
         <div
           class="emotion-8 emotion-9"
@@ -311,6 +347,7 @@ exports[`ScrollablePromo it should match a11y snapshot for list 1`] = `
       </li>
       <li
         class="emotion-6 emotion-7"
+        dir="ltr"
       >
         <div
           class="emotion-8 emotion-9"
@@ -422,18 +459,18 @@ exports[`ScrollablePromo it should match a11y snapshot for list with no title 1`
 }
 
 .emotion-2 {
-  margin-right: 0.5rem;
+  margin-left: 0.5rem;
 }
 
 @media (min-width: 25rem) {
   .emotion-2 {
-    margin-right: 1rem;
+    margin-left: 1rem;
   }
 }
 
 @media (min-width: 63rem) {
   .emotion-2 {
-    margin-right: 0;
+    margin-left: 0;
   }
 }
 
@@ -469,6 +506,8 @@ exports[`ScrollablePromo it should match a11y snapshot for list with no title 1`
   text-decoration: none;
   overflow-wrap: break-word;
   display: inline-block;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -507,6 +546,20 @@ exports[`ScrollablePromo it should match a11y snapshot for list with no title 1`
   color: #6E6E73;
 }
 
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-6 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-6 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
 .emotion-6:hover,
 .emotion-6:focus {
   -webkit-text-decoration: underline;
@@ -519,13 +572,14 @@ exports[`ScrollablePromo it should match a11y snapshot for list with no title 1`
 
 <div>
   <section
-    aria-label="Related Content"
+    aria-label="Related content"
     class="emotion-0 emotion-1"
     dir="ltr"
     role="region"
   >
     <div
       class="emotion-2 emotion-3"
+      dir="ltr"
     >
       <div
         class="emotion-4 emotion-5"
@@ -637,6 +691,8 @@ exports[`ScrollablePromo it should match a11y snapshot for single card 1`] = `
 
 .emotion-2 {
   display: block;
+  font-size: 1.125rem;
+  line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -644,37 +700,51 @@ exports[`ScrollablePromo it should match a11y snapshot for single card 1`] = `
   color: #3F3F42;
 }
 
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-2 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
 @media (min-width: 0rem) {
   .emotion-2 {
-    margin-right: 0.5rem;
+    margin-left: 0.5rem;
   }
 }
 
 @media (min-width: 25rem) {
   .emotion-2 {
-    margin-right: 1rem;
+    margin-left: 1rem;
   }
 }
 
 @media (min-width: 63rem) {
   .emotion-2 {
-    margin-right: 0;
+    margin-left: 0;
   }
 }
 
 .emotion-4 {
-  margin-right: 0.5rem;
+  margin-left: 0.5rem;
 }
 
 @media (min-width: 25rem) {
   .emotion-4 {
-    margin-right: 1rem;
+    margin-left: 1rem;
   }
 }
 
 @media (min-width: 63rem) {
   .emotion-4 {
-    margin-right: 0;
+    margin-left: 0;
   }
 }
 
@@ -710,6 +780,8 @@ exports[`ScrollablePromo it should match a11y snapshot for single card 1`] = `
   text-decoration: none;
   overflow-wrap: break-word;
   display: inline-block;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -748,6 +820,20 @@ exports[`ScrollablePromo it should match a11y snapshot for single card 1`] = `
   color: #6E6E73;
 }
 
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-8 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-8 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
 .emotion-8:hover,
 .emotion-8:focus {
   -webkit-text-decoration: underline;
@@ -768,18 +854,251 @@ exports[`ScrollablePromo it should match a11y snapshot for single card 1`] = `
     <strong
       class="emotion-2 emotion-3"
       data-testid="eoj-recommendations-heading"
+      dir="ltr"
       id="Single-link"
     >
       Single link
     </strong>
     <div
       class="emotion-4 emotion-5"
+      dir="ltr"
     >
       <div
         class="emotion-6 emotion-7"
       >
         <a
           class="emotion-8 emotion-9"
+          href="https://www.bbc.com/pidgin"
+        >
+          Single link
+        </a>
+      </div>
+    </div>
+  </section>
+</div>
+`;
+
+exports[`ScrollablePromo it should match snapshot when in dark ui mode 1`] = `
+@media (max-width: 14.9375rem) {
+  .emotion-0 {
+    margin-left: 0%;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-0 {
+    margin-left: 0%;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-0 {
+    margin-left: 0%;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-0 {
+    margin-left: 0%;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-0 {
+    margin-left: 20%;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-0 {
+    margin-left: 40%;
+  }
+}
+
+@supports (display: grid) {
+  .emotion-0 {
+    display: block;
+    width: initial;
+    margin: 0;
+  }
+
+  @media (max-width: 14.9375rem) {
+    .emotion-0 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-start: 1;
+    }
+  }
+
+  @media (min-width: 15rem) and (max-width: 24.9375rem) {
+    .emotion-0 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-start: 1;
+    }
+  }
+
+  @media (min-width: 25rem) and (max-width: 37.4375rem) {
+    .emotion-0 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-start: 1;
+    }
+  }
+
+  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+    .emotion-0 {
+      grid-template-columns: repeat(5, 1fr);
+      grid-column-end: span 5;
+      grid-column-start: 1;
+    }
+  }
+
+  @media (min-width: 63rem) and (max-width: 79.9375rem) {
+    .emotion-0 {
+      grid-template-columns: repeat(5, 1fr);
+      grid-column-end: span 5;
+      grid-column-start: 2;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-0 {
+      grid-template-columns: repeat(10, 1fr);
+      grid-column-end: span 10;
+      grid-column-start: 5;
+    }
+  }
+}
+
+.emotion-2 {
+  margin-left: 0.5rem;
+}
+
+@media (min-width: 25rem) {
+  .emotion-2 {
+    margin-left: 1rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-2 {
+    margin-left: 0;
+  }
+}
+
+.emotion-4 {
+  position: relative;
+  background-color: #E6E8EA;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+@media (min-width: 0rem) {
+  .emotion-4 {
+    width: 14.8125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-4 {
+    width: 11.125rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-4 {
+    width: 12.6875rem;
+  }
+}
+
+.emotion-6 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow-wrap: break-word;
+  display: inline-block;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  width: 100%;
+  overflow-wrap: break-word;
+  text-overflow: ellipsis;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  color: #141414;
+}
+
+.emotion-6:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.emotion-6:hover,
+.emotion-6:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-6:visited {
+  color: #6E6E73;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-6 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-6 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+.emotion-6:hover,
+.emotion-6:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-6:visited {
+  color: #545658;
+}
+
+<div>
+  <section
+    aria-label="Related content"
+    class="emotion-0 emotion-1"
+    dir="ltr"
+    role="region"
+  >
+    <div
+      class="emotion-2 emotion-3"
+      dir="ltr"
+    >
+      <div
+        class="emotion-4 emotion-5"
+      >
+        <a
+          class="emotion-6 emotion-7"
           href="https://www.bbc.com/pidgin"
         >
           Single link

--- a/src/app/legacy/components/ScrollablePromo/index.jsx
+++ b/src/app/legacy/components/ScrollablePromo/index.jsx
@@ -41,7 +41,8 @@ const LabelComponent = styled.strong`
   ${({ script }) => script && getDoublePica(script)};
   ${({ service }) => getSansRegular(service)}
   margin-bottom: ${GEL_SPACING_DBL};
-  color: ${props => props.theme.palette.SHADOW};
+  color: ${({ theme }) =>
+    theme.isDarkUi ? theme.palette.GREY_2 : theme.palette.SHADOW};
 
   ${({ dir }) =>
     `

--- a/src/app/legacy/components/ScrollablePromo/index.test.jsx
+++ b/src/app/legacy/components/ScrollablePromo/index.test.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import * as viewTracking from '#hooks/useViewTracker';
-import { ToggleContextProvider } from '#contexts/ToggleContext';
 import * as clickTracking from '#hooks/useClickTrackerHandler';
 import { render } from '../../../components/react-testing-library-with-providers';
-import { ServiceContext } from '../../../contexts/ServiceContext';
 import {
   threeLinks,
   oneLinkOnly,
@@ -12,39 +10,29 @@ import {
 } from './helpers/fixtureData';
 import ScrollablePromo from '.';
 import { edOjA, edOjB } from './fixtures';
-
-// eslint-disable-next-line react/prop-types
-const ScrollablePromoWithContext = ({ blocks, blockGroupIndex }) => (
-  <ToggleContextProvider>
-    <ServiceContext.Provider value={{ service: 'news' }}>
-      <ScrollablePromo blocks={blocks} blockGroupIndex={blockGroupIndex} />
-    </ServiceContext.Provider>
-  </ToggleContextProvider>
-);
+import { MEDIA_ARTICLE_PAGE } from '../../../routes/utils/pageTypes';
 
 describe('ScrollablePromo', () => {
   it('should return null if no data is passed', () => {
-    const { container } = render(<ScrollablePromoWithContext blocks={[]} />);
+    const { container } = render(<ScrollablePromo blocks={[]} />);
     expect(container).toBeEmptyDOMElement();
   });
 
   it('should render max 3 promo items', () => {
     const { getAllByRole } = render(
-      <ScrollablePromoWithContext blocks={moreThanThreeLinks} />,
+      <ScrollablePromo blocks={moreThanThreeLinks} />,
     );
     expect(getAllByRole('listitem').length).toEqual(3);
   });
 
   it('should render single promo item', () => {
-    const { container } = render(
-      <ScrollablePromoWithContext blocks={oneLinkOnly} />,
-    );
+    const { container } = render(<ScrollablePromo blocks={oneLinkOnly} />);
     expect(container.childElementCount).toEqual(1);
   });
 
   it('should render single promo item with a title', () => {
     const { container, getByTestId } = render(
-      <ScrollablePromoWithContext blocks={oneLinkOnly} />,
+      <ScrollablePromo blocks={oneLinkOnly} />,
     );
     expect(container.childElementCount).toEqual(1);
     expect(getByTestId('eoj-recommendations-heading')).toBeInTheDocument();
@@ -52,7 +40,7 @@ describe('ScrollablePromo', () => {
 
   it('should render single promo item without a title', () => {
     const { container, queryByTestId } = render(
-      <ScrollablePromoWithContext blocks={oneLinkWithNoTitle} />,
+      <ScrollablePromo blocks={oneLinkWithNoTitle} />,
     );
     expect(container.childElementCount).toEqual(1);
     expect(
@@ -61,9 +49,7 @@ describe('ScrollablePromo', () => {
   });
 
   it('should not render a list when there is only one promo', () => {
-    const { queryByRole } = render(
-      <ScrollablePromoWithContext blocks={oneLinkOnly} />,
-    );
+    const { queryByRole } = render(<ScrollablePromo blocks={oneLinkOnly} />);
 
     expect(queryByRole('list')).not.toBeInTheDocument();
     expect(queryByRole('listitem')).not.toBeInTheDocument();
@@ -71,7 +57,7 @@ describe('ScrollablePromo', () => {
 
   it('should render unordered list if more than 1 item', () => {
     const { queryByRole, getAllByRole } = render(
-      <ScrollablePromoWithContext blocks={threeLinks} />,
+      <ScrollablePromo blocks={threeLinks} />,
     );
     expect(queryByRole('list')).toBeInTheDocument();
     expect(getAllByRole('listitem').length).toEqual(3);
@@ -86,10 +72,7 @@ describe('ScrollablePromo', () => {
       const viewTrackerSpy = jest.spyOn(viewTracking, 'default');
 
       render(
-        <ScrollablePromoWithContext
-          blocks={edOjA.model.blocks}
-          blockGroupIndex={1}
-        />,
+        <ScrollablePromo blocks={edOjA.model.blocks} blockGroupIndex={1} />,
       );
 
       expect(viewTrackerSpy).toHaveBeenCalledWith({
@@ -101,16 +84,10 @@ describe('ScrollablePromo', () => {
     it('should call the view tracking hook with the correct params with multiple editorial onward journeys', () => {
       const viewTrackerSpy = jest.spyOn(viewTracking, 'default');
       render(
-        <ScrollablePromoWithContext
-          blocks={edOjA.model.blocks}
-          blockGroupIndex={1}
-        />,
+        <ScrollablePromo blocks={edOjA.model.blocks} blockGroupIndex={1} />,
       );
       render(
-        <ScrollablePromoWithContext
-          blocks={edOjB.model.blocks}
-          blockGroupIndex={2}
-        />,
+        <ScrollablePromo blocks={edOjB.model.blocks} blockGroupIndex={2} />,
       );
 
       expect(viewTrackerSpy).toHaveBeenCalledTimes(2);
@@ -127,10 +104,7 @@ describe('ScrollablePromo', () => {
     it('should call the click tracking hook with one editorial onward journey', () => {
       const clickTrackerSpy = jest.spyOn(clickTracking, 'default');
       render(
-        <ScrollablePromoWithContext
-          blocks={edOjA.model.blocks}
-          blockGroupIndex={1}
-        />,
+        <ScrollablePromo blocks={edOjA.model.blocks} blockGroupIndex={1} />,
       );
 
       expect(clickTrackerSpy).toHaveBeenCalledWith({
@@ -142,16 +116,10 @@ describe('ScrollablePromo', () => {
     it('should call the click tracking hook with multiple editorial onward journeys', () => {
       const clickTrackerSpy = jest.spyOn(clickTracking, 'default');
       render(
-        <ScrollablePromoWithContext
-          blocks={edOjA.model.blocks}
-          blockGroupIndex={1}
-        />,
+        <ScrollablePromo blocks={edOjA.model.blocks} blockGroupIndex={1} />,
       );
       render(
-        <ScrollablePromoWithContext
-          blocks={edOjB.model.blocks}
-          blockGroupIndex={2}
-        />,
+        <ScrollablePromo blocks={edOjB.model.blocks} blockGroupIndex={2} />,
       );
 
       expect(clickTrackerSpy).toHaveBeenCalledTimes(2);
@@ -167,21 +135,26 @@ describe('ScrollablePromo', () => {
   });
 
   it('it should match a11y snapshot for single card', () => {
-    const { container } = render(
-      <ScrollablePromoWithContext blocks={oneLinkOnly} />,
-    );
+    const { container } = render(<ScrollablePromo blocks={oneLinkOnly} />);
     expect(container).toMatchSnapshot();
   });
 
   it('it should match a11y snapshot for list', () => {
-    const { container } = render(
-      <ScrollablePromoWithContext blocks={threeLinks} />,
-    );
+    const { container } = render(<ScrollablePromo blocks={threeLinks} />);
     expect(container).toMatchSnapshot();
   });
   it('it should match a11y snapshot for list with no title', () => {
     const { container } = render(
-      <ScrollablePromoWithContext blocks={oneLinkWithNoTitle} />,
+      <ScrollablePromo blocks={oneLinkWithNoTitle} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+  it('it should match snapshot when in dark ui mode', () => {
+    const { container } = render(
+      <ScrollablePromo blocks={oneLinkWithNoTitle} />,
+      {
+        pageType: MEDIA_ARTICLE_PAGE,
+      },
     );
     expect(container).toMatchSnapshot();
   });


### PR DESCRIPTION
Overall changes
======
- Fixes Scrollable promo title colour when on a MediaArticlePage
- Removes custom context wrapper for Scrollable promo tests
- Adds snapshot test to capture styling for Scrollable promo on MediaArticlePage

Testing
======
1. Pull down this branch
2. Navigate to http://localhost:7080/igbo/articles/crgk5yll5xzo?renderer_env=live
3. Confirm that the scrollable promo title is white in colour

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
