### PR TITLE
WSTEAM1-240: Fix a11y bug with fixed width

### DIFF
--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/MaskedImage/styles.tsx
@@ -33,33 +33,12 @@ const mobileImageMask = `
   rgba(${maskColours.white}, 0) 100%
 `;
 
-const group4Mask = `
-  rgba(${maskColours.black}) 0%,
-  rgba(${maskColours.black}) 50%,
-  rgba(${maskColours.black}) 54%,
-  rgba(${maskColours.white}, 0.98) 56%,
-  rgba(${maskColours.white}, 0.96) 58%,
-  rgba(${maskColours.white}, 0.93) 60%,
-  rgba(${maskColours.white}, 0.89) 62%,
-  rgba(${maskColours.white}, 0.84) 64%,
-  rgba(${maskColours.white}, 0.8) 66%,
-  rgba(${maskColours.white}, 0.74) 68%,
-  rgba(${maskColours.white}, 0.68) 70%,
-  rgba(${maskColours.white}, 0.62) 72%,
-  rgba(${maskColours.white}, 0.56) 74%,
-  rgba(${maskColours.white}, 0.5) 76%,
-  rgba(${maskColours.white}, 0.44) 78%,
-  rgba(${maskColours.white}, 0.38) 80%,
-  rgba(${maskColours.white}, 0.32) 82%,
-  rgba(${maskColours.white}, 0.26) 84%,
-  rgba(${maskColours.white}, 0.2) 86%,
-  rgba(${maskColours.white}, 0.16) 88%,
-  rgba(${maskColours.white}, 0.11) 90%,
-  rgba(${maskColours.white}, 0.07) 92%,
-  rgba(${maskColours.white}, 0.04) 94%,
-  rgba(${maskColours.white}, 0.02) 96%,
-  rgba(${maskColours.white}, 0) 98%,
-  rgba(${maskColours.white}, 0) 100%`;
+const group4MaskReduced = `
+rgba(${maskColours.black}) 0%,
+rgba(${maskColours.black}) 45%,
+rgba(${maskColours.black}) 50%,
+  rgba(${maskColours.white}, 0) 78%,
+  rgba(${maskColours.white}, 0) 80%`;
 
 const extraWideMask = `
   rgba(${maskColours.white}, 0) 0%,
@@ -126,13 +105,14 @@ export default {
         height: '100%',
         aspectRatio: '16 / 9',
         overflow: 'hidden',
+        maxWidth: '80%', // can change this
       },
     }),
   linearGradientLtr: ({ mq }: Theme) =>
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
         maskImage: `linear-gradient(
-          270deg, ${group4Mask})`, // 270deg for LTR
+          270deg, ${group4MaskReduced})`, // 270deg for LTR
       },
       [mq.GROUP_5_MIN_WIDTH]: {
         maskImage: `linear-gradient(
@@ -144,7 +124,7 @@ export default {
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
         maskImage: `linear-gradient(
-          90deg, ${group4Mask})`, // 90deg for RTL
+          90deg, ${group4MaskReduced})`, // 90deg for RTL
       },
       [mq.GROUP_5_MIN_WIDTH]: {
         maskImage: `linear-gradient(

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/index.stories.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/index.stories.tsx
@@ -165,3 +165,19 @@ export const TitleWithLiveLabelAndImage = ({
     imageWidth={660}
   />
 );
+
+export const TitleAndDescriptionWithLiveLabelAndImageExtraLongText = ({
+  service,
+  variant,
+}: StoryProps) => (
+  <Component
+    title="An kai wa jirgin kwashe yan Turkiyya hari a Sudan An kai wa jirgin kwashe yan Turkiyya hari a Sudan An kai wa jirgin kwashe yan Turkiyya hari a Sudan An kai wa jirgin kwashe yan Turkiyya hari a Sudan An kai wa jirgin kwashe yan Turkiyya hari a Sudan v v An kai wa jirgin kwashe yan Turkiyya hari a Sudan"
+    description="Wannan shaft ne da ke kawo muku laqbarai daga sassan duniya daban-daban Wannan shaft ne da ke kawo muku laqbarai daga sassan duniya daban-daban Wannan shaft ne da ke kawo muku laqbarai daga sassan duniya daban-daban Wannan shaft ne da ke kawo muku laqbarai daga sassan duniya daban-daban Wannan shaft ne da ke kawo muku laqbarai daga sassan duniya daban-daban v"
+    showLiveLabel
+    service={service}
+    variant={variant}
+    imageUrl="https://ichef.bbci.co.uk/ace/standard/480/cpsdevpb/1d5b/test/5f969ec0-c4d8-11ed-8319-9b394d8ed0dd.jpg"
+    imageUrlTemplate="https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/1d5b/test/5f969ec0-c4d8-11ed-8319-9b394d8ed0dd.jpg"
+    imageWidth={660}
+  />
+);


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-240](https://jira.dev.bbc.co.uk/browse/WSTEAM1-240) - subtask https://jira.dev.bbc.co.uk/browse/WSTEAM1-791

See https://github.com/bbc/simorgh/pull/11286 for A11y bug details

Overall changes
======
Gives the image a fixed width. Means that a black gap appears beneath the image if the header exceeds 440px.

![Screenshot 2024-01-29 at 14 23 57](https://github.com/bbc/simorgh/assets/98817636/1e4cd229-371c-4fe5-88c8-3b9837a95a13)

Code changes
======

- _A bullet point list of key code changes that have been made._

Testing
======
Storybook permalink: https://wsteam1-240-fixed-width--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&id=new-components-livepageheader--title-and-description-with-live-label-and-image-extra-long-text&viewMode=story

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
