### PR TITLE
Initial demo of issue with environment variables in nextjs

### DIFF
--- a/ws-nextjs-app/next.config.js
+++ b/ws-nextjs-app/next.config.js
@@ -24,15 +24,15 @@ module.exports = {
     externalDir: true,
   },
   env: {
-    ...(isLocal
-      ? // Add all env variables to the client when running locally
-        getClientEnvVars(DOT_ENV_CONFIG, { stringify: false })
-      : {
-          // Expose subset of env variables to the client when on preview, test or live
-          // The rest are set directly on the Lambda and accessible via process.env on the server
-          SIMORGH_ATI_BASE_URL: process.env.SIMORGH_ATI_BASE_URL,
-          SIMORGH_OPTIMIZELY_SDK_KEY: process.env.SIMORGH_OPTIMIZELY_SDK_KEY,
-        }),
+    // ...(isLocal
+    //   ? // Add all env variables to the client when running locally
+    //     getClientEnvVars(DOT_ENV_CONFIG, { stringify: false })
+    //   : {
+    //       // Expose subset of env variables to the client when on preview, test or live
+    //       // The rest are set directly on the Lambda and accessible via process.env on the server
+    //       SIMORGH_ATI_BASE_URL: process.env.SIMORGH_ATI_BASE_URL,
+    //       SIMORGH_OPTIMIZELY_SDK_KEY: process.env.SIMORGH_OPTIMIZELY_SDK_KEY,
+    //     }),
     LOG_TO_CONSOLE: 'true',
     NEXTJS: 'true',
   },

--- a/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
@@ -11,6 +11,7 @@ import { RequestContext } from '#app/contexts/RequestContext';
 import MetadataContainer from '#app/components/Metadata';
 import LinkedDataContainer from '#app/components/LinkedData';
 import getLiveBlogPostingSchema from '#app/lib/seoUtils/getLiveBlogPostingSchema';
+import Link from 'next/link';
 import Stream from './Stream';
 import Header from './Header';
 import KeyPoints from './KeyPoints';
@@ -127,6 +128,9 @@ const LivePage = ({ pageData }: ComponentProps) => {
           entities: [liveBlogPostingSchema],
         })}
       />
+      <Link href="/pidgin/live/c07zr0zwjnnt?renderer_env=test&page=2">
+        Go to page
+      </Link>
       <main>
         <Header
           showLiveLabel={isLive}

--- a/ws-nextjs-app/pages/[service]/live/[id]/Post/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Post/index.tsx
@@ -22,6 +22,87 @@ import {
   ComponentToRenderProps,
 } from './types';
 
+const imageBlock = [
+  {
+    id: 'fc238059',
+    type: 'rawImage',
+    model: {
+      height: 416,
+      width: 624,
+      locator:
+        'vivo/test/images/2023/12/7/0781b49d-0b5b-43b5-9b39-605b189c2136.jpg',
+      originCode: 'cpsdevpb',
+      copyrightHolder: 'AFP',
+    },
+  },
+  {
+    id: 'ccfa2c6f',
+    type: 'altText',
+    model: {
+      blocks: [
+        {
+          id: 'e76f2f22',
+          type: 'text',
+          model: {
+            blocks: [
+              {
+                id: '03a73508',
+                type: 'paragraph',
+                model: {
+                  text: 'Bombing over the Gaza Strip',
+                  blocks: [
+                    {
+                      id: 'e7f83cb4',
+                      type: 'fragment',
+                      model: {
+                        text: 'Bombing over the Gaza Strip',
+                        attributes: [],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+  {
+    id: 'f5f6212a',
+    type: 'caption',
+    model: {
+      blocks: [
+        {
+          id: '64aa2df7',
+          type: 'text',
+          model: {
+            blocks: [
+              {
+                id: 'f407ed3b',
+                type: 'paragraph',
+                model: {
+                  text: 'A view of Gaza shows smoke rising during Israeli shelling, taken from southern Israel',
+                  blocks: [
+                    {
+                      id: '1af79e32',
+                      type: 'fragment',
+                      model: {
+                        text: 'A view of Gaza shows smoke rising during Israeli shelling, taken from southern Israel',
+                        attributes: [],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+];
+
 const PostBreakingNewsLabel = ({
   isBreakingNews,
   breakingNewsLabelText,
@@ -193,6 +274,13 @@ const Post = ({ post }: { post: PostType }) => {
         </span>
       </Heading>
       <div css={styles.postContent}>
+        <ImageWithCaption
+          blocks={imageBlock}
+          sizes="(min-width: 1008px) 760px, 100vw"
+          className="mediaStyles"
+          css={styles.bodyMedia}
+          position={[9]}
+        />
         <PostContent contentBlocks={contentBlocks} />
       </div>
     </article>


### PR DESCRIPTION
Background
======
This PR allows the replication of a problem we are experiencing on test with a view to a future where we do more clientside rendering in NextJS. Today we have an issue where [test environment variables](https://github.com/bbc/simorgh/blob/latest/envConfig/test.env) are not used on test in clientside logic, instead [live environment variables](https://github.com/bbc/simorgh/blob/latest/envConfig/live.env) are used.

You can see this problem by visiting https://www.test.bbc.com/pidgin/live/c7p765ynk9qt with the network tab open:
![image](https://github.com/bbc/simorgh/assets/9645462/9e8b5cb9-94d9-4c6f-ba90-4d4b70cbd90a)

Amongst the network requests you can see an piano analytics request sending a beacon to the live piano service at [`https://a1.api.bbc.co.uk/hit.xiti?`](https://github.com/bbc/simorgh/blob/latest/envConfig/live.env#L5C22-L5C56) rather than [`https://logws1363.ati-host.net?`](https://github.com/bbc/simorgh/blob/latest/envConfig/test.env#L5C22-L5C53) you should expect for test.

This is because the request is sent clientside in a [`useEffect`](https://github.com/bbc/simorgh/blob/latest/src/app/hooks/useViewTracker/index.jsx#L89) using [environment variables](https://github.com/bbc/simorgh/blob/latest/src/app/components/ATIAnalytics/atiUrl/index.ts#L331) clientside rather than in the server render; the server render correctly uses the environment variables provided in the lamdba execution environment that are specific to environments.

Demo
=====
To experience the issue quite specific steps must be followed:
- cd to the nextjs app: `cd ws-nextjs-app`
- run `yarn build:local` to make local build using [`local.env`](https://github.com/bbc/simorgh/blob/latest/envConfig/local.env)
- Copy the the `test.env` config over the `.env` used for a local exection: `cp ../envConfig/test.env build/standalone/ws-nextjs-app/.env`
- Run `yarn start` to run the app. The app will use the values in `.env` for serverside rendered pages but will use the [`local.env`](https://github.com/bbc/simorgh/blob/latest/envConfig/local.env) for anything clientside as the values have been built into the javascript bundles.
- Visit http://localhost:7081/pidgin/live/c07zr0zwjnnt?renderer_env=test to see a server render, observe the images all coming from live ichef as configured in the [`local.env`](https://github.com/bbc/simorgh/blob/latest/envConfig/local.env#L9C24-L9C48) (I'm unsure why local uses live ichef but it useful for this reproduction 😅 )
  - On this PR we have hardcoded each post to include an image, you can observe in this initial _server_ render test ichef is being used as per the `test.env` we copied into out the build directory:
  - ![image](https://github.com/bbc/simorgh/assets/9645462/8b238923-639d-4038-9f6b-3a385e006b34)
- We have also hardcoded a next clientside link to force a full clientside render, please click this link _leaving the network tab open_: 
![image](https://github.com/bbc/simorgh/assets/9645462/36801970-3168-4d41-994f-43605648c10d)
  - We move to a different page of the live page, observe the images are now fetched from live ichef as configured in [`local.env`](https://github.com/bbc/simorgh/blob/latest/envConfig/local.env#L9C24-L9C48) and built into our javascript bundles.

Long term a solution needs to be found to stop this happening to allow for reliable testing on our test environment as we use more clientside routing.

Code changes
======
See comments

Helpful Links
======
https://nextjs.org/docs/pages/api-reference/next-config-js/env
https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
