### PR TITLE
WSTEAM1-807 Live label pulse vertical alignment for burmese with no header image

### DIFF
--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.styles.ts
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.styles.ts
@@ -38,6 +38,7 @@ const styles = {
       'span:first-of-type': {
         display: 'inline-flex',
         color: palette.LIVE_LIGHT,
+        verticalAlign: 'middle',
         'overflow-wrap': 'anywhere',
         marginInlineEnd: '0',
         [mq.GROUP_0_MAX_WIDTH]: {
@@ -48,6 +49,14 @@ const styles = {
         },
         [mq.GROUP_5_MIN_WIDTH]: {
           width: `calc(25%  - ${PULSE_SIZE_TOTAL_WIDTH_3_MIN}rem)`,
+        },
+      },
+    }),
+  burmeseLiveLabelTextWithoutImage: ({ mq }: Theme) =>
+    css({
+      'span:first-of-type': {
+        [mq.GROUP_4_MIN_WIDTH]: {
+          fontSize: '2rem',
         },
       },
     }),

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.styles.ts
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.styles.ts
@@ -46,17 +46,10 @@ const styles = {
         },
         [mq.GROUP_4_MIN_WIDTH]: {
           width: `calc(100% / 3  - ${PULSE_SIZE_TOTAL_WIDTH_3_MIN}rem)`,
+          fontSize: '2rem',
         },
         [mq.GROUP_5_MIN_WIDTH]: {
           width: `calc(25%  - ${PULSE_SIZE_TOTAL_WIDTH_3_MIN}rem)`,
-        },
-      },
-    }),
-  burmeseLiveLabelTextWithoutImage: ({ mq }: Theme) =>
-    css({
-      'span:first-of-type': {
-        [mq.GROUP_4_MIN_WIDTH]: {
-          fontSize: '2rem',
         },
       },
     }),

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.styles.ts
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.styles.ts
@@ -38,7 +38,6 @@ const styles = {
       'span:first-of-type': {
         display: 'inline-flex',
         color: palette.LIVE_LIGHT,
-        verticalAlign: 'middle',
         'overflow-wrap': 'anywhere',
         marginInlineEnd: '0',
         [mq.GROUP_0_MAX_WIDTH]: {

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.styles.ts
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.styles.ts
@@ -18,8 +18,8 @@ const styles = {
         height: `${spacings.TRIPLE}rem`,
       },
       [mq.GROUP_3_MIN_WIDTH]: {
-        width: `${spacings.QUADRUPLE}rem`,
-        height: `${spacings.QUADRUPLE}rem`,
+        width: `${spacings.TRIPLE + spacings.HALF}rem`,
+        height: `${spacings.TRIPLE + spacings.HALF}rem`,
       },
       [mq.HIGH_CONTRAST]: {
         color: 'canvasText',

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.styles.ts
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.styles.ts
@@ -25,15 +25,24 @@ const styles = {
         color: 'canvasText',
       },
     }),
-  liveLabelTextWithImage: ({ palette }: Theme) =>
+  liveLabelTextWithImage: ({ palette, fontSizes, fontVariants, mq }: Theme) =>
     css({
       'span:first-of-type': {
         color: palette.LIVE_LIGHT,
         verticalAlign: 'middle',
         display: 'inline',
+        [mq.GROUP_3_MIN_WIDTH]: {
+          ...fontVariants.sansBold,
+          ...fontSizes.paragon,
+        },
       },
     }),
-  liveLabelTextWithoutImage: ({ mq, palette }: Theme) =>
+  liveLabelTextWithoutImage: ({
+    mq,
+    palette,
+    fontSizes,
+    fontVariants,
+  }: Theme) =>
     css({
       'span:first-of-type': {
         display: 'inline-flex',
@@ -44,9 +53,14 @@ const styles = {
         [mq.GROUP_0_MAX_WIDTH]: {
           display: 'inline',
         },
+        [mq.GROUP_3_MIN_WIDTH]: {
+          ...fontVariants.sansBold,
+          ...fontSizes.paragon,
+        },
         [mq.GROUP_4_MIN_WIDTH]: {
           width: `calc(100% / 3  - ${PULSE_SIZE_TOTAL_WIDTH_3_MIN}rem)`,
-          fontSize: '2rem',
+          ...fontVariants.sansBold,
+          ...fontSizes.paragon,
         },
         [mq.GROUP_5_MIN_WIDTH]: {
           width: `calc(25%  - ${PULSE_SIZE_TOTAL_WIDTH_3_MIN}rem)`,

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.tsx
@@ -5,7 +5,6 @@ import { PropsWithChildren } from 'react';
 import { jsx } from '@emotion/react';
 import { LiveLabelProps } from '#app/components/LiveLabel/types';
 import LiveLabel from '#app/components/LiveLabel';
-
 import styles from './index.styles';
 
 interface LiveLabelPromoProps extends LiveLabelProps {

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.tsx
@@ -1,10 +1,11 @@
 /** @jsx jsx */
 /** @jsxRuntime classic */
 /* @jsxFrag React.Fragment */
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useContext } from 'react';
 import { jsx } from '@emotion/react';
 import { LiveLabelProps } from '#app/components/LiveLabel/types';
 import LiveLabel from '#app/components/LiveLabel';
+import { ServiceContext } from '#app/contexts/ServiceContext';
 import styles from './index.styles';
 
 interface LiveLabelPromoProps extends LiveLabelProps {
@@ -19,6 +20,9 @@ const LiveLabelHeader = ({
   className,
   isHeaderImage,
 }: PropsWithChildren<LiveLabelPromoProps>) => {
+  const { service } = useContext(ServiceContext);
+  const isBurmese = service === 'burmese';
+
   return (
     <div data-testid="live-label">
       <LiveLabel.Pulse
@@ -34,7 +38,12 @@ const LiveLabelHeader = ({
         css={
           isHeaderImage
             ? styles.liveLabelTextWithImage
-            : styles.liveLabelTextWithoutImage
+            : [
+                styles.liveLabelTextWithoutImage,
+                !isBurmese && {
+                  'span:first-of-type': { verticalAlign: 'middle' },
+                },
+              ]
         }
       >
         {children}

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.tsx
@@ -1,11 +1,11 @@
 /** @jsx jsx */
 /** @jsxRuntime classic */
 /* @jsxFrag React.Fragment */
-import { PropsWithChildren, useContext } from 'react';
+import { PropsWithChildren } from 'react';
 import { jsx } from '@emotion/react';
 import { LiveLabelProps } from '#app/components/LiveLabel/types';
 import LiveLabel from '#app/components/LiveLabel';
-import { ServiceContext } from '#app/contexts/ServiceContext';
+
 import styles from './index.styles';
 
 interface LiveLabelPromoProps extends LiveLabelProps {

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.tsx
@@ -20,9 +20,6 @@ const LiveLabelHeader = ({
   className,
   isHeaderImage,
 }: PropsWithChildren<LiveLabelPromoProps>) => {
-  const { service } = useContext(ServiceContext);
-  const isBurmese = service === 'burmese';
-
   return (
     <div data-testid="live-label">
       <LiveLabel.Pulse
@@ -38,10 +35,7 @@ const LiveLabelHeader = ({
         css={
           isHeaderImage
             ? styles.liveLabelTextWithImage
-            : [
-                styles.liveLabelTextWithoutImage,
-                isBurmese && styles.burmeseLiveLabelTextWithoutImage,
-              ]
+            : styles.liveLabelTextWithoutImage
         }
       >
         {children}

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.tsx
@@ -40,9 +40,7 @@ const LiveLabelHeader = ({
             ? styles.liveLabelTextWithImage
             : [
                 styles.liveLabelTextWithoutImage,
-                !isBurmese && {
-                  'span:first-of-type': { verticalAlign: 'middle' },
-                },
+                isBurmese && styles.burmeseLiveLabelTextWithoutImage,
               ]
         }
       >

--- a/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
@@ -164,6 +164,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 @media (min-width: 63rem) {
   .emotion-8 span:first-of-type {
     width: calc(100% / 3  - 2.25rem);
+    font-size: 2rem;
   }
 }
 

--- a/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
@@ -149,6 +149,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   color: #00CCC7;
+  vertical-align: middle;
   overflow-wrap: anywhere;
   -webkit-margin-end: 0;
   margin-inline-end: 0;
@@ -170,10 +171,6 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   .emotion-8 span:first-of-type {
     width: calc(25%  - 2.25rem);
   }
-}
-
-.emotion-8 span:first-of-type {
-  vertical-align: middle;
 }
 
 .emotion-9 {

--- a/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
@@ -125,8 +125,8 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 
 @media (min-width: 37.5rem) {
   .emotion-6 {
-    width: 2rem;
-    height: 2rem;
+    width: 1.75rem;
+    height: 1.75rem;
   }
 }
 

--- a/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
@@ -149,7 +149,6 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   color: #00CCC7;
-  vertical-align: middle;
   overflow-wrap: anywhere;
   -webkit-margin-end: 0;
   margin-inline-end: 0;
@@ -171,6 +170,10 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   .emotion-8 span:first-of-type {
     width: calc(25%  - 2.25rem);
   }
+}
+
+.emotion-8 span:first-of-type {
+  vertical-align: middle;
 }
 
 .emotion-9 {

--- a/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
@@ -161,10 +161,52 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 }
 
+@media (min-width: 37.5rem) {
+  .emotion-8 span:first-of-type {
+    font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+    font-style: normal;
+    font-weight: 700;
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+
+  @media (min-width: 20rem) and (max-width: 37.4375rem) {
+    .emotion-8 span:first-of-type {
+      font-size: 1.375rem;
+      line-height: 1.625rem;
+    }
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-8 span:first-of-type {
+      font-size: 1.75rem;
+      line-height: 2rem;
+    }
+  }
+}
+
 @media (min-width: 63rem) {
   .emotion-8 span:first-of-type {
     width: calc(100% / 3  - 2.25rem);
-    font-size: 2rem;
+    font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+    font-style: normal;
+    font-weight: 700;
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+
+  @media (min-width: 20rem) and (max-width: 37.4375rem) {
+    .emotion-8 span:first-of-type {
+      font-size: 1.375rem;
+      line-height: 1.625rem;
+    }
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-8 span:first-of-type {
+      font-size: 1.75rem;
+      line-height: 2rem;
+    }
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/pull/11372#issuecomment-1978690168

Overall changes
======
Reduces the font size of live label text and the size of the pulse from the `GROUP_3` breakpoint and above in line with new styles. Makes sure the burmese live label text is aligned correctly with the pulse.

Code changes
======

- Sets `fontSize` to `paragon bold` at `GROUP_3_MIN_WIDTH` on `liveLabelTextWithImage` and `liveLabelTextWithoutImage`

Testing
======
1. Visit the [storybook link](https://live-label-for-burmese--5d28eb3fe163f6002046d6fa.chromatic.com/?path=/story/new-components-livepageheader--title-only-with-live-label) and check that at the largest breakpoint for burmese the live label looks like this. Also worth double checking other services to make sure they still work as expected from https://github.com/bbc/simorgh/pull/11372

<img width="1274" alt="Screenshot 2024-03-05 at 14 57 07" src="https://github.com/bbc/simorgh/assets/71819756/8ca74cda-16c1-48ab-aa2b-79cb72ec34a0">

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
