### PR TITLE
Lighthouse `bestPractises` updates

### DIFF
--- a/src/app/components/ImageWithCaption/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/ImageWithCaption/__snapshots__/index.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`Image with data should render an image with alt text and caption 1`] = 
   margin: 0;
 }
 
-.emotion-3>span>p:last-child {
+.emotion-3>span>p:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/legacy/components/OptimoPromos/PromoItem/index.styles.jsx
+++ b/src/app/legacy/components/OptimoPromos/PromoItem/index.styles.jsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 const PromoItem = styled.li`
   height: 100%;
   margin-bottom: ${GEL_SPACING_DBL};
-  &:last-child {
+  &:last-of-type {
     margin: 0;
   }
 `;

--- a/src/app/legacy/components/ScrollablePromo/PromoList/index.jsx
+++ b/src/app/legacy/components/ScrollablePromo/PromoList/index.jsx
@@ -46,23 +46,23 @@ const StyledList = styled.li`
     `
       @media (min-width: ${GEL_GROUP_0_SCREEN_WIDTH_MIN}){
         margin-${dir === 'ltr' ? 'left' : 'right'}: ${GEL_SPACING};
-        &:first-child {
+        &:first-of-type {
           margin-${dir === 'ltr' ? 'left' : 'right'}: ${GEL_SPACING};
         }
-        &:last-child {
+        &:last-of-type {
           margin-${dir === 'ltr' ? 'right' : 'left'}: ${GEL_SPACING};
         }
       }
       @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}){
         margin-${dir === 'ltr' ? `left` : `right`}: ${GEL_SPACING_DBL};  
 
-        &:first-child {
+        &:first-of-type {
           margin-${dir === 'ltr' ? 'left' : 'right'}: ${GEL_SPACING_DBL};
         }
       }
       @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}){
           margin-${dir === 'ltr' ? `left` : `right`}: ${GEL_SPACING_DBL};
-          &:first-child {
+          &:first-of-type {
             margin-${dir === 'ltr' ? 'left' : 'right'}: 0;
           }
       }

--- a/src/app/legacy/components/ScrollablePromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/components/ScrollablePromo/__snapshots__/index.test.jsx.snap
@@ -170,11 +170,11 @@ exports[`ScrollablePromo it should match a11y snapshot for list 1`] = `
     margin-left: 0.5rem;
   }
 
-  .emotion-6:first-child {
+  .emotion-6:first-of-type {
     margin-left: 0.5rem;
   }
 
-  .emotion-6:last-child {
+  .emotion-6:last-of-type {
     margin-right: 0.5rem;
   }
 }
@@ -184,7 +184,7 @@ exports[`ScrollablePromo it should match a11y snapshot for list 1`] = `
     margin-left: 1rem;
   }
 
-  .emotion-6:first-child {
+  .emotion-6:first-of-type {
     margin-left: 1rem;
   }
 }
@@ -194,7 +194,7 @@ exports[`ScrollablePromo it should match a11y snapshot for list 1`] = `
     margin-left: 1rem;
   }
 
-  .emotion-6:first-child {
+  .emotion-6:first-of-type {
     margin-left: 0;
   }
 }

--- a/src/app/legacy/containers/ArticleTimestamp/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/ArticleTimestamp/__snapshots__/index.test.jsx.snap
@@ -136,7 +136,7 @@ exports[`ArticleTimestamp should render a 'created' Timestamp correctly 1`] = `
   }
 }
 
-.emotion-3:last-child {
+.emotion-3:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -291,7 +291,7 @@ exports[`ArticleTimestamp should render both a 'created' and an 'updated' Timest
   }
 }
 
-.emotion-3:last-child {
+.emotion-3:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -454,7 +454,7 @@ exports[`ArticleTimestamp should render with a prefix 1`] = `
   }
 }
 
-.emotion-3:last-child {
+.emotion-3:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -617,7 +617,7 @@ exports[`ArticleTimestamp should render with a suffix 1`] = `
   }
 }
 
-.emotion-3:last-child {
+.emotion-3:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -780,7 +780,7 @@ exports[`ArticleTimestamp should render with no suffix or prefix 1`] = `
   }
 }
 
-.emotion-3:last-child {
+.emotion-3:last-of-type {
   padding-bottom: 1rem;
 }
 

--- a/src/app/legacy/containers/Caption/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/Caption/__snapshots__/index.test.jsx.snap
@@ -43,7 +43,7 @@ exports[`should render caption text with example Farsi offscreen text 1`] = `
   margin: 0;
 }
 
-.emotion-0>span>p:last-child {
+.emotion-0>span>p:last-of-type {
   padding-bottom: 0;
 }
 
@@ -138,7 +138,7 @@ exports[`should render caption text with example News offscreen text 1`] = `
   margin: 0;
 }
 
-.emotion-0>span>p:last-child {
+.emotion-0>span>p:last-of-type {
   padding-bottom: 0;
 }
 
@@ -233,7 +233,7 @@ exports[`should render caption with multiple paragraphs 1`] = `
   margin: 0;
 }
 
-.emotion-0>span>p:last-child {
+.emotion-0>span>p:last-of-type {
   padding-bottom: 0;
 }
 
@@ -334,7 +334,7 @@ exports[`should render correctly with inline block 1`] = `
   margin: 0;
 }
 
-.emotion-0>span>p:last-child {
+.emotion-0>span>p:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/legacy/containers/CpsFeaturesAnalysis/index.jsx
+++ b/src/app/legacy/containers/CpsFeaturesAnalysis/index.jsx
@@ -39,24 +39,24 @@ const StoryPromoLiFeatures = styled(StoryPromoLi)`
   line-height: 0;
   height: 100%;
 
-  &:first-child {
+  &:first-of-type {
     padding: 0 0 0.5rem 0;
   }
 
-  &:last-child {
+  &:last-of-type {
     padding: 0.5rem 0 0 0;
   }
 
-  &:not(:first-child):not(:last-child) {
+  &:not(:first-of-type):not(:last-of-type) {
     padding: 0.5rem 0 0.5rem 0;
   }
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
     padding: 0;
 
-    &:first-child,
-    &:last-child,
-    &:not(:first-child):not(:last-child) {
+    &:first-of-type,
+    &:last-of-type,
+    &:not(:first-of-type):not(:last-of-type) {
       padding: 0;
     }
   }

--- a/src/app/legacy/containers/CpsRecommendations/RecommendationsPromoList/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/CpsRecommendations/RecommendationsPromoList/__snapshots__/index.test.jsx.snap
@@ -64,7 +64,7 @@ exports[`RecommendationsPromoList it renders a list of Story Promos wrapped in G
   }
 }
 
-.emotion-4:last-child {
+.emotion-4:last-of-type {
   border: none;
 }
 

--- a/src/app/legacy/containers/CpsRecommendations/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/CpsRecommendations/__snapshots__/index.test.jsx.snap
@@ -921,7 +921,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
   }
 }
 
-.emotion-23:last-child {
+.emotion-23:last-of-type {
   border: none;
 }
 
@@ -1768,7 +1768,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
   }
 }
 
-.emotion-23:last-child {
+.emotion-23:last-of-type {
   border: none;
 }
 

--- a/src/app/legacy/containers/CpsRelatedContent/RelatedContentPromoList/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/CpsRelatedContent/RelatedContentPromoList/__snapshots__/index.test.jsx.snap
@@ -74,7 +74,7 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for MAP pages
   }
 }
 
-.emotion-4:last-child {
+.emotion-4:last-of-type {
   border: none;
 }
 
@@ -90,17 +90,17 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for MAP pages
   }
 }
 
-.emotion-4:first-child {
+.emotion-4:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-4:first-child {
+  .emotion-4:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-4:last-child {
+.emotion-4:last-of-type {
   padding-bottom: 0;
 }
 
@@ -668,7 +668,7 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for STY pages
   }
 }
 
-.emotion-4:last-child {
+.emotion-4:last-of-type {
   border: none;
 }
 
@@ -684,17 +684,17 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for STY pages
   }
 }
 
-.emotion-4:first-child {
+.emotion-4:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-4:first-child {
+  .emotion-4:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-4:last-child {
+.emotion-4:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/legacy/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
@@ -388,7 +388,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   }
 }
 
-.emotion-21:last-child {
+.emotion-21:last-of-type {
   border: none;
 }
 
@@ -404,17 +404,17 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   }
 }
 
-.emotion-21:first-child {
+.emotion-21:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-21:first-child {
+  .emotion-21:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-21:last-child {
+.emotion-21:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/legacy/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
@@ -331,7 +331,7 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
   }
 }
 
-.emotion-19:last-child {
+.emotion-19:last-of-type {
   border: none;
 }
 
@@ -347,17 +347,17 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
   }
 }
 
-.emotion-19:first-child {
+.emotion-19:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-19:first-child {
+  .emotion-19:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-19:last-child {
+.emotion-19:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/legacy/containers/EpisodeList/RecentAudioEpisodes/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/EpisodeList/RecentAudioEpisodes/__snapshots__/index.test.jsx.snap
@@ -137,15 +137,15 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
   line-height: 0;
 }
 
-.emotion-15:first-child {
+.emotion-15:first-of-type {
   padding-top: 0;
 }
 
-.emotion-15:last-child {
+.emotion-15:last-of-type {
   padding-bottom: 0;
 }
 
-.emotion-15:not(:last-child) {
+.emotion-15:not(:last-of-type) {
   border-bottom: 1px #BABABA solid;
 }
 

--- a/src/app/legacy/containers/EpisodeList/RecentVideoEpisodes/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/EpisodeList/RecentVideoEpisodes/__snapshots__/index.test.jsx.snap
@@ -134,15 +134,15 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
   line-height: 0;
 }
 
-.emotion-13:first-child {
+.emotion-13:first-of-type {
   padding-top: 0;
 }
 
-.emotion-13:last-child {
+.emotion-13:last-of-type {
   padding-bottom: 0;
 }
 
-.emotion-13:not(:last-child) {
+.emotion-13:not(:last-of-type) {
   border-bottom: 1px #BABABA solid;
 }
 

--- a/src/app/legacy/containers/EpisodeList/index.jsx
+++ b/src/app/legacy/containers/EpisodeList/index.jsx
@@ -22,13 +22,13 @@ const StyledEpisodeList = styled.ul`
 const StyledEpisodeListItem = styled.li`
   padding: ${GEL_SPACING_DBL} 0;
   line-height: 0;
-  &:first-child {
+  &:first-of-type {
     padding-top: 0;
   }
-  &:last-child {
+  &:last-of-type {
     padding-bottom: 0;
   }
-  &:not(:last-child) {
+  &:not(:last-of-type) {
     border-bottom: 1px ${props => props.theme.palette.CLOUD_LIGHT} solid;
   }
 `;

--- a/src/app/legacy/containers/FrontPageStoryRows/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/FrontPageStoryRows/__snapshots__/index.test.jsx.snap
@@ -11,7 +11,7 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow - rtl 1`] = `
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   border: none;
 }
 
@@ -27,17 +27,17 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow - rtl 1`] = `
   }
 }
 
-.emotion-1:first-child {
+.emotion-1:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-1:first-child {
+  .emotion-1:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   padding-bottom: 0;
 }
 
@@ -380,7 +380,7 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow - rtl 1`] = `
   }
 }
 
-.emotion-25:last-child {
+.emotion-25:last-of-type {
   border: none;
 }
 
@@ -396,17 +396,17 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow - rtl 1`] = `
   }
 }
 
-.emotion-25:first-child {
+.emotion-25:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-25:first-child {
+  .emotion-25:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-25:last-child {
+.emotion-25:last-of-type {
   padding-bottom: 0;
 }
 
@@ -898,7 +898,7 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow 1`] = `
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   border: none;
 }
 
@@ -914,17 +914,17 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow 1`] = `
   }
 }
 
-.emotion-1:first-child {
+.emotion-1:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-1:first-child {
+  .emotion-1:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   padding-bottom: 0;
 }
 
@@ -1267,7 +1267,7 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow 1`] = `
   }
 }
 
-.emotion-24:last-child {
+.emotion-24:last-of-type {
   border: none;
 }
 
@@ -1283,17 +1283,17 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow 1`] = `
   }
 }
 
-.emotion-24:first-child {
+.emotion-24:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-24:first-child {
+  .emotion-24:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-24:last-child {
+.emotion-24:last-of-type {
   padding-bottom: 0;
 }
 
@@ -1640,7 +1640,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images - rtl 1
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   border: none;
 }
 
@@ -1656,17 +1656,17 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images - rtl 1
   }
 }
 
-.emotion-1:first-child {
+.emotion-1:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-1:first-child {
+  .emotion-1:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   padding-bottom: 0;
 }
 
@@ -2573,7 +2573,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images 1`] = `
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   border: none;
 }
 
@@ -2589,17 +2589,17 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images 1`] = `
   }
 }
 
-.emotion-1:first-child {
+.emotion-1:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-1:first-child {
+  .emotion-1:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   padding-bottom: 0;
 }
 
@@ -3172,7 +3172,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images - rt
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   border: none;
 }
 
@@ -3188,17 +3188,17 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images - rt
   }
 }
 
-.emotion-1:first-child {
+.emotion-1:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-1:first-child {
+  .emotion-1:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   padding-bottom: 0;
 }
 
@@ -3692,7 +3692,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images - rt
   padding: 0.5rem 0 1rem;
 }
 
-.emotion-38:last-child {
+.emotion-38:last-of-type {
   border: none;
 }
 
@@ -3708,17 +3708,17 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images - rt
   }
 }
 
-.emotion-38:first-child {
+.emotion-38:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-38:first-child {
+  .emotion-38:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-38:last-child {
+.emotion-38:last-of-type {
   padding-bottom: 0;
 }
 
@@ -3983,7 +3983,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images 1`] 
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   border: none;
 }
 
@@ -3999,17 +3999,17 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images 1`] 
   }
 }
 
-.emotion-1:first-child {
+.emotion-1:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-1:first-child {
+  .emotion-1:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   padding-bottom: 0;
 }
 
@@ -4224,7 +4224,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images 1`] 
   padding: 0.5rem 0 1rem;
 }
 
-.emotion-25:last-child {
+.emotion-25:last-of-type {
   border: none;
 }
 
@@ -4240,17 +4240,17 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images 1`] 
   }
 }
 
-.emotion-25:first-child {
+.emotion-25:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-25:first-child {
+  .emotion-25:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-25:last-child {
+.emotion-25:last-of-type {
   padding-bottom: 0;
 }
 
@@ -4445,7 +4445,7 @@ exports[`FrontPageStoryRows Container - snapshots TopRow - rtl 1`] = `
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   border: none;
 }
 
@@ -4461,17 +4461,17 @@ exports[`FrontPageStoryRows Container - snapshots TopRow - rtl 1`] = `
   }
 }
 
-.emotion-1:first-child {
+.emotion-1:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-1:first-child {
+  .emotion-1:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   padding-bottom: 0;
 }
 
@@ -4907,7 +4907,7 @@ exports[`FrontPageStoryRows Container - snapshots TopRow 1`] = `
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   border: none;
 }
 
@@ -4923,17 +4923,17 @@ exports[`FrontPageStoryRows Container - snapshots TopRow 1`] = `
   }
 }
 
-.emotion-1:first-child {
+.emotion-1:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-1:first-child {
+  .emotion-1:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-1:last-child {
+.emotion-1:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/legacy/containers/Gist/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/Gist/__snapshots__/index.test.jsx.snap
@@ -273,7 +273,7 @@ exports[`Gist should render the gist with multiple list items 1`] = `
   }
 }
 
-.emotion-8 li:last-child {
+.emotion-8 li:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -282,7 +282,7 @@ exports[`Gist should render the gist with multiple list items 1`] = `
     padding-left: 1rem;
   }
 
-  .emotion-8 li:last-child {
+  .emotion-8 li:last-of-type {
     padding-bottom: 2rem;
   }
 }
@@ -730,7 +730,7 @@ exports[`Gist should render the gist with one list item 1`] = `
   }
 }
 
-.emotion-8 li:last-child {
+.emotion-8 li:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -739,7 +739,7 @@ exports[`Gist should render the gist with one list item 1`] = `
     padding-left: 1rem;
   }
 
-  .emotion-8 li:last-child {
+  .emotion-8 li:last-of-type {
     padding-bottom: 2rem;
   }
 }

--- a/src/app/legacy/containers/Gist/index.jsx
+++ b/src/app/legacy/containers/Gist/index.jsx
@@ -73,7 +73,7 @@ const GistList = styled(UnorderedList)`
     ${({ direction }) => `padding-${direction}: ${GEL_SPACING_HLF_TRPL};`}
     margin-bottom: ${GEL_SPACING_DBL};
 
-    &:last-child {
+    &:last-of-type {
       padding-bottom: ${GEL_SPACING_DBL};
     }
 
@@ -88,7 +88,7 @@ const GistList = styled(UnorderedList)`
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     ${({ direction }) => `padding-${direction}: ${GEL_SPACING_DBL};`}
-    li:last-child {
+    li:last-of-type {
       padding-bottom: ${GEL_SPACING_QUAD};
     }
   }

--- a/src/app/legacy/containers/Header/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/Header/__snapshots__/index.test.jsx.snap
@@ -641,7 +641,7 @@ exports[`Header Snapshots should render correctly for WS frontpage 1`] = `
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-43:last-child {
+  .emotion-43:last-of-type {
     margin-right: 3rem;
   }
 }
@@ -760,7 +760,7 @@ exports[`Header Snapshots should render correctly for WS frontpage 1`] = `
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
-.emotion-91:last-child {
+.emotion-91:last-of-type {
   padding-bottom: 0.25rem;
   border: 0;
 }
@@ -1923,7 +1923,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-43:last-child {
+  .emotion-43:last-of-type {
     margin-right: 3rem;
   }
 }
@@ -2042,7 +2042,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
-.emotion-91:last-child {
+.emotion-91:last-of-type {
   padding-bottom: 0.25rem;
   border: 0;
 }
@@ -3205,7 +3205,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-43:last-child {
+  .emotion-43:last-of-type {
     margin-right: 3rem;
   }
 }
@@ -3324,7 +3324,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
-.emotion-91:last-child {
+.emotion-91:last-of-type {
   padding-bottom: 0.25rem;
   border: 0;
 }

--- a/src/app/legacy/containers/IndexPageSection/UsefulLinks/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/IndexPageSection/UsefulLinks/__snapshots__/index.test.jsx.snap
@@ -51,7 +51,7 @@ exports[`Useful links should render multiple correctly 1`] = `
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-4:first-child {
+  .emotion-4:first-of-type {
     padding-top: 0;
   }
 }

--- a/src/app/legacy/containers/IndexPageSection/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/IndexPageSection/__snapshots__/index.test.jsx.snap
@@ -214,7 +214,7 @@ HTMLCollection [
   }
 }
 
-.emotion-18:last-child {
+.emotion-18:last-of-type {
   border: none;
 }
 
@@ -230,17 +230,17 @@ HTMLCollection [
   }
 }
 
-.emotion-18:first-child {
+.emotion-18:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-18:first-child {
+  .emotion-18:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-18:last-child {
+.emotion-18:last-of-type {
   padding-bottom: 0;
 }
 
@@ -615,7 +615,7 @@ HTMLCollection [
   }
 }
 
-.emotion-41:last-child {
+.emotion-41:last-of-type {
   border: none;
 }
 
@@ -631,17 +631,17 @@ HTMLCollection [
   }
 }
 
-.emotion-41:first-child {
+.emotion-41:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-41:first-child {
+  .emotion-41:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-41:last-child {
+.emotion-41:last-of-type {
   padding-bottom: 0;
 }
 
@@ -1515,7 +1515,7 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
   }
 }
 
-.emotion-18:last-child {
+.emotion-18:last-of-type {
   border: none;
 }
 
@@ -1531,17 +1531,17 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
   }
 }
 
-.emotion-18:first-child {
+.emotion-18:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-18:first-child {
+  .emotion-18:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-18:last-child {
+.emotion-18:last-of-type {
   padding-bottom: 0;
 }
 
@@ -1916,7 +1916,7 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
   }
 }
 
-.emotion-41:last-child {
+.emotion-41:last-of-type {
   border: none;
 }
 
@@ -1932,17 +1932,17 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
   }
 }
 
-.emotion-41:first-child {
+.emotion-41:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-41:first-child {
+  .emotion-41:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-41:last-child {
+.emotion-41:last-of-type {
   padding-bottom: 0;
 }
 
@@ -2798,7 +2798,7 @@ exports[`IndexPageSection Container snapshots should render correctly with a lin
   }
 }
 
-.emotion-16:last-child {
+.emotion-16:last-of-type {
   border: none;
 }
 
@@ -2814,17 +2814,17 @@ exports[`IndexPageSection Container snapshots should render correctly with a lin
   }
 }
 
-.emotion-16:first-child {
+.emotion-16:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-16:first-child {
+  .emotion-16:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-16:last-child {
+.emotion-16:last-of-type {
   padding-bottom: 0;
 }
 
@@ -3221,7 +3221,7 @@ exports[`IndexPageSection Container snapshots should render correctly with a lin
   }
 }
 
-.emotion-39:last-child {
+.emotion-39:last-of-type {
   border: none;
 }
 
@@ -3237,17 +3237,17 @@ exports[`IndexPageSection Container snapshots should render correctly with a lin
   }
 }
 
-.emotion-39:first-child {
+.emotion-39:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-39:first-child {
+  .emotion-39:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-39:last-child {
+.emotion-39:last-of-type {
   padding-bottom: 0;
 }
 
@@ -4347,7 +4347,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
   }
 }
 
-.emotion-16:last-child {
+.emotion-16:last-of-type {
   border: none;
 }
 
@@ -4363,17 +4363,17 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
   }
 }
 
-.emotion-16:first-child {
+.emotion-16:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-16:first-child {
+  .emotion-16:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-16:last-child {
+.emotion-16:last-of-type {
   padding-bottom: 0;
 }
 
@@ -4748,7 +4748,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
   }
 }
 
-.emotion-39:last-child {
+.emotion-39:last-of-type {
   border: none;
 }
 
@@ -4764,17 +4764,17 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
   }
 }
 
-.emotion-39:first-child {
+.emotion-39:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-39:first-child {
+  .emotion-39:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-39:last-child {
+.emotion-39:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/legacy/containers/LivePageMediaPlayer/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/LivePageMediaPlayer/__snapshots__/index.test.jsx.snap
@@ -175,7 +175,7 @@ exports[`MediaPlayer Calls the amp media player 1`] = `
   margin: 0;
 }
 
-.emotion-8>span>p:last-child {
+.emotion-8>span>p:last-of-type {
   padding-bottom: 0;
 }
 
@@ -538,7 +538,7 @@ exports[`MediaPlayer Calls the canonical media player, with a placeholder 1`] = 
   margin: 0;
 }
 
-.emotion-24>span>p:last-child {
+.emotion-24>span>p:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/legacy/containers/MediaPlayer/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/MediaPlayer/__snapshots__/index.test.jsx.snap
@@ -440,7 +440,7 @@ exports[`MediaPlayer Calls the canonical placeholder when platform is canonical 
   margin: 0;
 }
 
-.emotion-22>span>p:last-child {
+.emotion-22>span>p:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/legacy/containers/Navigation/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/Navigation/__snapshots__/index.test.jsx.snap
@@ -136,7 +136,7 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
-.emotion-15:last-child {
+.emotion-15:last-of-type {
   padding-bottom: 0.25rem;
   border: 0;
 }
@@ -259,7 +259,7 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-67:last-child {
+  .emotion-67:last-of-type {
     margin-right: 3rem;
   }
 }
@@ -975,7 +975,7 @@ exports[`Navigation Container should correctly render amp navigation on non-home
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
-.emotion-15:last-child {
+.emotion-15:last-of-type {
   padding-bottom: 0.25rem;
   border: 0;
 }
@@ -1093,7 +1093,7 @@ exports[`Navigation Container should correctly render amp navigation on non-home
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-64:last-child {
+  .emotion-64:last-of-type {
     margin-right: 3rem;
   }
 }
@@ -1713,7 +1713,7 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
-.emotion-15:last-child {
+.emotion-15:last-of-type {
   padding-bottom: 0.25rem;
   border: 0;
 }
@@ -1831,7 +1831,7 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-64:last-child {
+  .emotion-64:last-of-type {
     margin-right: 3rem;
   }
 }
@@ -2497,7 +2497,7 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-15:last-child {
+  .emotion-15:last-of-type {
     margin-right: 3rem;
   }
 }
@@ -2692,7 +2692,7 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
-.emotion-66:last-child {
+.emotion-66:last-of-type {
   padding-bottom: 0.25rem;
   border: 0;
 }
@@ -3310,7 +3310,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-15:last-child {
+  .emotion-15:last-of-type {
     margin-right: 3rem;
   }
 }
@@ -3429,7 +3429,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
-.emotion-63:last-child {
+.emotion-63:last-of-type {
   padding-bottom: 0.25rem;
   border: 0;
 }
@@ -4022,7 +4022,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-15:last-child {
+  .emotion-15:last-of-type {
     margin-right: 3rem;
   }
 }
@@ -4141,7 +4141,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
-.emotion-63:last-child {
+.emotion-63:last-of-type {
   padding-bottom: 0.25rem;
   border: 0;
 }

--- a/src/app/legacy/psammead/psammead-caption/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-caption/src/__snapshots__/index.test.jsx.snap
@@ -43,7 +43,7 @@ exports[`Caption should render with some offscreen text 1`] = `
   margin: 0;
 }
 
-.emotion-0>span>p:last-child {
+.emotion-0>span>p:last-of-type {
   padding-bottom: 0;
 }
 
@@ -132,7 +132,7 @@ exports[`Caption should render with some offscreen text and arabic script typogr
   margin: 0;
 }
 
-.emotion-0>span>p:last-child {
+.emotion-0>span>p:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/legacy/psammead/psammead-caption/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-caption/src/index.jsx
@@ -71,7 +71,7 @@ const Caption = styled.figcaption`
     padding-bottom: ${GEL_SPACING_TRPL};
     margin: 0; /* reset */
   }
-  & > span > p:last-child {
+  & > span > p:last-of-type {
     padding-bottom: 0;
   }
   ${({ dir }) => (dir === 'rtl' ? rtlStyles : ltrStyles)}

--- a/src/app/legacy/psammead/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
@@ -676,7 +676,7 @@ exports[`Dropdown navigation should render correctly when closer 1`] = `
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
-.emotion-4:last-child {
+.emotion-4:last-of-type {
   padding-bottom: 0.25rem;
   border: 0;
 }
@@ -937,7 +937,7 @@ exports[`Dropdown navigation should render correctly when open 1`] = `
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
-.emotion-4:last-child {
+.emotion-4:last-of-type {
   padding-bottom: 0.25rem;
   border: 0;
 }

--- a/src/app/legacy/psammead/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/src/app/legacy/psammead/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -94,7 +94,7 @@ const StyledDropdownLi = styled.li`
   padding: 0.75rem 0;
   border-bottom: 0.0625rem solid ${props => props.theme.palette.GREY_3};
 
-  &:last-child {
+  &:last-of-type {
     padding-bottom: ${GEL_SPACING_HLF};
     border: 0;
   }

--- a/src/app/legacy/psammead/psammead-navigation/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-navigation/src/__snapshots__/index.test.jsx.snap
@@ -60,7 +60,7 @@ exports[`Navigation should render correctly 1`] = `
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-6:last-child {
+  .emotion-6:last-of-type {
     margin-right: 3rem;
   }
 }
@@ -378,7 +378,7 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-6:last-child {
+  .emotion-6:last-of-type {
     margin-right: 3rem;
   }
 }
@@ -690,7 +690,7 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-6:last-child {
+  .emotion-6:last-of-type {
     margin-right: 3rem;
   }
 }
@@ -1052,7 +1052,7 @@ exports[`Scrollable Navigation should render correctly 1`] = `
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-8:last-child {
+  .emotion-8:last-of-type {
     margin-right: 3rem;
   }
 }

--- a/src/app/legacy/psammead/psammead-navigation/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-navigation/src/index.jsx
@@ -105,7 +105,7 @@ const StyledListItem = styled.li`
   margin-inline-end: 0.75rem;
 
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
-    &:last-child {
+    &:last-of-type {
       ${({ dir }) => `
         margin-${dir === 'ltr' ? 'right' : 'left'}: ${GEL_SPACING_SEXT}; 
       `}

--- a/src/app/legacy/psammead/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-story-promo-list/src/__snapshots__/index.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`StoryPromo list base should render correctly 1`] = `
   }
 }
 
-.emotion-2:last-child {
+.emotion-2:last-of-type {
   border: none;
 }
 
@@ -222,7 +222,7 @@ exports[`StoryPromo list base should render correctly without border 1`] = `
   padding: 0;
 }
 
-.emotion-2:last-child {
+.emotion-2:last-of-type {
   border: none;
 }
 
@@ -441,7 +441,7 @@ exports[`StoryPromo list should render correctly 1`] = `
   }
 }
 
-.emotion-2:last-child {
+.emotion-2:last-of-type {
   border: none;
 }
 
@@ -457,17 +457,17 @@ exports[`StoryPromo list should render correctly 1`] = `
   }
 }
 
-.emotion-2:first-child {
+.emotion-2:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-2:first-child {
+  .emotion-2:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-2:last-child {
+.emotion-2:last-of-type {
   padding-bottom: 0;
 }
 
@@ -679,7 +679,7 @@ exports[`StoryPromo list should render correctly without border 1`] = `
   padding: 0.5rem 0 1rem;
 }
 
-.emotion-2:last-child {
+.emotion-2:last-of-type {
   border: none;
 }
 
@@ -695,17 +695,17 @@ exports[`StoryPromo list should render correctly without border 1`] = `
   }
 }
 
-.emotion-2:first-child {
+.emotion-2:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-2:first-child {
+  .emotion-2:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-2:last-child {
+.emotion-2:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/legacy/psammead/psammead-story-promo-list/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-story-promo-list/src/index.jsx
@@ -30,7 +30,7 @@ export const StoryPromoLiBase = styled.li`
     }
   `}
 
-  &:last-child {
+  &:last-of-type {
     border: none;
   }
 `;
@@ -52,7 +52,7 @@ export const StoryPromoLi = styled(StoryPromoLiBase)`
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
     padding: 0 0 ${GEL_SPACING_TRPL};
   }
-  &:first-child {
+  &:first-of-type {
     padding-top: 0;
 
     @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
@@ -60,7 +60,7 @@ export const StoryPromoLi = styled(StoryPromoLiBase)`
     }
   }
 
-  &:last-child {
+  &:last-of-type {
     padding-bottom: 0;
   }
 `;

--- a/src/app/legacy/psammead/psammead-timestamp-container/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-timestamp-container/src/__snapshots__/index.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`Timestamp should add prefix and suffix 1`] = `
   }
 }
 
-.emotion-0:last-child {
+.emotion-0:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -66,7 +66,7 @@ exports[`Timestamp should render correctly 1`] = `
   }
 }
 
-.emotion-0:last-child {
+.emotion-0:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -106,7 +106,7 @@ exports[`Timestamp should render without a leading zero on the day 1`] = `
   }
 }
 
-.emotion-0:last-child {
+.emotion-0:last-of-type {
   padding-bottom: 1rem;
 }
 

--- a/src/app/legacy/psammead/psammead-timestamp/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-timestamp/src/__snapshots__/index.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`Timestamp should render Timestamp correctly 1`] = `
   }
 }
 
-.emotion-0:last-child {
+.emotion-0:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -66,7 +66,7 @@ exports[`Timestamp should render Timestamp with a prefix 1`] = `
   }
 }
 
-.emotion-0:last-child {
+.emotion-0:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -141,7 +141,7 @@ exports[`Timestamp should render dark mode Timestamp correctly on page types tha
   }
 }
 
-.emotion-0:last-child {
+.emotion-0:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -181,7 +181,7 @@ exports[`Timestamp should render with the correct typography style applied 1`] =
   }
 }
 
-.emotion-0:last-child {
+.emotion-0:last-of-type {
   padding-bottom: 1rem;
 }
 

--- a/src/app/legacy/psammead/psammead-timestamp/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-timestamp/src/index.jsx
@@ -11,7 +11,7 @@ import { getSansRegular } from '#psammead/psammead-styles/src/font-styles';
 
 const PADDING = `
   padding-bottom: ${GEL_SPACING_HLF};
-  &:last-child {
+  &:last-of-type {
     padding-bottom: ${GEL_SPACING_DBL};
   }
 `;

--- a/src/app/legacy/psammead/psammead-useful-links/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-useful-links/src/__snapshots__/index.test.jsx.snap
@@ -35,7 +35,7 @@ exports[`Multiple useful links should render correctly 1`] = `
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-2:first-child {
+  .emotion-2:first-of-type {
     padding-top: 0;
   }
 }

--- a/src/app/legacy/psammead/psammead-useful-links/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-useful-links/src/index.jsx
@@ -72,7 +72,7 @@ export const UsefulLinksLi = styled.li`
   padding-top: ${GEL_SPACING};
 
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
-    &:first-child {
+    &:first-of-type {
       padding-top: 0;
     }
   }

--- a/src/app/models/propTypes/promo/index.js
+++ b/src/app/models/propTypes/promo/index.js
@@ -32,7 +32,7 @@ export const optimoPromoHeadlineOrSummaryPropTypes = {
 };
 
 export const optimoPromoPropTypes = {
-  id: string.isRequired,
+  id: string,
   headlines: shape({
     seoHeadline: string.isRequired,
     promoHeadline: oneOfType([

--- a/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
@@ -292,7 +292,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 }
 
-.emotion-22:last-child {
+.emotion-22:last-of-type {
   border: none;
 }
 
@@ -308,17 +308,17 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 }
 
-.emotion-22:first-child {
+.emotion-22:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-22:first-child {
+  .emotion-22:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-22:last-child {
+.emotion-22:last-of-type {
   padding-bottom: 0;
 }
 
@@ -755,7 +755,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 }
 
-.emotion-52:last-child {
+.emotion-52:last-of-type {
   border: none;
 }
 
@@ -771,17 +771,17 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 }
 
-.emotion-52:first-child {
+.emotion-52:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-52:first-child {
+  .emotion-52:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-52:last-child {
+.emotion-52:last-of-type {
   padding-bottom: 0;
 }
 
@@ -1082,7 +1082,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 }
 
-.emotion-159:last-child {
+.emotion-159:last-of-type {
   border: none;
 }
 
@@ -1098,17 +1098,17 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 }
 
-.emotion-159:first-child {
+.emotion-159:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-159:first-child {
+  .emotion-159:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-159:last-child {
+.emotion-159:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/pages/MediaArticlePage/PagePromoSections/LatestMediaSection/index.styles.ts
+++ b/src/app/pages/MediaArticlePage/PagePromoSections/LatestMediaSection/index.styles.ts
@@ -30,7 +30,7 @@ const styles = {
         borderBottom: '0',
         width: '48.5%',
       },
-      '&:last-child': {
+      '&:last-of-type': {
         borderBottom: 'none',
       },
     }),

--- a/src/app/pages/MediaArticlePage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/MediaArticlePage/__snapshots__/index.test.tsx.snap
@@ -318,7 +318,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   margin: 0;
 }
 
-.emotion-30>span>p:last-child {
+.emotion-30>span>p:last-of-type {
   padding-bottom: 0;
 }
 
@@ -607,7 +607,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 }
 
-.emotion-40:last-child {
+.emotion-40:last-of-type {
   padding-bottom: 1rem;
 }
 

--- a/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
@@ -565,7 +565,7 @@ exports[`Media Asset Page AV player should render version (live audio stream) 1`
   }
 }
 
-.emotion-26:last-child {
+.emotion-26:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -1931,7 +1931,7 @@ exports[`Media Asset Page should render component 1`] = `
   }
 }
 
-.emotion-26:last-child {
+.emotion-26:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -2403,7 +2403,7 @@ exports[`Media Asset Page should render component 1`] = `
   margin: 0;
 }
 
-.emotion-108>span>p:last-child {
+.emotion-108>span>p:last-of-type {
   padding-bottom: 0;
 }
 
@@ -2809,7 +2809,7 @@ exports[`Media Asset Page should render component 1`] = `
   }
 }
 
-.emotion-161:last-child {
+.emotion-161:last-of-type {
   border: none;
 }
 
@@ -2825,17 +2825,17 @@ exports[`Media Asset Page should render component 1`] = `
   }
 }
 
-.emotion-161:first-child {
+.emotion-161:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-161:first-child {
+  .emotion-161:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-161:last-child {
+.emotion-161:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/pages/MostWatchedPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MostWatchedPage/__snapshots__/index.test.jsx.snap
@@ -360,7 +360,7 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
   }
 }
 
-.emotion-17:last-child {
+.emotion-17:last-of-type {
   border: none;
 }
 
@@ -376,17 +376,17 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
   }
 }
 
-.emotion-17:first-child {
+.emotion-17:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-17:first-child {
+  .emotion-17:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-17:last-child {
+.emotion-17:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
@@ -449,7 +449,7 @@ exports[`Photo Gallery Page should not show the pop-out timestamp when allowDate
   margin: 0;
 }
 
-.emotion-17>span>p:last-child {
+.emotion-17>span>p:last-of-type {
   padding-bottom: 0;
 }
 
@@ -1521,7 +1521,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with about t
   }
 }
 
-.emotion-11:last-child {
+.emotion-11:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -1753,7 +1753,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with about t
   margin: 0;
 }
 
-.emotion-22>span>p:last-child {
+.emotion-22>span>p:last-of-type {
   padding-bottom: 0;
 }
 
@@ -2837,7 +2837,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   }
 }
 
-.emotion-11:last-child {
+.emotion-11:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -3069,7 +3069,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   margin: 0;
 }
 
-.emotion-22>span>p:last-child {
+.emotion-22>span>p:last-of-type {
   padding-bottom: 0;
 }
 
@@ -3486,7 +3486,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   }
 }
 
-.emotion-126:last-child {
+.emotion-126:last-of-type {
   border: none;
 }
 
@@ -3502,17 +3502,17 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   }
 }
 
-.emotion-126:first-child {
+.emotion-126:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-126:first-child {
+  .emotion-126:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-126:last-child {
+.emotion-126:last-of-type {
   padding-bottom: 0;
 }
 
@@ -4958,7 +4958,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
   }
 }
 
-.emotion-11:last-child {
+.emotion-11:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -5237,7 +5237,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
   margin: 0;
 }
 
-.emotion-24>span>p:last-child {
+.emotion-24>span>p:last-of-type {
   padding-bottom: 0;
 }
 
@@ -6079,7 +6079,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   }
 }
 
-.emotion-11:last-child {
+.emotion-11:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -6358,7 +6358,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   margin: 0;
 }
 
-.emotion-24>span>p:last-child {
+.emotion-24>span>p:last-of-type {
   padding-bottom: 0;
 }
 
@@ -6764,7 +6764,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   }
 }
 
-.emotion-228:last-child {
+.emotion-228:last-of-type {
   border: none;
 }
 
@@ -6780,17 +6780,17 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   }
 }
 
-.emotion-228:first-child {
+.emotion-228:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-228:first-child {
+  .emotion-228:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-228:last-child {
+.emotion-228:last-of-type {
   padding-bottom: 0;
 }
 

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -656,7 +656,7 @@ exports[`Story Page should render correctly when the secondary column data is no
   }
 }
 
-.emotion-24:last-child {
+.emotion-24:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -788,7 +788,7 @@ exports[`Story Page should render correctly when the secondary column data is no
   margin: 0;
 }
 
-.emotion-31>span>p:last-child {
+.emotion-31>span>p:last-of-type {
   padding-bottom: 0;
 }
 
@@ -3437,7 +3437,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 }
 
-.emotion-24:last-child {
+.emotion-24:last-of-type {
   padding-bottom: 1rem;
 }
 
@@ -3569,7 +3569,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   margin: 0;
 }
 
-.emotion-31>span>p:last-child {
+.emotion-31>span>p:last-of-type {
   padding-bottom: 0;
 }
 
@@ -4330,7 +4330,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 }
 
-.emotion-177:last-child {
+.emotion-177:last-of-type {
   border: none;
 }
 
@@ -4346,17 +4346,17 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 }
 
-.emotion-177:first-child {
+.emotion-177:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-177:first-child {
+  .emotion-177:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-177:last-child {
+.emotion-177:last-of-type {
   padding-bottom: 0;
 }
 
@@ -4539,7 +4539,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   height: 100%;
 }
 
-.emotion-230:last-child {
+.emotion-230:last-of-type {
   border: none;
 }
 
@@ -4555,29 +4555,29 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 }
 
-.emotion-230:first-child {
+.emotion-230:first-of-type {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-230:first-child {
+  .emotion-230:first-of-type {
     padding-top: 1rem;
   }
 }
 
-.emotion-230:last-child {
+.emotion-230:last-of-type {
   padding-bottom: 0;
 }
 
-.emotion-230:first-child {
+.emotion-230:first-of-type {
   padding: 0 0 0.5rem 0;
 }
 
-.emotion-230:last-child {
+.emotion-230:last-of-type {
   padding: 0.5rem 0 0 0;
 }
 
-.emotion-230:not(:first-child):not(:last-child) {
+.emotion-230:not(:first-of-type):not(:last-of-type) {
   padding: 0.5rem 0 0.5rem 0;
 }
 
@@ -4586,9 +4586,9 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
     padding: 0;
   }
 
-  .emotion-230:first-child,
-  .emotion-230:last-child,
-  .emotion-230:not(:first-child):not(:last-child) {
+  .emotion-230:first-of-type,
+  .emotion-230:last-of-type,
+  .emotion-230:not(:first-of-type):not(:last-of-type) {
     padding: 0;
   }
 }

--- a/ws-nextjs-app/pages/[service]/live/[id]/KeyPoints/styles.ts
+++ b/ws-nextjs-app/pages/[service]/live/[id]/KeyPoints/styles.ts
@@ -29,7 +29,7 @@ export default {
       },
       '& li': {
         paddingInlineStart: `${pixelsToRem(3)}rem`,
-        '&:last-child': {
+        '&:last-of-type': {
           marginBottom: 0,
         },
       },

--- a/ws-nextjs-app/pages/[service]/live/[id]/Post/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Post/styles.tsx
@@ -88,7 +88,7 @@ export default {
       },
       '& li': {
         marginBottom: `${spacings.FULL}rem`,
-        '&:last-child': {
+        '&:last-of-type': {
           marginBottom: 0,
         },
       },


### PR DESCRIPTION
Overall changes
======
- Replaces `:first-child` with `:first-of-type`
- Replaces `:last-child` with `:last-of-type`
- Changing these resolves the console error `the pseudo class ":first-child" is potentially unsafe when doing server-side rendering. Try changing it to ":first-of-type".` and fixes the Lighthouse `bestPractices` score

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
