### PR TITLE
Check `variant` in topicTags e2e

### DIFF
--- a/cypress/support/helpers/topicTagsTest.js
+++ b/cypress/support/helpers/topicTagsTest.js
@@ -16,7 +16,7 @@ const getPageData = (url, service, variant, pageType) => {
     const bffUrl = `https://web-cdn.${
       env === 'live' ? '' : `${env}.`
     }api.bbci.co.uk/fd/simorgh-bff?pageType=article&id=${articleId}&service=${service}${
-      variant ? `&variant=${variant}` : ''
+      variant !== 'default' ? `&variant=${variant}` : ''
     }`;
 
     cy.log(bffUrl);


### PR DESCRIPTION
Overall changes
======
- Checks the `variant` in the topicTags e2e test to ensure it doesn't get added to the request URL if its set to `default`. This has now be highlighted as a bug as we strictly check to ensure the asset ID requested matches the service and variant in the response


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
