### PR TITLE
NEWSWORLDSERVICE-1585: Remove duplicate favicon link in HTML head

### DIFF
--- a/src/server/Document/__snapshots__/component.test.jsx.snap
+++ b/src/server/Document/__snapshots__/component.test.jsx.snap
@@ -10,11 +10,6 @@ exports[`Document Component should render AMP version correctly 1`] = `
       data-react-helmet="true"
       name="viewport"
     />
-    <link
-      href="/favicon.ico"
-      rel="shortcut icon"
-      type="image/x-icon"
-    />
     <title
       data-react-helmet="true"
     >
@@ -91,11 +86,6 @@ exports[`Document Component should render APP version correctly 1`] = `
       content="width=device-width, initial-scale=1, minimum-scale=1"
       data-react-helmet="true"
       name="viewport"
-    />
-    <link
-      href="/favicon.ico"
-      rel="shortcut icon"
-      type="image/x-icon"
     />
     <title
       data-react-helmet="true"
@@ -179,11 +169,6 @@ exports[`Document Component should render correctly 1`] = `
       content="width=device-width, initial-scale=1, minimum-scale=1"
       data-react-helmet="true"
       name="viewport"
-    />
-    <link
-      href="/favicon.ico"
-      rel="shortcut icon"
-      type="image/x-icon"
     />
     <title
       data-react-helmet="true"

--- a/src/server/Document/component.jsx
+++ b/src/server/Document/component.jsx
@@ -49,7 +49,6 @@ const Document = ({
       <head>
         {isApp && <meta name="robots" content="noindex" />}
         {meta}
-        <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
         {title}
         {helmetLinkTags}
         {headScript}


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/NEWSWORLDSERVICE-1585

Overall changes
======
Removes duplicate declaration of favicon in HTML head

Code changes
======
Removes favicon from Document document as it is already declared in the Metadata component

Testing
======
http://localhost:7080/pidgin - inspect HTML, search for favicon - there should only be 1 reference

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
