### PR TITLE
Fix Opera Mini `SIMORGH_DATA` object error

### DIFF
--- a/src/server/Document/__snapshots__/component.test.jsx.snap
+++ b/src/server/Document/__snapshots__/component.test.jsx.snap
@@ -116,6 +116,9 @@ exports[`Document Component should render APP version correctly 1`] = `
         App!
       </h1>
     </div>
+    <script>
+      window.SIMORGH_DATA={"test":"data"}
+    </script>
     <link
       href="modern.main.js"
       rel="modulePreload"
@@ -152,9 +155,6 @@ exports[`Document Component should render APP version correctly 1`] = `
     <div>
       <!--&lt;![endif]-->
     </div>
-    <script>
-      window.SIMORGH_DATA={"test":"data"}
-    </script>
     <script
       type="text/javascript"
     >
@@ -204,6 +204,9 @@ exports[`Document Component should render correctly 1`] = `
         App!
       </h1>
     </div>
+    <script>
+      window.SIMORGH_DATA={"test":"data"}
+    </script>
     <link
       href="modern.main.js"
       rel="modulePreload"
@@ -240,9 +243,6 @@ exports[`Document Component should render correctly 1`] = `
     <div>
       <!--&lt;![endif]-->
     </div>
-    <script>
-      window.SIMORGH_DATA={"test":"data"}
-    </script>
     <script
       type="text/javascript"
     >

--- a/src/server/Document/component.jsx
+++ b/src/server/Document/component.jsx
@@ -99,22 +99,22 @@ const Document = ({
       </head>
       <body {...ampGeoPendingAttrs}>
         <div id="root" dangerouslySetInnerHTML={{ __html: html }} />
-        {!isAmp && links}
         {scriptsAllowed && (
-          <>
-            {scriptTags}
-            <script
-              dangerouslySetInnerHTML={{
-                __html: `window.SIMORGH_DATA=${serialisedData}`,
-              }}
-            />
-            <script
-              type="text/javascript"
-              dangerouslySetInnerHTML={{
-                __html: `document.documentElement.classList.remove("no-js");`,
-              }}
-            />
-          </>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `window.SIMORGH_DATA=${serialisedData}`,
+            }}
+          />
+        )}
+        {!isAmp && links}
+        {scriptsAllowed && scriptTags}
+        {scriptsAllowed && (
+          <script
+            type="text/javascript"
+            dangerouslySetInnerHTML={{
+              __html: `document.documentElement.classList.remove("no-js");`,
+            }}
+          />
         )}
       </body>
     </html>


### PR DESCRIPTION
Overall changes
======
- Reverts back to the original way of setting the script elements in the `document/component.jsx` file, as it appears the ordering is required for Opera Mini to parse the `window.SIMORGH_DATA` object correctly

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
