### PR TITLE
Suppress `digest` error in Cypress

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -27,6 +27,9 @@ const KNOWN_ERRORS = [
   // React 18 elevates hydration errors from 'warning' to 'error' level. So its likely this issue has
   // always been present, but was not caught before.
   'Minified React error #418',
+  // Catches an error that is elevated when tests click on some of our Topic Tags that results
+  // in a redirect to a page outside of our control throwing this error.
+  `Cannot read properties of undefined (reading 'digest')`,
 ];
 
 // eslint-disable-next-line consistent-return


### PR DESCRIPTION
Overall changes
======
- Suppresses an error we're experiencing when some of our Topics Tags tests hit a `/news/topics` page outside of the UK. `/news/topics` pages outside the UK are in the process of being redirected to a different platform outside of our control. The error is elevated from that platform rather than our own, so this change should ignore those errors


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
