### PR TITLE
Puppeteer timeout increase

### DIFF
--- a/puppeteer/bundleRequests.test.js
+++ b/puppeteer/bundleRequests.test.js
@@ -15,7 +15,7 @@ let requests = [];
 
 const isJsBundle = url => url.includes(localBaseUrl);
 
-jest.setTimeout(30000); // overriding the default jest timeout
+jest.setTimeout(60000); // overriding the default jest timeout
 
 const getServiceBundleRegex = service => {
   const SHARED_RUSSIAN_UKRAINIAN = 'shared-russian-ukrainian';


### PR DESCRIPTION
Overall changes
======
- Double Puppeteer timeout to prevent needing to manually re-run the tests (they typically pass on the 2nd run)
- Think this has been changed in the recent past, so probably worth looking into the real reason why these are taking longer than expected

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
