### PR TITLE
Re-route Persian/Afghanistan Home AMP pages to Canonical Home

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -134,7 +134,10 @@ server
         }
       });
     },
-  );
+  )
+  .get('/persian/afghanistan.amp', (req, res) => {
+    res.redirect(301, '/persian/afghanistan');
+  });
 
 // Set Up Local Server
 if (process.env.SIMORGH_APP_ENV === 'local') {


### PR DESCRIPTION
Related to
https://github.com/bbc/belfrage/pull/2556 

- Re-routes in `server` 
- This change to be removed once the above PR has been promoted to Live


