### PR TITLE
Add `SIMORGH_DATA` script comment + test

### DIFF
--- a/src/server/Document/component.jsx
+++ b/src/server/Document/component.jsx
@@ -100,6 +100,7 @@ const Document = ({
       <body {...ampGeoPendingAttrs}>
         <div id="root" dangerouslySetInnerHTML={{ __html: html }} />
         {scriptsAllowed && (
+          // This script should be the first script tag in the body, otherwise Opera Mini has trouble parsing the `window.SIMORGH_DATA` object
           <script
             dangerouslySetInnerHTML={{
               __html: `window.SIMORGH_DATA=${serialisedData}`,

--- a/src/server/Document/component.test.jsx
+++ b/src/server/Document/component.test.jsx
@@ -109,4 +109,19 @@ describe('Document Component', () => {
 
     expect(head).toContainHTML('<meta name="robots" content="noindex" />');
   });
+
+  it('should render the "window.SIMORGH_DATA" object as the first script tag in the body', () => {
+    const dom = new JSDOM(
+      renderToString(<TestDocumentComponent service="news" />),
+    );
+
+    const body = dom.window.document.querySelector('body');
+    const scripts = body.querySelectorAll('script');
+
+    const firstScript = scripts[0];
+
+    expect(firstScript.innerHTML).toBe(
+      `window.SIMORGH_DATA=${JSON.stringify(data)}`,
+    );
+  });
 });


### PR DESCRIPTION
Overall changes
======
- Adds a comment for future reference about the ordering of the `SIMORGH_DATA` script in the DOM.
- Adds test to check the first script tag in the `body` is the `SIMORGH_DATA` one

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
