### PR TITLE
WSTEAM1-807 Live label pulse vertical alignment for all fonts V2 new and improved

### DIFF
--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.styles.ts
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.styles.ts
@@ -1,6 +1,5 @@
 import { css, Theme } from '@emotion/react';
 import { HALF, QUADRUPLE } from '#app/components/ThemeProvider/spacings';
-import pixelsToRem from '#app/utilities/pixelsToRem';
 
 const PULSE_END_MARGIN = HALF;
 const PULSE_SIZE_3_4 = QUADRUPLE;
@@ -12,15 +11,13 @@ const styles = {
       width: `${spacings.HALF + spacings.DOUBLE}rem`,
       height: `${spacings.HALF + spacings.DOUBLE}rem`,
       color: palette.LIVE_LIGHT,
-      verticalAlign: `${pixelsToRem(-5)}rem`,
+      verticalAlign: 'middle',
       marginInlineEnd: `${PULSE_END_MARGIN}rem`,
       [mq.GROUP_1_MIN_WIDTH]: {
-        verticalAlign: `${pixelsToRem(-7)}rem`,
         width: `${spacings.TRIPLE}rem`,
         height: `${spacings.TRIPLE}rem`,
       },
       [mq.GROUP_3_MIN_WIDTH]: {
-        verticalAlign: `${pixelsToRem(-8)}rem`,
         width: `${spacings.QUADRUPLE}rem`,
         height: `${spacings.QUADRUPLE}rem`,
       },
@@ -30,15 +27,23 @@ const styles = {
     }),
   liveLabelTextWithImage: ({ palette }: Theme) =>
     css({
-      'span:first-of-type': { color: palette.LIVE_LIGHT },
+      'span:first-of-type': {
+        color: palette.LIVE_LIGHT,
+        verticalAlign: 'middle',
+        display: 'inline',
+      },
     }),
   liveLabelTextWithoutImage: ({ mq, palette }: Theme) =>
     css({
       'span:first-of-type': {
         display: 'inline-flex',
         color: palette.LIVE_LIGHT,
+        verticalAlign: 'middle',
         'overflow-wrap': 'anywhere',
         marginInlineEnd: '0',
+        [mq.GROUP_0_MAX_WIDTH]: {
+          display: 'inline',
+        },
         [mq.GROUP_4_MIN_WIDTH]: {
           width: `calc(100% / 3  - ${PULSE_SIZE_TOTAL_WIDTH_3_MIN}rem)`,
         },

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -79,6 +79,9 @@ export default {
       display: 'block',
       color: palette.GREY_1,
       marginTop: `${spacings.DOUBLE}rem`,
+      [mq.GROUP_0_MAX_WIDTH]: {
+        marginTop: `${spacings.FULL}rem`,
+      },
       [mq.GROUP_4_MIN_WIDTH]: {
         width: 'calc(100% / 3 * 2)',
         display: 'inline-flex',

--- a/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
@@ -111,14 +111,13 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   width: 1.25rem;
   height: 1.25rem;
   color: #00CCC7;
-  vertical-align: -0.3125rem;
+  vertical-align: middle;
   -webkit-margin-end: 0.25rem;
   margin-inline-end: 0.25rem;
 }
 
 @media (min-width: 15rem) {
   .emotion-6 {
-    vertical-align: -0.4375rem;
     width: 1.5rem;
     height: 1.5rem;
   }
@@ -126,7 +125,6 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 
 @media (min-width: 37.5rem) {
   .emotion-6 {
-    vertical-align: -0.5rem;
     width: 2rem;
     height: 2rem;
   }
@@ -151,9 +149,16 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   color: #00CCC7;
+  vertical-align: middle;
   overflow-wrap: anywhere;
   -webkit-margin-end: 0;
   margin-inline-end: 0;
+}
+
+@media (max-width: 14.9375rem) {
+  .emotion-8 span:first-of-type {
+    display: inline;
+  }
 }
 
 @media (min-width: 63rem) {
@@ -193,6 +198,12 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   display: block;
   color: #FEFEFE;
   margin-top: 1rem;
+}
+
+@media (max-width: 14.9375rem) {
+  .emotion-11 {
+    margin-top: 0.5rem;
+  }
 }
 
 @media (min-width: 63rem) {


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-807](https://jira.dev.bbc.co.uk/browse/WSTEAM1-807)

Overall changes
======
Added CSS to the live label header

Code changes
======

- Added `verticalAlign: middle`  and `display: inline` to the `liveLabelText`
- Adjusted `margin-top` value for `titleWithoutImage` inline with new design specs

Testing
======
1. cd into `ws-nextjs-app` and yarn dev
2. Visit the following links and check the pulse is centered to the live label, matching the design specs

[Long live label text with no image](http://localhost:7081/pidgin/live/c7p765ynk9qt?renderer_env=test)
[Short live label text, RTL language](http://localhost:7081/urdu/live/cd0jyl9r0lzt?renderer_env=test)
[Long live label text with image](http://localhost:7081/pidgin/live/c0mrezv7rd0t?renderer_env=test)

You can also check it against this Burmese URL by removing the code which conditionally renders the live pulse to always render it  [here](https://github.com/bbc/simorgh/blob/7c79b7523879fe082ccd87d870c15a96d8534e87/ws-nextjs-app/pages/%5Bservice%5D/live/%5Bid%5D/Header/index.tsx#L56)

http://localhost:7081/burmese/live/c51v5pq2d2wt?renderer_env=live

Check the live label on a home page to make sure it hasnt regressed:
http://localhost:7080/pidgin

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Design Specs](https://www.figma.com/file/D9w5JGLOhznDlz5tHu3rH0/Live-mvp---Live-Topic-Header---handoff?type=design&node-id=552-57843&mode=design&t=G8XAuaV0LS4gn5NU-0)

[Design Specs for long live label text on small breakpoints](https://www.figma.com/file/D9w5JGLOhznDlz5tHu3rH0/Live-mvp---Live-Topic-Header---handoff?type=design&node-id=541-54975&mode=design)

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
