### PR TITLE
WSTEAM1-717: Change border from 3 to 1px

### DIFF
--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -6,7 +6,7 @@ export default {
     css({
       backgroundColor: palette.GREY_10,
       [mq.HIGH_CONTRAST]: {
-        borderBottom: `solid ${pixelsToRem(3)}rem transparent`,
+        borderBottom: `solid ${pixelsToRem(1)}rem transparent`,
       },
     }),
   outerGrid: ({ mq, gridWidths }: Theme) =>

--- a/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 
 @media screen and (forced-colors: active) {
   .emotion-0 {
-    border-bottom: solid 0.1875rem transparent;
+    border-bottom: solid 0.0625rem transparent;
   }
 }
 


### PR DESCRIPTION
Resolves JIRA [WSTEAM-717](https://jira.dev.bbc.co.uk/browse/WSTEAM1-717)

Overall changes
======
Changes border size from 3 to 1px:
![Screenshot 2023-12-05 at 12 39 44 (2)](https://github.com/bbc/simorgh/assets/32307964/1ce8af35-bae8-4249-b385-d1260c1bec44)


Code changes
======

- _Minor CSS changes._

Testing
======
1. _Visit `/pidgin/live/c07zr0zwjnnt`._
2._Turn on user colour overrides._
3._Make sure that there is a border at the bottom of the Heading._ 

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
