### PR TITLE
Next.js app Cypress global retries

### DIFF
--- a/ws-nextjs-app/cypress.config.ts
+++ b/ws-nextjs-app/cypress.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
+  // Consider moving 'retries' to a per-test level once we have more tests
   retries: 3,
   e2e: {
     setupNodeEvents(on, config) {

--- a/ws-nextjs-app/cypress.config.ts
+++ b/ws-nextjs-app/cypress.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
+  retries: 3,
   e2e: {
     setupNodeEvents(on, config) {
       if (!config.env.APP_ENV) {


### PR DESCRIPTION
Overall changes
======
- Sets Cypress `retries` to `3` at a global level to see if it helps with the potential cold start-up issue on the Lambda returning false 500's.

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
