### PR TITLE
Improve VS Code debugging to skip node_modules, in effect running jus…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,14 +6,17 @@
   "configurations": [
     {
       "type": "node",
-      "runtimeVersion": "16",
+      "runtimeVersion": "18",
       "request": "launch",
       "name": "Debug Express App",
       "program": "${workspaceFolder}/node_modules/webpack/bin/webpack.js",
       "args": [
         "--watch", "--progress", "--env" , "config='server'"
       ],
-      "env" : { "NODE_ENV" : "development" }
+      "env" : { "NODE_ENV" : "development" },
+      "skipFiles": [
+        "${workspaceFolder}/node_modules/**/*",
+      ]
     }
   ]
 }


### PR DESCRIPTION
…t our code

Overall changes
======
This PR implements a [stackoverflow suggestion](https://stackoverflow.com/a/47566410/2156186) enabling debugging of user code only rather than `node_modules`; this makes debugging easier as you don't have to step through library code.

Code changes
======
- Adds `skipFiles` config to skip `node_modules` files
- Updates runtime to match our production version of Node

Testing
======
Follow debugging steps in the repo and step through the code ensuring you never pause in library code.

Helpful Links
======
[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
