### PR TITLE
WSTEAM1-240: Header Image A11y Bug Fix using overlay behind text

### DIFF
--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/index.tsx
@@ -33,22 +33,24 @@ const MaskedImage = ({
     });
 
   return (
-    <div
-      css={[
-        styles.maskedImage,
-        isRtl ? styles.linearGradientRtl : styles.linearGradientLtr,
-      ]}
-    >
-      <Image
-        alt=""
-        src={imageUrl}
-        aspectRatio={[16, 9]}
-        srcSet={primarySrcset || undefined}
-        fallbackSrcSet={fallbackSrcset || undefined}
-        mediaType={primaryMimeType || undefined}
-        fallbackMediaType={fallbackMimeType || undefined}
-        sizes="(min-width: 1008px) 660px, 100vw"
-      />
+    <div css={styles.wrapper}>
+      <div
+        css={[
+          styles.maskedImage,
+          isRtl ? styles.linearGradientRtl : styles.linearGradientLtr,
+        ]}
+      >
+        <Image
+          alt=""
+          src={imageUrl}
+          // aspectRatio={[16, 9]}
+          srcSet={primarySrcset || undefined}
+          fallbackSrcSet={fallbackSrcset || undefined}
+          mediaType={primaryMimeType || undefined}
+          fallbackMediaType={fallbackMimeType || undefined}
+          sizes="(min-width: 1008px) 660px, 100vw"
+        />
+      </div>
     </div>
   );
 };

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/index.tsx
@@ -33,11 +33,16 @@ const MaskedImage = ({
     });
 
   return (
-    <div css={[styles.wrapper, isRtl ? styles.wrapperRtl : styles.wrapperLtr]}>
+    <div
+      css={[
+        styles.textBackground,
+        isRtl ? styles.textBackgroundRtl : styles.textBackgroundLtr,
+      ]}
+    >
       <div
         css={[
           styles.maskedImage,
-          isRtl ? styles.linearGradientRtl : styles.linearGradientLtr,
+          isRtl ? styles.maskedImageRtl : styles.maskedImageLtr,
         ]}
       >
         <Image

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/index.tsx
@@ -48,7 +48,7 @@ const MaskedImage = ({
         <Image
           alt=""
           src={imageUrl}
-          // aspectRatio={[16, 9]}
+          aspectRatio={[16, 9]}
           srcSet={primarySrcset || undefined}
           fallbackSrcSet={fallbackSrcset || undefined}
           mediaType={primaryMimeType || undefined}

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/index.tsx
@@ -33,7 +33,7 @@ const MaskedImage = ({
     });
 
   return (
-    <div css={styles.wrapper}>
+    <div css={[styles.wrapper, isRtl ? styles.wrapperRtl : styles.wrapperLtr]}>
       <div
         css={[
           styles.maskedImage,

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
@@ -105,8 +105,7 @@ export default {
     css({
       [mq.GROUP_4_ONLY]: {
         '::after': {
-          backgroundImage:
-            'linear-gradient(to right, rgba(0,0,0,0), rgba(20,20,20, 1) 20%)', // this works ok, need to edit colours
+          backgroundImage: `linear-gradient(to right, rgba(0,0,0,0), rgba(${maskColours.grey_10}, 1) 20%)`, // this works ok, need to edit colours
         },
       },
     }),
@@ -114,8 +113,7 @@ export default {
     css({
       [mq.GROUP_4_ONLY]: {
         '::after': {
-          backgroundImage:
-            'linear-gradient(to left, rgba(0,0,0,0), rgba(20,20,20, 1) 20%)', // this works ok, need to edit colours
+          backgroundImage: `linear-gradient(to left, rgba(0,0,0,0), rgba(${maskColours.grey_10}, 1) 20%)`, // this works ok, need to edit colours
         },
       },
     }),

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
@@ -87,9 +87,9 @@ const extraWideMask = `
   rgba(${maskColours.white}, 0) 100%`;
 
 export default {
-  wrapper: ({ mq }: Theme) =>
+  textBackground: ({ mq }: Theme) =>
     css({
-      // decided only over min for visual?
+      // decided to use GROUP_4_ONLY to avoid overlapping styles
       [mq.GROUP_4_ONLY]: {
         '::after': {
           content: '""',
@@ -97,23 +97,23 @@ export default {
           insetInlineStart: 0,
           top: 0,
           bottom: 0,
-          width: '60%', // this needs to apply to this wrapper and not thw image
+          width: '60%', // this needs to apply to this wrapper and not the image
         },
       },
     }),
-  wrapperRtl: ({ mq }: Theme) =>
+  textBackgroundRtl: ({ mq }: Theme) =>
     css({
       [mq.GROUP_4_ONLY]: {
         '::after': {
-          backgroundImage: `linear-gradient(to right, rgba(0,0,0,0), rgba(${maskColours.grey_10}, 1) 20%)`, // this works ok, need to edit colours
+          backgroundImage: `linear-gradient(to right, rgba(0,0,0,0), rgba(${maskColours.grey_10}, 1) 20%)`, // could pass colour in as a prop
         },
       },
     }),
-  wrapperLtr: ({ mq }: Theme) =>
+  textBackgroundLtr: ({ mq }: Theme) =>
     css({
       [mq.GROUP_4_ONLY]: {
         '::after': {
-          backgroundImage: `linear-gradient(to left, rgba(0,0,0,0), rgba(${maskColours.grey_10}, 1) 20%)`, // this works ok, need to edit colours
+          backgroundImage: `linear-gradient(to left, rgba(0,0,0,0), rgba(${maskColours.grey_10}, 1) 20%)`, // could pass colour in as a prop
         },
       },
     }),
@@ -133,7 +133,7 @@ export default {
       },
     }),
 
-  linearGradientLtr: ({ mq }: Theme) =>
+  maskedImageLtr: ({ mq }: Theme) =>
     css({
       [mq.GROUP_5_MIN_WIDTH]: {
         maskImage: `linear-gradient(
@@ -141,7 +141,7 @@ export default {
       },
     }),
 
-  linearGradientRtl: ({ mq }: Theme) =>
+  maskedImageRtl: ({ mq }: Theme) =>
     css({
       [mq.GROUP_5_MIN_WIDTH]: {
         maskImage: `linear-gradient(

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
@@ -110,11 +110,11 @@ export default {
   linearGradientLtr: ({ mq }: Theme) =>
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
-        background: `linear-gradient(
+        maskImage: `linear-gradient(
           270deg, ${group4MaskReduced})`, // 270deg for LTR
       },
       [mq.GROUP_5_MIN_WIDTH]: {
-        background: `linear-gradient(
+        maskImage: `linear-gradient(
           270deg, ${extraWideMask})`, // 270deg for LTR
       },
     }),
@@ -122,11 +122,11 @@ export default {
   linearGradientRtl: ({ mq }: Theme) =>
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
-        background: `linear-gradient(
+        maskImage: `linear-gradient(
           90deg, ${group4MaskReduced})`, // 90deg for RTL
       },
       [mq.GROUP_5_MIN_WIDTH]: {
-        background: `linear-gradient(
+        maskImage: `linear-gradient(
           90deg, ${extraWideMask})`, // 90deg for RTL
       },
     }),

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
@@ -93,6 +93,18 @@ const extraWideMask = `
   rgba(${maskColours.white}, 0) 100%`;
 
 export default {
+  wrapper: ({ mq }: Theme) =>
+    css({
+      //   [mq.GROUP_4_MIN_WIDTH]: {
+      //     position: 'absolute',
+      //     insetInlineEnd: 0,
+      //     top: '0',
+      //     height: '100%',
+      //     aspectRatio: '16 / 9',
+      //     overflow: 'hidden',
+      //     maxWidth: '80%', // can change this
+      // },
+    }),
   maskedImage: ({ mq }: Theme) =>
     css({
       maskSize: '100% 100%',
@@ -105,6 +117,7 @@ export default {
         height: '100%',
         aspectRatio: '16 / 9',
         overflow: 'hidden',
+        maxWidth: '80%', // can change this
       },
     }),
   linearGradientLtr: ({ mq }: Theme) =>

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
@@ -33,33 +33,12 @@ const mobileImageMask = `
   rgba(${maskColours.white}, 0) 100%
 `;
 
-const group4Mask = `
-  rgba(${maskColours.black}) 0%,
-  rgba(${maskColours.black}) 50%,
-  rgba(${maskColours.black}) 54%,
-  rgba(${maskColours.white}, 0.98) 56%,
-  rgba(${maskColours.white}, 0.96) 58%,
-  rgba(${maskColours.white}, 0.93) 60%,
-  rgba(${maskColours.white}, 0.89) 62%,
-  rgba(${maskColours.white}, 0.84) 64%,
-  rgba(${maskColours.white}, 0.8) 66%,
-  rgba(${maskColours.white}, 0.74) 68%,
-  rgba(${maskColours.white}, 0.68) 70%,
-  rgba(${maskColours.white}, 0.62) 72%,
-  rgba(${maskColours.white}, 0.56) 74%,
-  rgba(${maskColours.white}, 0.5) 76%,
-  rgba(${maskColours.white}, 0.44) 78%,
-  rgba(${maskColours.white}, 0.38) 80%,
-  rgba(${maskColours.white}, 0.32) 82%,
-  rgba(${maskColours.white}, 0.26) 84%,
-  rgba(${maskColours.white}, 0.2) 86%,
-  rgba(${maskColours.white}, 0.16) 88%,
-  rgba(${maskColours.white}, 0.11) 90%,
-  rgba(${maskColours.white}, 0.07) 92%,
-  rgba(${maskColours.white}, 0.04) 94%,
-  rgba(${maskColours.white}, 0.02) 96%,
-  rgba(${maskColours.white}, 0) 98%,
-  rgba(${maskColours.white}, 0) 100%`;
+const group4MaskReduced = `
+rgba(${maskColours.black}) 0%,
+rgba(${maskColours.black}) 45%,
+rgba(${maskColours.black}) 50%,
+  rgba(${maskColours.white}, 0) 78%,
+  rgba(${maskColours.white}, 0) 80%`;
 
 const extraWideMask = `
   rgba(${maskColours.white}, 0) 0%,
@@ -131,11 +110,11 @@ export default {
   linearGradientLtr: ({ mq }: Theme) =>
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
-        maskImage: `linear-gradient(
-          270deg, ${group4Mask})`, // 270deg for LTR
+        background: `linear-gradient(
+          270deg, ${group4MaskReduced})`, // 270deg for LTR
       },
       [mq.GROUP_5_MIN_WIDTH]: {
-        maskImage: `linear-gradient(
+        background: `linear-gradient(
           270deg, ${extraWideMask})`, // 270deg for LTR
       },
     }),
@@ -143,11 +122,11 @@ export default {
   linearGradientRtl: ({ mq }: Theme) =>
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
-        maskImage: `linear-gradient(
-          90deg, ${group4Mask})`, // 90deg for RTL
+        background: `linear-gradient(
+          90deg, ${group4MaskReduced})`, // 90deg for RTL
       },
       [mq.GROUP_5_MIN_WIDTH]: {
-        maskImage: `linear-gradient(
+        background: `linear-gradient(
           90deg, ${extraWideMask})`, // 90deg for RTL
       },
     }),

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
@@ -2,6 +2,7 @@ import { css, Theme } from '@emotion/react';
 
 const maskColours = {
   black: '0,0,0',
+  grey_10: '20,20,20',
   white: '255,255,255',
 };
 
@@ -32,13 +33,6 @@ const mobileImageMask = `
   rgba(${maskColours.white}, 0.1) 96%,
   rgba(${maskColours.white}, 0) 100%
 `;
-
-const group4MaskReduced = `
-rgba(${maskColours.black}) 0%,
-rgba(${maskColours.black}) 45%,
-rgba(${maskColours.black}) 50%,
-  rgba(${maskColours.white}, 0) 78%,
-  rgba(${maskColours.white}, 0) 80%`;
 
 const extraWideMask = `
   rgba(${maskColours.white}, 0) 0%,
@@ -95,15 +89,35 @@ const extraWideMask = `
 export default {
   wrapper: ({ mq }: Theme) =>
     css({
-      //   [mq.GROUP_4_MIN_WIDTH]: {
-      //     position: 'absolute',
-      //     insetInlineEnd: 0,
-      //     top: '0',
-      //     height: '100%',
-      //     aspectRatio: '16 / 9',
-      //     overflow: 'hidden',
-      //     maxWidth: '80%', // can change this
-      // },
+      // decided only over min for visual?
+      [mq.GROUP_4_ONLY]: {
+        '::after': {
+          content: '""',
+          position: 'absolute',
+          insetInlineStart: 0,
+          top: 0,
+          bottom: 0,
+          width: '60%', // this needs to apply to this wrapper and not thw image
+        },
+      },
+    }),
+  wrapperRtl: ({ mq }: Theme) =>
+    css({
+      [mq.GROUP_4_ONLY]: {
+        '::after': {
+          backgroundImage:
+            'linear-gradient(to right, rgba(0,0,0,0), rgba(20,20,20, 1) 20%)', // this works ok, need to edit colours
+        },
+      },
+    }),
+  wrapperLtr: ({ mq }: Theme) =>
+    css({
+      [mq.GROUP_4_ONLY]: {
+        '::after': {
+          backgroundImage:
+            'linear-gradient(to left, rgba(0,0,0,0), rgba(20,20,20, 1) 20%)', // this works ok, need to edit colours
+        },
+      },
     }),
   maskedImage: ({ mq }: Theme) =>
     css({
@@ -111,21 +125,18 @@ export default {
       maskImage: `linear-gradient(
       180deg, ${mobileImageMask})`,
       [mq.GROUP_4_MIN_WIDTH]: {
+        maskImage: 'none', // undoes mobile
         position: 'absolute',
         insetInlineEnd: 0,
         top: '0',
         height: '100%',
         aspectRatio: '16 / 9',
         overflow: 'hidden',
-        maxWidth: '80%', // can change this
       },
     }),
+
   linearGradientLtr: ({ mq }: Theme) =>
     css({
-      [mq.GROUP_4_MIN_WIDTH]: {
-        maskImage: `linear-gradient(
-          270deg, ${group4MaskReduced})`, // 270deg for LTR
-      },
       [mq.GROUP_5_MIN_WIDTH]: {
         maskImage: `linear-gradient(
           270deg, ${extraWideMask})`, // 270deg for LTR
@@ -134,10 +145,6 @@ export default {
 
   linearGradientRtl: ({ mq }: Theme) =>
     css({
-      [mq.GROUP_4_MIN_WIDTH]: {
-        maskImage: `linear-gradient(
-          90deg, ${group4MaskReduced})`, // 90deg for RTL
-      },
       [mq.GROUP_5_MIN_WIDTH]: {
         maskImage: `linear-gradient(
           90deg, ${extraWideMask})`, // 90deg for RTL

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
@@ -61,36 +61,12 @@ const extraWideMask = `
   rgba(${maskColours.black}) 24%,
   rgba(${maskColours.black}) 25%,
   rgba(${maskColours.black}) 50%,
-  rgba(${maskColours.black}) 54%,
-  rgba(${maskColours.white}, 0.98) 56%,
-  rgba(${maskColours.white}, 0.96) 58%,
-  rgba(${maskColours.white}, 0.93) 60%,
-  rgba(${maskColours.white}, 0.89) 62%,
-  rgba(${maskColours.white}, 0.84) 64%,
-  rgba(${maskColours.white}, 0.8) 66%,
-  rgba(${maskColours.white}, 0.74) 68%,
-  rgba(${maskColours.white}, 0.68) 70%,
-  rgba(${maskColours.white}, 0.62) 72%,
-  rgba(${maskColours.white}, 0.56) 74%,
-  rgba(${maskColours.white}, 0.5) 76%,
-  rgba(${maskColours.white}, 0.44) 78%,
-  rgba(${maskColours.white}, 0.38) 80%,
-  rgba(${maskColours.white}, 0.32) 82%,
-  rgba(${maskColours.white}, 0.26) 84%,
-  rgba(${maskColours.white}, 0.2) 86%,
-  rgba(${maskColours.white}, 0.16) 88%,
-  rgba(${maskColours.white}, 0.11) 90%,
-  rgba(${maskColours.white}, 0.07) 92%,
-  rgba(${maskColours.white}, 0.04) 94%,
-  rgba(${maskColours.white}, 0.02) 96%,
-  rgba(${maskColours.white}, 0) 98%,
-  rgba(${maskColours.white}, 0) 100%`;
+  rgba(${maskColours.black}) 54%`;
 
 export default {
   textBackground: ({ mq }: Theme) =>
     css({
-      // decided to use GROUP_4_ONLY to avoid overlapping styles
-      [mq.GROUP_4_ONLY]: {
+      [mq.GROUP_4_MIN_WIDTH]: {
         '::after': {
           content: '""',
           position: 'absolute',
@@ -103,7 +79,7 @@ export default {
     }),
   textBackgroundRtl: ({ mq }: Theme) =>
     css({
-      [mq.GROUP_4_ONLY]: {
+      [mq.GROUP_4_MIN_WIDTH]: {
         '::after': {
           backgroundImage: `linear-gradient(to right, rgba(0,0,0,0), rgba(${maskColours.grey_10}, 1) 20%)`, // could pass colour in as a prop
         },
@@ -111,7 +87,7 @@ export default {
     }),
   textBackgroundLtr: ({ mq }: Theme) =>
     css({
-      [mq.GROUP_4_ONLY]: {
+      [mq.GROUP_4_MIN_WIDTH]: {
         '::after': {
           backgroundImage: `linear-gradient(to left, rgba(0,0,0,0), rgba(${maskColours.grey_10}, 1) 20%)`, // could pass colour in as a prop
         },

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/index.stories.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/index.stories.tsx
@@ -165,3 +165,19 @@ export const TitleWithLiveLabelAndImage = ({
     imageWidth={660}
   />
 );
+
+export const TitleAndDescriptionWithLiveLabelAndImageExtraLongText = ({
+  service,
+  variant,
+}: StoryProps) => (
+  <Component
+    title="An kai wa jirgin kwashe yan Turkiyya hari a Sudan An kai wa jirgin kwashe yan Turkiyya hari a Sudan An kai wa jirgin kwashe yan Turkiyya hari a Sudan An kai wa jirgin kwashe yan Turkiyya hari a Sudan An kai wa jirgin kwashe yan Turkiyya hari a Sudan v v An kai wa jirgin kwashe yan Turkiyya hari a Sudan"
+    description="Wannan shaft ne da ke kawo muku laqbarai daga sassan duniya daban-daban Wannan shaft ne da ke kawo muku laqbarai daga sassan duniya daban-daban Wannan shaft ne da ke kawo muku laqbarai daga sassan duniya daban-daban Wannan shaft ne da ke kawo muku laqbarai daga sassan duniya daban-daban Wannan shaft ne da ke kawo muku laqbarai daga sassan duniya daban-daban v"
+    showLiveLabel
+    service={service}
+    variant={variant}
+    imageUrl="https://ichef.bbci.co.uk/ace/standard/480/cpsdevpb/1d5b/test/5f969ec0-c4d8-11ed-8319-9b394d8ed0dd.jpg"
+    imageUrlTemplate="https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/1d5b/test/5f969ec0-c4d8-11ed-8319-9b394d8ed0dd.jpg"
+    imageWidth={660}
+  />
+);


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-240](https://jira.dev.bbc.co.uk/browse/WSTEAM1-240) - subtask https://jira.dev.bbc.co.uk/browse/WSTEAM1-791

There are a few other possible solutions:
- https://github.com/bbc/simorgh/pull/11289
- https://github.com/bbc/simorgh/pull/11288

Overall changes
======
Fix an A11y bug that occurs when the browser is zoomed in up to 200% and/or there is a large amount of text

Bug Description
======
When the browser is zoomed in and/or there is a large amount of text, the header can exceed 440px in height. When this happens, the image becomes wider because we have a fixed image ratio.

In my initial solution, I used a image-mask to apply the gradient. This scales with the image and it does not provide adequate background to the text if the image becomes to wide.

Public Service get around this issue by changing the aspect ratio of the image. However our Image component does not allow for this.

I have decided to resolve this issue using CSS. I have created a div with a graident image-background which sits behind the text and is agnostic of the size of the image. The positive of this are that it means we can continue to use our image component. One negative of this is that it combines an mask-image and an image-background which might be confusing to engineers.  Another negative is that it might be harder to reuse the component since the image-background requires a colour to be declared whereas the image-mask does not (the colour declarations in the image-mask only effects the transparency of the image). However we could mitigate this by passing in the desired background colour as a prop.

Old PR (with bug - [storybook link](https://wsteam1-240-header-image--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&id=new-components-livepageheader--title-and-description-with-live-label-and-image&viewMode=story)):

<img width="1105" alt="Screenshot 2024-01-29 at 10 57 20" src="https://github.com/bbc/simorgh/assets/98817636/07e58eeb-960d-40fc-a5ee-e53345a74102">

This PR (bug resolved - [storybook link](https://wsteam1-240-header-image-ux-fix--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&id=new-components-livepageheader--title-and-description-with-live-label-and-image-extra-long-text&viewMode=story)):

<img width="1099" alt="Screenshot 2024-01-29 at 10 57 12" src="https://github.com/bbc/simorgh/assets/98817636/46ed9e23-519a-4d07-a850-56172a199f63">

Code changes
======
(from https://github.com/bbc/simorgh/pull/11273)
- Add textBackground div to MaskedImage component
- Apply lineargradient styles to this div on GROUP_4 and larger
- Remove existing GROUP_4 maskImage styles
- Update ExtraWide Image mask so that the gradients do not overlay
- Add extra long text storybook version for UX review.

Testing
======
Testing Locally

- pull down this branch
- cd into ws-nextjs-app and use yarn dev to run the application locally
- Visit http://localhost:7081/pidgin/live/c0mrezv7rd0t to see a header image (LTR)
- Visit http://localhost:7081/urdu/live/cd0jyl9r0lzt to see a header image (RTL)
- Visit http://localhost:7081/pidgin/live/c7p765ynk9qt to see a text-only header

Storybook links
- https://wsteam1-240-header-image-ux-fix--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&id=new-components-livepageheader--title-and-description-with-live-label-and-image&viewMode=story
- https://wsteam1-240-header-image-ux-fix--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&knob-Select%20a%20service=arabic&id=new-components-livepageheader--title-and-description-with-live-label-and-image&viewMode=story
- https://wsteam1-240-header-image-ux-fix--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&id=new-components-livepageheader--title-and-description-with-live-label-and-image-extra-long-text&viewMode=story
- https://wsteam1-240-header-image-ux-fix--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&knob-Select%20a%20service=arabic&id=new-components-livepageheader--title-and-description-with-live-label-and-image-extra-long-text&viewMode=story

Helpful Links
======
[UX designs (header image)](https://www.figma.com/file/D9w5JGLOhznDlz5tHu3rH0?node-id=5:63&locale=en&type=design)

[Screen reader UX Figma (header image)](https://www.figma.com/file/D9w5JGLOhznDlz5tHu3rH0/Live-mvp---Live-Topic-Header---handoff?type=design&node-id=104-10&mode=design&t=okUjISN0SwzmMfXw-0)

[Live Page Screen Reader UX](https://paper.dropbox.com/doc/WS-Live-page-Screen-reader-UX--CIFvUftYG2EdtFiNsaBzR9ovAg-8qm1UHDGVMhv5Qj9Q2mbi)

[Live Page A11y A/Cs](https://paper.dropbox.com/doc/Live-page-Accessibility-Acceptance-Criteria--CIHCd~3oDcJAv_Zt_ucLcbbIAg-KZQODmAf9tvodUlxsAVnA)

[UX designs (text only header)](https://www.figma.com/file/ozHsWG5R9tETw6lBOU740V/Live-mvp-header-(text-only)---handover?type=design&node-id=1-2&mode=design&t=xxJSN2MlwLiK80Ei-0)

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
