### PR TITLE
WSTEAMA-158: Resize topic badge image

### DIFF
--- a/src/app/pages/TopicPage/TopicImage/index.jsx
+++ b/src/app/pages/TopicPage/TopicImage/index.jsx
@@ -39,10 +39,12 @@ const ImageWrapper = styled.div`
 `;
 
 const TopicImage = ({ image }) => {
+  const imageUrl = image.replace('/480/', '/128/');
+
   return (
     <BadgeWrapper>
       <ImageWrapper>
-        <Image src={image} alt="" data-testid="topic-badge" />
+        <Image src={imageUrl} alt="" data-testid="topic-badge" />
       </ImageWrapper>
     </BadgeWrapper>
   );

--- a/src/app/pages/TopicPage/index.test.jsx
+++ b/src/app/pages/TopicPage/index.test.jsx
@@ -128,6 +128,22 @@ describe('Topic Page', () => {
     expect(container.getElementsByTagName('p').length).toEqual(1);
   });
 
+  it('should resize the badge image from 480 to 128', () => {
+    const { queryByTestId } = render(
+      <TopicPage pageData={mundoWithBadgeAndDescr} />,
+      getOptionParams({ service: 'mundo', lang: 'es' }),
+    );
+
+    const topicBadge = queryByTestId('topic-badge');
+
+    expect(topicBadge).toBeInTheDocument();
+    const topicBadgeSrc = topicBadge.getAttribute('src');
+    expect(topicBadgeSrc).not.toBe(mundoWithBadgeAndDescr.imageData.url);
+    expect(topicBadgeSrc).toBe(
+      'https://ichef.bbci.co.uk/news/png/128/cpsdevpb/b40b/test/5e614490-0360-11ed-b35d-c5a474731c9c.png',
+    );
+  });
+
   it('should render description without badge', () => {
     const { container, queryByTestId } = render(
       <TopicPage pageData={pidginMultipleItems} service="pidgin" />,

--- a/src/app/pages/TopicPage/index.test.jsx
+++ b/src/app/pages/TopicPage/index.test.jsx
@@ -140,7 +140,7 @@ describe('Topic Page', () => {
     const topicBadgeSrc = topicBadge.getAttribute('src');
     expect(topicBadgeSrc).not.toBe(mundoWithBadgeAndDescr.imageData.url);
     expect(topicBadgeSrc).toBe(
-      'https://ichef.bbci.co.uk/news/png/128/cpsdevpb/b40b/test/5e614490-0360-11ed-b35d-c5a474731c9c.png',
+      mundoWithBadgeAndDescr.imageData.url.replace('/480/', '/128/'),
     );
   });
 


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAMA-158

Overall changes
======
Reduces the topic badge image size to 128 so that it renders correctly when CSS is disabled

Code changes
======
- replace 480 ichef images with 128 
- add unit test

Testing
======
With CSS enabled and disabled

**Local**
http://localhost:7080/arabic/topics/c404vr23x4dt?renderer_env=live
Compare to https://www.bbc.com/arabic/topics/c404vr23x4dt where image is gigantic!

**Storybook**
[PR Storybook](https://wsteama-158-topic-badge-sizing--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&id=topic-page--example&viewMode=story)
Compare to [Latest Storybook](https://latest--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&id=topic-page--example&viewMode=story)

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
