### PR TITLE
Pin Lighthouse version to `11.3.0`

### DIFF
--- a/scripts/lighthouseRun.sh
+++ b/scripts/lighthouseRun.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-npx -p lighthouse@11 lighthouse http://localhost:7080/news/articles/cn7k01xp8kxo --chrome-flags="--no-sandbox --headless --disable-gpu" --output json --output html --output-path simorgh --config-path scripts/lighthouseConfig.js && node scripts/lighthouseBudget.js run
-npx -p lighthouse@11 lighthouse http://localhost:7080/kyrgyz --chrome-flags="--no-sandbox --headless --disable-gpu" --output json --output html --output-path simorgh --config-path scripts/lighthouseConfig.js && node scripts/lighthouseBudget.js run
+npx -p lighthouse@11.3.0 lighthouse http://localhost:7080/news/articles/cn7k01xp8kxo --chrome-flags="--no-sandbox --headless --disable-gpu" --output json --output html --output-path simorgh --config-path scripts/lighthouseConfig.js && node scripts/lighthouseBudget.js run
+npx -p lighthouse@11.3.0 lighthouse http://localhost:7080/kyrgyz --chrome-flags="--no-sandbox --headless --disable-gpu" --output json --output html --output-path simorgh --config-path scripts/lighthouseConfig.js && node scripts/lighthouseBudget.js run


### PR DESCRIPTION
Overall changes
======
Pins Lighthouse version to `11.3.0`, as `11.4.0` introduces a new cookie audit check that causes some of our Lighthouse tests to fail: https://github.com/GoogleChrome/lighthouse/releases/tag/v11.4.0

We should remove this pinned version once we have resolved the outstanding issues with third party cookies getting set in the app.


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
