### PR TITLE
Puppeteer wait for page load

### DIFF
--- a/puppeteer/bundleRequests.test.js
+++ b/puppeteer/bundleRequests.test.js
@@ -15,7 +15,9 @@ let requests = [];
 
 const isJsBundle = url => url.includes(localBaseUrl);
 
-jest.setTimeout(60000); // overriding the default jest timeout
+const TIMEOUT = 60000;
+
+jest.setTimeout(TIMEOUT); // overriding the default jest timeout
 
 const getServiceBundleRegex = service => {
   const SHARED_RUSSIAN_UKRAINIAN = 'shared-russian-ukrainian';
@@ -37,7 +39,7 @@ describe('Js bundle requests', () => {
     });
     page = await browser.newPage();
 
-    page.setDefaultNavigationTimeout(0);
+    page.setDefaultNavigationTimeout(TIMEOUT);
 
     page.on('request', request => {
       requests.push(request.url());

--- a/puppeteer/bundleRequests.test.js
+++ b/puppeteer/bundleRequests.test.js
@@ -62,7 +62,8 @@ describe('Js bundle requests', () => {
           describe(service, () => {
             beforeAll(async () => {
               await page.goto(`${localBaseUrl}${path}`, {
-                waitUntil: 'networkidle2',
+                waitUntil: 'load',
+                timeout: 0,
               });
             });
 

--- a/puppeteer/bundleRequests.test.js
+++ b/puppeteer/bundleRequests.test.js
@@ -37,6 +37,8 @@ describe('Js bundle requests', () => {
     });
     page = await browser.newPage();
 
+    page.setDefaultNavigationTimeout(0);
+
     page.on('request', request => {
       requests.push(request.url());
     });
@@ -61,11 +63,9 @@ describe('Js bundle requests', () => {
 
           describe(service, () => {
             beforeAll(async () => {
-              await page
-                .setDefaultNavigationTimeout(0)
-                .goto(`${localBaseUrl}${path}`, {
-                  waitUntil: 'networkidle2',
-                });
+              await page.goto(`${localBaseUrl}${path}`, {
+                waitUntil: 'networkidle2',
+              });
             });
 
             afterAll(() => {

--- a/puppeteer/bundleRequests.test.js
+++ b/puppeteer/bundleRequests.test.js
@@ -61,10 +61,11 @@ describe('Js bundle requests', () => {
 
           describe(service, () => {
             beforeAll(async () => {
-              await page.goto(`${localBaseUrl}${path}`, {
-                waitUntil: 'load',
-                timeout: 0,
-              });
+              await page
+                .setDefaultNavigationTimeout(0)
+                .goto(`${localBaseUrl}${path}`, {
+                  waitUntil: 'networkidle2',
+                });
             });
 
             afterAll(() => {


### PR DESCRIPTION
Overall changes
======
- Sets the `setDefaultNavigationTimeout` value on Puppeteer to the same value as the Jest timeout

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
