### PR TITLE
Updates to the navigation of Afrique, Bengali and Persian

### DIFF
--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -350,8 +350,8 @@ export const service: DefaultServiceConfig = {
         url: '/afrique/topics/c0vmyy90q8zt',
       },
       {
-        title: 'Science',
-        url: '/afrique/topics/cdr561vr57gt',
+        title: 'Science et technologie',
+        url: '/afrique/topics/crezq2zk0q4t',
       },
       {
         title: 'Technologie',

--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -354,10 +354,6 @@ export const service: DefaultServiceConfig = {
         url: '/afrique/topics/crezq2zk0q4t',
       },
       {
-        title: 'Technologie',
-        url: '/afrique/topics/cnq687nn703t',
-      },
-      {
         title: 'Economie',
         url: '/afrique/topics/cnq687nr9v1t',
       },

--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -327,12 +327,16 @@ export const service: DefaultServiceConfig = {
         url: '/bengali',
       },
       {
-        title: 'বিশ্ব',
-        url: '/bengali/topics/c907347rezkt',
+        title: 'সংসদ নির্বাচন ২০২৪',
+        url: '/bengali/topics/c90xlq1n7llt',
       },
       {
-        title: 'রাজনীতি',
-        url: '/bengali/topics/cqywj91rkg6t',
+        title: 'সর্বাধিক পঠিত',
+        url: '/bengali/popular/read',
+      },
+      {
+        title: 'বিশ্ব',
+        url: '/bengali/topics/c907347rezkt',
       },
       {
         title: 'অর্থনীতি',
@@ -351,12 +355,12 @@ export const service: DefaultServiceConfig = {
         url: '/bengali/topics/c8y94k95v52t',
       },
       {
-        title: 'ভিডিও',
-        url: '/bengali/topics/cxy7jg418e7t',
+        title: 'রাজনীতি',
+        url: '/bengali/topics/cqywj91rkg6t',
       },
       {
-        title: 'সর্বাধিক পঠিত',
-        url: '/bengali/popular/read',
+        title: 'ভিডিও',
+        url: '/bengali/topics/cxy7jg418e7t',
       },
     ],
   },

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -415,10 +415,6 @@ export const service: DefaultServiceConfig = {
         url: '/persian/topics/ckdxnwr4r1yt',
       },
       {
-        title: 'ناظران می‌گویند',
-        url: '/persian/blogs-54099951',
-      },
-      {
         title: 'رادیو',
         url: '/persian/tv-and-radio-37434376',
       },

--- a/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
@@ -249,13 +249,6 @@ exports[`AMP Articles Header Navigation link should match text and url 12`] = `
 
 exports[`AMP Articles Header Navigation link should match text and url 13`] = `
 {
-  "text": "ناظران می‌گویند",
-  "url": "/persian/blogs-54099951",
-}
-`;
-
-exports[`AMP Articles Header Navigation link should match text and url 14`] = `
-{
   "text": "رادیو",
   "url": "/persian/tv-and-radio-37434376",
 }

--- a/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
@@ -152,13 +152,6 @@ exports[`Canonical Articles Header Navigation link should match text and url 12`
 
 exports[`Canonical Articles Header Navigation link should match text and url 13`] = `
 {
-  "text": "ناظران می‌گویند",
-  "url": "/persian/blogs-54099951",
-}
-`;
-
-exports[`Canonical Articles Header Navigation link should match text and url 14`] = `
-{
   "text": "رادیو",
   "url": "/persian/tv-and-radio-37434376",
 }

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
@@ -244,8 +244,8 @@ exports[`AMP Feature Index page Header Navigation link should match text and url
 
 exports[`AMP Feature Index page Header Navigation link should match text and url 6`] = `
 {
-  "text": "Science",
-  "url": "/afrique/topics/cdr561vr57gt",
+  "text": "Science et technologie",
+  "url": "/afrique/topics/crezq2zk0q4t",
 }
 `;
 

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
@@ -103,8 +103,8 @@ exports[`Canonical Feature Index page Header Navigation link should match text a
 
 exports[`Canonical Feature Index page Header Navigation link should match text and url 6`] = `
 {
-  "text": "Science",
-  "url": "/afrique/topics/cdr561vr57gt",
+  "text": "Science et technologie",
+  "url": "/afrique/topics/crezq2zk0q4t",
 }
 `;
 

--- a/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/amp.test.js.snap
@@ -293,13 +293,6 @@ exports[`AMP persian/afghanistan IDX page Header Navigation link should match te
 
 exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 13`] = `
 {
-  "text": "ناظران می‌گویند",
-  "url": "/persian/blogs-54099951",
-}
-`;
-
-exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 14`] = `
-{
   "text": "رادیو",
   "url": "/persian/tv-and-radio-37434376",
 }

--- a/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/canonical.test.js.snap
@@ -152,13 +152,6 @@ exports[`Canonical persian/afghanistan IDX page Header Navigation link should ma
 
 exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 13`] = `
 {
-  "text": "ناظران می‌گویند",
-  "url": "/persian/blogs-54099951",
-}
-`;
-
-exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 14`] = `
-{
   "text": "رادیو",
   "url": "/persian/tv-and-radio-37434376",
 }

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
@@ -293,13 +293,6 @@ exports[`AMP Media Asset Page Header Navigation link should match text and url 1
 
 exports[`AMP Media Asset Page Header Navigation link should match text and url 13`] = `
 {
-  "text": "ناظران می‌گویند",
-  "url": "/persian/blogs-54099951",
-}
-`;
-
-exports[`AMP Media Asset Page Header Navigation link should match text and url 14`] = `
-{
   "text": "رادیو",
   "url": "/persian/tv-and-radio-37434376",
 }

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
@@ -152,13 +152,6 @@ exports[`Canonical Media Asset Page Header Navigation link should match text and
 
 exports[`Canonical Media Asset Page Header Navigation link should match text and url 13`] = `
 {
-  "text": "ناظران می‌گویند",
-  "url": "/persian/blogs-54099951",
-}
-`;
-
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 14`] = `
-{
   "text": "رادیو",
   "url": "/persian/tv-and-radio-37434376",
 }

--- a/src/integration/pages/mostWatchedPage/afrique/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/afrique/__snapshots__/amp.test.js.snap
@@ -233,8 +233,8 @@ exports[`AMP Most Watched Page Header Navigation link should match text and url 
 
 exports[`AMP Most Watched Page Header Navigation link should match text and url 6`] = `
 {
-  "text": "Science",
-  "url": "/afrique/topics/cdr561vr57gt",
+  "text": "Science et technologie",
+  "url": "/afrique/topics/crezq2zk0q4t",
 }
 `;
 

--- a/src/integration/pages/mostWatchedPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/afrique/__snapshots__/canonical.test.js.snap
@@ -103,8 +103,8 @@ exports[`Canonical Most Watched Page Header Navigation link should match text an
 
 exports[`Canonical Most Watched Page Header Navigation link should match text and url 6`] = `
 {
-  "text": "Science",
-  "url": "/afrique/topics/cdr561vr57gt",
+  "text": "Science et technologie",
+  "url": "/afrique/topics/crezq2zk0q4t",
 }
 `;
 


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
Updates to the navigation of Afrique to replace Science and Technology topics with one single topic, Bengali to add link to Elections 2024 topic and rearrange the order and to Persian to remove the Blogs link.

Code changes
======

- edited the navigation section of src/app/lib/config/services/afrique.ts to add link to /afrique/topics/crezq2zk0q4t  and remove links to Science and Technologie
- edited the navigation section of src/app/lib/config/services/bengali.ts to add link to /bengali/topics/c90xlq1n7llt
-  edited the navigation of src/app/lib/config/services/persian.ts to remove the link to /persian/blogs-54099951

Testing
======
1. Open Afrique's front page the sixth item in the navigation should be 'Science et tecnologie' pointing to /afrique/topics/crezq2zk0q4t
2. Open the Bengali front page the second item in the navigation should be সংসদ নির্বাচন ২০২৪, the navigation items should follow this order: Home| Election 2024 | Most read | World | Economy | Health | Sport | Technology | Politics | Videos
3. Open the Persian front page the Blogs link 'ناظران می‌گویند' (/persian/blogs-54099951) should no longer be in second to last position







Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
