### PR TITLE
Remove live Persian TC2 MAP in test assets and replace with live Urdu TC2 MAP

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -4569,7 +4569,6 @@ module.exports = () => ({
               '/persian/media-49522521', // CPS MAP with live stream
               '/persian/world-51497110', // CPS MAP with video clip
               '/persian/tv-and-radio-51780528', // CPS MAP with audio clip
-              '/persian/world/2016/06/160613_om_naked_dining', // TC2 MAP with video clip
             ],
             enabled: true,
           },
@@ -8162,7 +8161,7 @@ module.exports = () => ({
               '/urdu/entertainment-51584098', // CPS MAP with audio clip
               '/urdu/multimedia/2014/11/141104_hindu_riaz_kq', // TC2 MAP with video clip
             ],
-            enabled: false,
+            enabled: true,
           },
           test: {
             paths: [


### PR DESCRIPTION
This MAP keeps appearing in most watched way too much...

Replacement to keep level of test coverage RTL TC2 live asset

Overall changes
======
_A very high-level summary of easily-reproducible changes that can be understood by non-devs, and why these changes where made._

Code changes
======

- _A bullet point list of key code changes that have been made._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
