### PR TITLE
WSTEAM1-832+833 - SMP settings builder

### DIFF
--- a/src/app/components/LegacyLivePageMediaPlayer/index.tsx
+++ b/src/app/components/LegacyLivePageMediaPlayer/index.tsx
@@ -27,7 +27,7 @@ const LegacyLivePageMediaPlayer = ({ blocks, className }: Props) => {
 
 type Props = {
   blocks: MediaBlock[];
-  className: string;
+  className?: string;
 };
 
 export default LegacyLivePageMediaPlayer;

--- a/src/app/components/MediaLoader/README.md
+++ b/src/app/components/MediaLoader/README.md
@@ -2,21 +2,24 @@
 
 ## Description
 
-This component loads a media player into our webpage. It uses the BBC Universal Media Player module (BUMP) to choose the correct Embedded Media Player (EMP) for the user's device. Using BUMP removes the concerns involved in serving different devices and web-browsers as BUMP automatically provides the best fitting EMP for the client. For example, BUMP can cater for differences between mobiles, laptops and desktops, but also factors such as whether the user is using network data (3G) or a WIFI. 
-
+This component loads a media player into our webpage. It uses the BBC Universal Media Player module (BUMP) to choose the correct Embedded Media Player (EMP) for the user's device. Using BUMP removes the concerns involved in serving different devices and web-browsers as BUMP automatically provides the best fitting EMP for the client. For example, BUMP can cater for differences between mobiles, laptops and desktops, but also factors such as whether the user is using network data (3G) or a WIFI.
 
 ## Local Development
+
 So that the EMP can load video data, our localhost's domain name should be altered from `localhost:7080` to `localhost.bbc.com:7080` to fully encorporate the bbc domain name (bbc) and top-level domain (.com).
 
-First, run the command (you only need to run this once):  
+First, run the command (you only need to run this once):
 
 `sudo -- sh -c -e "echo '127.0.0.1       localhost.bbc.com' >> /etc/hosts";`
 
-Then, access local pages using: `localhost.bbc.com:7080/`, 
+Then, access local pages using: `localhost.bbc.com:7080/`,
 eg.
-Express pages:  `http://localhost.bbc.com:7080/afaanoromoo/articles/c4g19kgl85ko`
+Express pages: `http://localhost.bbc.com:7080/afaanoromoo/articles/c4g19kgl85ko`
 
 Next pages: `http://localhost.bbc.com:7081/pidgin/live/c7p765ynk9qt?renderer_env=test`
 
+Currently, the EMP is set to only load Live video assets by default. To load test assets, append the query `?renderer_env=test` to the url. Eg. `http://localhost.bbc.com:7080/afaanoromoo/articles/c4g19kgl85ko?renderer_env=test`
 
-Currently, the EMP is set to only load Live video assets by default. To load test assets, append the query `?renderer_env=test` to the url. Eg.  `http://localhost.bbc.com:7080/afaanoromoo/articles/c4g19kgl85ko?renderer_env=test`
+## Note on playback in local development
+
+In the Next.js app we have `reactStrictMode: true`. This causes lifecycle hooks to be called twice in development mode. This can result in the media player being loaded twice, causing mulitple playbacks of the same media. This does **not** happen in production mode.

--- a/src/app/components/MediaLoader/configs/article.ts
+++ b/src/app/components/MediaLoader/configs/article.ts
@@ -1,14 +1,25 @@
 import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
-import { AresMediaBlock, MediaBlock } from '../types';
+import {
+  AresMediaBlock,
+  BasePlayerConfig,
+  MediaBlock,
+  PlayerConfig,
+} from '../types';
 
 const DEFAULT_WIDTH = 512;
 
 type Props = {
   blocks: MediaBlock[];
+  basePlayerConfig: BasePlayerConfig;
 };
 
-export default ({ blocks }: Props) => {
+type ReturnProps = {
+  mediaType: string;
+  playerConfig: PlayerConfig;
+} | null;
+
+export default ({ blocks, basePlayerConfig }: Props): ReturnProps => {
   const aresMediaBlock: AresMediaBlock = filterForBlockType(
     blocks,
     'aresMedia',
@@ -51,7 +62,8 @@ export default ({ blocks }: Props) => {
 
   return {
     mediaType: format || 'video',
-    pagePlayerSettings: {
+    playerConfig: {
+      ...basePlayerConfig,
       playlistObject: {
         title,
         holdingImageURL: placeholderSrc,

--- a/src/app/components/MediaLoader/configs/article.ts
+++ b/src/app/components/MediaLoader/configs/article.ts
@@ -31,13 +31,13 @@ export default ({
   const { originCode, locator } =
     aresMediaBlock?.model?.blocks?.[1]?.model?.blocks?.[0]?.model ?? {};
 
-  const versionId =
+  const versionID =
     aresMediaBlock?.model?.blocks?.[0]?.model?.[versionParameter]?.[0]
       ?.versionId;
 
   const format = aresMediaBlock?.model?.blocks?.[0]?.model?.format;
 
-  const rawDuration =
+  const duration =
     aresMediaBlock?.model?.blocks?.[0]?.model?.[versionParameter]?.[0]
       ?.duration;
 
@@ -68,13 +68,7 @@ export default ({
         title,
         summary: caption || '',
         holdingImageURL: placeholderSrc,
-        items: [
-          {
-            versionID: versionId,
-            kind,
-            duration: rawDuration,
-          },
-        ],
+        items: [{ versionID, kind, duration }],
         ...(guidanceMessage && { guidance: guidanceMessage }),
       },
       ...(pageType === 'mediaArticle' && { preload: 'high' }),

--- a/src/app/components/MediaLoader/configs/article.ts
+++ b/src/app/components/MediaLoader/configs/article.ts
@@ -61,7 +61,7 @@ export default ({ pageType, blocks, basePlayerConfig }: Props): ReturnProps => {
     mediaType: format || 'video',
     playerConfig: {
       ...basePlayerConfig,
-      autoplay: pageType !== 'mediaArticle',
+      // autoplay: pageType !== 'mediaArticle',
       playlistObject: {
         title,
         holdingImageURL: placeholderSrc,

--- a/src/app/components/MediaLoader/configs/article.ts
+++ b/src/app/components/MediaLoader/configs/article.ts
@@ -1,15 +1,18 @@
 import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
-import { AresMediaBlock } from '../types';
+import { AresMediaBlock, MediaBlock } from '../types';
 
 const DEFAULT_WIDTH = 512;
 
 type Props = {
-  blocks: AresMediaBlock[];
+  blocks: MediaBlock[];
 };
 
 export default ({ blocks }: Props) => {
-  const aresMediaBlock = filterForBlockType(blocks, 'aresMedia');
+  const aresMediaBlock: AresMediaBlock = filterForBlockType(
+    blocks,
+    'aresMedia',
+  );
 
   if (!aresMediaBlock) return null;
 
@@ -21,7 +24,7 @@ export default ({ blocks }: Props) => {
   const versionParameter = hasWebcastItems ? 'webcastVersions' : 'versions';
 
   const { originCode, locator } =
-    aresMediaBlock?.model?.blocks?.[1]?.model?.blocks?.[0]?.model;
+    aresMediaBlock?.model?.blocks?.[1]?.model?.blocks?.[0]?.model ?? {};
 
   const versionId =
     aresMediaBlock?.model?.blocks?.[0]?.model?.[versionParameter]?.[0]

--- a/src/app/components/MediaLoader/configs/article.ts
+++ b/src/app/components/MediaLoader/configs/article.ts
@@ -1,11 +1,11 @@
 import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
-import { MediaBlock } from '../types';
+import { AresMediaBlock } from '../types';
 
 const DEFAULT_WIDTH = 512;
 
 type Props = {
-  blocks: MediaBlock[];
+  blocks: AresMediaBlock[];
 };
 
 export default ({ blocks }: Props) => {

--- a/src/app/components/MediaLoader/configs/article.ts
+++ b/src/app/components/MediaLoader/configs/article.ts
@@ -61,7 +61,7 @@ export default ({ pageType, blocks, basePlayerConfig }: Props): ReturnProps => {
     mediaType: format || 'video',
     playerConfig: {
       ...basePlayerConfig,
-      // autoplay: pageType !== 'mediaArticle',
+      autoplay: pageType !== 'mediaArticle',
       playlistObject: {
         title,
         holdingImageURL: placeholderSrc,

--- a/src/app/components/MediaLoader/configs/article.ts
+++ b/src/app/components/MediaLoader/configs/article.ts
@@ -1,0 +1,66 @@
+import buildIChefURL from '#lib/utilities/ichefURL';
+import filterForBlockType from '#lib/utilities/blockHandlers';
+import { MediaBlock } from '../types';
+
+const DEFAULT_WIDTH = 512;
+
+type Props = {
+  blocks: MediaBlock[];
+};
+
+export default ({ blocks }: Props) => {
+  const aresMediaBlock = filterForBlockType(blocks, 'aresMedia');
+
+  if (!aresMediaBlock) return null;
+
+  const { webcastVersions = [] } =
+    aresMediaBlock?.model?.blocks?.[0]?.model ?? [];
+
+  const hasWebcastItems = webcastVersions.length > 0;
+
+  const versionParameter = hasWebcastItems ? 'webcastVersions' : 'versions';
+
+  const { originCode, locator } =
+    aresMediaBlock?.model?.blocks?.[1]?.model?.blocks?.[0]?.model;
+
+  const versionId =
+    aresMediaBlock?.model?.blocks?.[0]?.model?.[versionParameter]?.[0]
+      ?.versionId;
+
+  const format = aresMediaBlock?.model?.blocks?.[0]?.model?.format;
+
+  const rawDuration =
+    aresMediaBlock?.model?.blocks?.[0]?.model?.[versionParameter]?.[0]
+      ?.duration;
+
+  const placeholderSrc = buildIChefURL({
+    originCode,
+    locator,
+    resolution: DEFAULT_WIDTH,
+  });
+
+  const title = aresMediaBlock?.model?.blocks?.[0]?.model?.title;
+  const kind =
+    aresMediaBlock?.model?.blocks?.[0]?.model?.smpKind || 'programme';
+  const guidanceMessage =
+    aresMediaBlock?.model?.blocks?.[0]?.model?.[versionParameter]?.[0]?.warnings
+      ?.short;
+
+  return {
+    mediaType: format === 'audio' ? 'audio' : 'video',
+    pagePlayerSettings: {
+      playlistObject: {
+        title,
+        holdingImageURL: placeholderSrc,
+        items: [
+          {
+            versionID: versionId,
+            kind,
+            duration: rawDuration,
+          },
+        ],
+        ...(guidanceMessage && { guidance: guidanceMessage }),
+      },
+    },
+  };
+};

--- a/src/app/components/MediaLoader/configs/article.ts
+++ b/src/app/components/MediaLoader/configs/article.ts
@@ -1,23 +1,19 @@
 import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
-import { PageTypes } from '#app/models/types/global';
-import { AresMediaBlock, MediaBlock, PlayerConfig } from '../types';
+import {
+  AresMediaBlock,
+  ConfigBuilderProps,
+  ConfigBuilderReturnProps,
+} from '../types';
 import getCaptionBlock from '../utils/getCaptionBlock';
 
 const DEFAULT_WIDTH = 512;
 
-type Props = {
-  pageType: PageTypes;
-  blocks: MediaBlock[];
-  basePlayerConfig: PlayerConfig;
-};
-
-type ReturnProps = {
-  mediaType: string;
-  playerConfig: PlayerConfig;
-} | null;
-
-export default ({ pageType, blocks, basePlayerConfig }: Props): ReturnProps => {
+export default ({
+  pageType,
+  blocks,
+  basePlayerConfig,
+}: ConfigBuilderProps): ConfigBuilderReturnProps => {
   const aresMediaBlock: AresMediaBlock = filterForBlockType(
     blocks,
     'aresMedia',

--- a/src/app/components/MediaLoader/configs/article.ts
+++ b/src/app/components/MediaLoader/configs/article.ts
@@ -1,5 +1,6 @@
 import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
+import { PageTypes } from '#app/models/types/global';
 import {
   AresMediaBlock,
   BasePlayerConfig,
@@ -10,6 +11,7 @@ import {
 const DEFAULT_WIDTH = 512;
 
 type Props = {
+  pageType: PageTypes;
   blocks: MediaBlock[];
   basePlayerConfig: BasePlayerConfig;
 };
@@ -19,7 +21,7 @@ type ReturnProps = {
   playerConfig: PlayerConfig;
 } | null;
 
-export default ({ blocks, basePlayerConfig }: Props): ReturnProps => {
+export default ({ pageType, blocks, basePlayerConfig }: Props): ReturnProps => {
   const aresMediaBlock: AresMediaBlock = filterForBlockType(
     blocks,
     'aresMedia',
@@ -64,6 +66,7 @@ export default ({ blocks, basePlayerConfig }: Props): ReturnProps => {
     mediaType: format || 'video',
     playerConfig: {
       ...basePlayerConfig,
+      autoplay: pageType !== 'mediaArticle',
       playlistObject: {
         title,
         holdingImageURL: placeholderSrc,
@@ -76,6 +79,7 @@ export default ({ blocks, basePlayerConfig }: Props): ReturnProps => {
         ],
         ...(guidanceMessage && { guidance: guidanceMessage }),
       },
+      ...(pageType === 'mediaArticle' && { preload: 'high' }),
     },
   };
 };

--- a/src/app/components/MediaLoader/configs/article.ts
+++ b/src/app/components/MediaLoader/configs/article.ts
@@ -50,7 +50,7 @@ export default ({ blocks }: Props) => {
       ?.short;
 
   return {
-    mediaType: format === 'audio' ? 'audio' : 'video',
+    mediaType: format || 'video',
     pagePlayerSettings: {
       playlistObject: {
         title,

--- a/src/app/components/MediaLoader/configs/article.ts
+++ b/src/app/components/MediaLoader/configs/article.ts
@@ -1,19 +1,14 @@
 import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
 import { PageTypes } from '#app/models/types/global';
-import {
-  AresMediaBlock,
-  BasePlayerConfig,
-  MediaBlock,
-  PlayerConfig,
-} from '../types';
+import { AresMediaBlock, MediaBlock, PlayerConfig } from '../types';
 
 const DEFAULT_WIDTH = 512;
 
 type Props = {
   pageType: PageTypes;
   blocks: MediaBlock[];
-  basePlayerConfig: BasePlayerConfig;
+  basePlayerConfig: PlayerConfig;
 };
 
 type ReturnProps = {

--- a/src/app/components/MediaLoader/configs/article.ts
+++ b/src/app/components/MediaLoader/configs/article.ts
@@ -2,6 +2,7 @@ import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
 import { PageTypes } from '#app/models/types/global';
 import { AresMediaBlock, MediaBlock, PlayerConfig } from '../types';
+import getCaptionBlock from '../utils/getCaptionBlock';
 
 const DEFAULT_WIDTH = 512;
 
@@ -51,6 +52,11 @@ export default ({ pageType, blocks, basePlayerConfig }: Props): ReturnProps => {
   });
 
   const title = aresMediaBlock?.model?.blocks?.[0]?.model?.title;
+  const captionBlock = getCaptionBlock(blocks, pageType);
+
+  const caption =
+    captionBlock?.model?.blocks?.[0]?.model?.blocks?.[0]?.model?.text;
+
   const kind =
     aresMediaBlock?.model?.blocks?.[0]?.model?.smpKind || 'programme';
   const guidanceMessage =
@@ -64,6 +70,7 @@ export default ({ pageType, blocks, basePlayerConfig }: Props): ReturnProps => {
       autoplay: pageType !== 'mediaArticle',
       playlistObject: {
         title,
+        summary: caption || '',
         holdingImageURL: placeholderSrc,
         items: [
           {

--- a/src/app/components/MediaLoader/configs/index.ts
+++ b/src/app/components/MediaLoader/configs/index.ts
@@ -10,6 +10,6 @@ export default (pageType: PageTypes) => {
     case 'mediaArticle':
       return article;
     default:
-      return article;
+      return null;
   }
 };

--- a/src/app/components/MediaLoader/configs/index.ts
+++ b/src/app/components/MediaLoader/configs/index.ts
@@ -1,0 +1,11 @@
+import { PageTypes } from '#app/models/types/global';
+import livePage from './livePage';
+
+export default (pageType: PageTypes) => {
+  switch (pageType) {
+    case 'live':
+      return livePage;
+    default:
+      return livePage;
+  }
+};

--- a/src/app/components/MediaLoader/configs/index.ts
+++ b/src/app/components/MediaLoader/configs/index.ts
@@ -1,11 +1,15 @@
 import { PageTypes } from '#app/models/types/global';
 import livePage from './livePage';
+import article from './article';
 
 export default (pageType: PageTypes) => {
   switch (pageType) {
     case 'live':
       return livePage;
+    case 'article':
+    case 'mediaArticle':
+      return article;
     default:
-      return livePage;
+      return article;
   }
 };

--- a/src/app/components/MediaLoader/configs/livePage.ts
+++ b/src/app/components/MediaLoader/configs/livePage.ts
@@ -3,6 +3,7 @@ import moment from 'moment-timezone';
 import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
 import { ClipMediaBlock, MediaBlock, PlayerConfig } from '../types';
+import getCaptionBlock from '../utils/getCaptionBlock';
 
 const DEFAULT_WIDTH = 512;
 
@@ -35,6 +36,11 @@ export default ({ blocks, basePlayerConfig }: Props): ReturnProps => {
   const rawDuration = moment.duration(clipISO8601Duration).asSeconds();
 
   const title = video?.title;
+  const captionBlock = getCaptionBlock(blocks, 'live');
+
+  const caption =
+    captionBlock?.model?.blocks?.[0]?.model?.blocks?.[0]?.model?.text;
+
   const kind = video?.version?.kind || 'programme';
   const guidanceMessage = video?.version?.guidance?.warnings?.short;
 
@@ -60,6 +66,7 @@ export default ({ blocks, basePlayerConfig }: Props): ReturnProps => {
       ...basePlayerConfig,
       playlistObject: {
         title,
+        summary: caption || '',
         holdingImageURL: placeholderSrc,
         items: [
           {

--- a/src/app/components/MediaLoader/configs/livePage.ts
+++ b/src/app/components/MediaLoader/configs/livePage.ts
@@ -2,15 +2,26 @@ import moment from 'moment-timezone';
 
 import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
-import { ClipMediaBlock, MediaBlock } from '../types';
+import {
+  BasePlayerConfig,
+  ClipMediaBlock,
+  MediaBlock,
+  PlayerConfig,
+} from '../types';
 
 const DEFAULT_WIDTH = 512;
 
 type Props = {
   blocks: MediaBlock[];
+  basePlayerConfig: BasePlayerConfig;
 };
 
-export default ({ blocks }: Props) => {
+type ReturnProps = {
+  mediaType: string;
+  playerConfig: PlayerConfig;
+} | null;
+
+export default ({ blocks, basePlayerConfig }: Props): ReturnProps => {
   const clipMediaBlock: ClipMediaBlock = filterForBlockType(
     blocks,
     'clipMedia',
@@ -38,9 +49,20 @@ export default ({ blocks }: Props) => {
     resolution: DEFAULT_WIDTH,
   });
 
+  const audioUi = {
+    skin: 'audio',
+    colour: '#b80000',
+    foreColour: '#222222',
+    baseColour: '#222222',
+    colourOnBaseColour: '#ffffff',
+    fallbackBackgroundColour: '#ffffff',
+    controls: { enabled: true, volumeSlider: true },
+  };
+
   return {
     mediaType: type || 'video',
-    pagePlayerSettings: {
+    playerConfig: {
+      ...basePlayerConfig,
       playlistObject: {
         title,
         holdingImageURL: placeholderSrc,
@@ -52,6 +74,10 @@ export default ({ blocks }: Props) => {
           },
         ],
         ...(guidanceMessage && { guidance: guidanceMessage }),
+      },
+      ui: {
+        ...basePlayerConfig.ui,
+        ...(type === 'audio' && audioUi),
       },
     },
   };

--- a/src/app/components/MediaLoader/configs/livePage.ts
+++ b/src/app/components/MediaLoader/configs/livePage.ts
@@ -2,18 +2,15 @@ import moment from 'moment-timezone';
 
 import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
-import formatDuration from '#lib/utilities/formatDuration';
-import { Translations } from '#app/models/types/translations';
 import { MediaBlock } from '../types';
 
 const DEFAULT_WIDTH = 512;
 
 type Props = {
   blocks: MediaBlock[];
-  translations: Translations;
 };
 
-export default ({ blocks, translations }: Props) => {
+export default ({ blocks }: Props) => {
   const clipMediaBlock = filterForBlockType(blocks, 'clipMedia');
 
   if (!clipMediaBlock) return null;
@@ -26,24 +23,11 @@ export default ({ blocks, translations }: Props) => {
   const clipISO8601Duration = clipMediaBlock?.model?.video?.version?.duration;
 
   const rawDuration = moment.duration(clipISO8601Duration).asSeconds();
-  const duration = moment.duration(rawDuration, 'seconds');
 
-  const durationSpokenPrefix = translations?.media?.duration || 'Duration';
-
-  const mediaInfo = {
-    title: clipMediaBlock?.model?.video?.title,
-    kind: clipMediaBlock?.model?.video?.video?.kind || 'programme',
-    duration: formatDuration({ duration, padMinutes: true }),
-    rawDuration,
-    durationSpoken: `${durationSpokenPrefix} ${formatDuration({
-      duration,
-      separator: ',',
-    })}`,
-    datetime: clipISO8601Duration,
-    type: format === 'audio' ? 'audio' : 'video',
-    guidanceMessage:
-      clipMediaBlock?.model?.video?.video?.guidance?.warnings?.short,
-  };
+  const title = clipMediaBlock?.model?.video?.title;
+  const kind = clipMediaBlock?.model?.video?.video?.kind || 'programme';
+  const guidanceMessage =
+    clipMediaBlock?.model?.video?.video?.guidance?.warnings?.short;
 
   const placeholderSrc = buildIChefURL({
     originCode,
@@ -52,21 +36,19 @@ export default ({ blocks, translations }: Props) => {
   });
 
   return {
-    mediaType: mediaInfo.type,
+    mediaType: format === 'audio' ? 'audio' : 'video',
     pagePlayerSettings: {
       playlistObject: {
-        title: mediaInfo.title,
+        title,
         holdingImageURL: placeholderSrc,
         items: [
           {
             versionID: versionId,
-            kind: mediaInfo.kind,
+            kind,
             duration: rawDuration,
           },
         ],
-        ...(mediaInfo.guidanceMessage && {
-          guidance: mediaInfo.guidanceMessage,
-        }),
+        ...(guidanceMessage && { guidance: guidanceMessage }),
       },
     },
   };

--- a/src/app/components/MediaLoader/configs/livePage.ts
+++ b/src/app/components/MediaLoader/configs/livePage.ts
@@ -52,13 +52,22 @@ export default ({ blocks, translations }: Props) => {
   });
 
   return {
-    clipId: versionId,
-    guidanceMessage: mediaInfo.guidanceMessage,
-    kind: mediaInfo.kind,
     mediaType: mediaInfo.type,
-    placeholderSrc,
-    rawDuration,
-    title: mediaInfo.title,
-    mediaBlock: clipMediaBlock,
+    pagePlayerSettings: {
+      playlistObject: {
+        title: mediaInfo.title,
+        holdingImageURL: placeholderSrc,
+        items: [
+          {
+            versionID: versionId,
+            kind: mediaInfo.kind,
+            duration: rawDuration,
+          },
+        ],
+        ...(mediaInfo.guidanceMessage && {
+          guidance: mediaInfo.guidanceMessage,
+        }),
+      },
+    },
   };
 };

--- a/src/app/components/MediaLoader/configs/livePage.ts
+++ b/src/app/components/MediaLoader/configs/livePage.ts
@@ -1,0 +1,64 @@
+import moment from 'moment-timezone';
+
+import buildIChefURL from '#lib/utilities/ichefURL';
+import filterForBlockType from '#lib/utilities/blockHandlers';
+import formatDuration from '#lib/utilities/formatDuration';
+import { Translations } from '#app/models/types/translations';
+import { MediaBlock } from '../types';
+
+const DEFAULT_WIDTH = 512;
+
+type Props = {
+  blocks: MediaBlock[];
+  translations: Translations;
+};
+
+export default ({ blocks, translations }: Props) => {
+  const clipMediaBlock = filterForBlockType(blocks, 'clipMedia');
+
+  if (!clipMediaBlock) return null;
+
+  const { source, urlTemplate: locator } = clipMediaBlock?.model?.images?.[1];
+
+  const originCode = source.replace('Image', '');
+  const versionId = clipMediaBlock?.model?.video?.version?.id;
+  const format = clipMediaBlock?.model?.type;
+  const clipISO8601Duration = clipMediaBlock?.model?.video?.version?.duration;
+
+  const rawDuration = moment.duration(clipISO8601Duration).asSeconds();
+  const duration = moment.duration(rawDuration, 'seconds');
+
+  const durationSpokenPrefix = translations?.media?.duration || 'Duration';
+
+  const mediaInfo = {
+    title: clipMediaBlock?.model?.video?.title,
+    kind: clipMediaBlock?.model?.video?.video?.kind || 'programme',
+    duration: formatDuration({ duration, padMinutes: true }),
+    rawDuration,
+    durationSpoken: `${durationSpokenPrefix} ${formatDuration({
+      duration,
+      separator: ',',
+    })}`,
+    datetime: clipISO8601Duration,
+    type: format === 'audio' ? 'audio' : 'video',
+    guidanceMessage:
+      clipMediaBlock?.model?.video?.video?.guidance?.warnings?.short,
+  };
+
+  const placeholderSrc = buildIChefURL({
+    originCode,
+    locator,
+    resolution: DEFAULT_WIDTH,
+  });
+
+  return {
+    clipId: versionId,
+    guidanceMessage: mediaInfo.guidanceMessage,
+    kind: mediaInfo.kind,
+    mediaType: mediaInfo.type,
+    placeholderSrc,
+    rawDuration,
+    title: mediaInfo.title,
+    mediaBlock: clipMediaBlock,
+  };
+};

--- a/src/app/components/MediaLoader/configs/livePage.ts
+++ b/src/app/components/MediaLoader/configs/livePage.ts
@@ -18,20 +18,19 @@ export default ({ blocks }: Props) => {
 
   if (!clipMediaBlock) return null;
 
-  const { source, urlTemplate: locator } =
-    clipMediaBlock?.model?.images?.[1] ?? {};
+  const { images, video, type } = clipMediaBlock?.model;
+
+  const { source, urlTemplate: locator } = images?.[1] ?? {};
 
   const originCode = source?.replace('Image', '');
-  const versionId = clipMediaBlock?.model?.video?.version?.id;
-  const format = clipMediaBlock?.model?.type;
-  const clipISO8601Duration = clipMediaBlock?.model?.video?.version?.duration;
+  const versionId = video?.version?.id;
+  const clipISO8601Duration = video?.version?.duration;
 
   const rawDuration = moment.duration(clipISO8601Duration).asSeconds();
 
-  const title = clipMediaBlock?.model?.video?.title;
-  const kind = clipMediaBlock?.model?.video?.version?.kind || 'programme';
-  const guidanceMessage =
-    clipMediaBlock?.model?.video?.version?.guidance?.warnings?.short;
+  const title = video?.title;
+  const kind = video?.version?.kind || 'programme';
+  const guidanceMessage = video?.version?.guidance?.warnings?.short;
 
   const placeholderSrc = buildIChefURL({
     originCode,
@@ -40,7 +39,7 @@ export default ({ blocks }: Props) => {
   });
 
   return {
-    mediaType: format === 'audio' ? 'audio' : 'video',
+    mediaType: type || 'video',
     pagePlayerSettings: {
       playlistObject: {
         title,

--- a/src/app/components/MediaLoader/configs/livePage.ts
+++ b/src/app/components/MediaLoader/configs/livePage.ts
@@ -2,22 +2,26 @@ import moment from 'moment-timezone';
 
 import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
-import { ClipMediaBlock } from '../types';
+import { ClipMediaBlock, MediaBlock } from '../types';
 
 const DEFAULT_WIDTH = 512;
 
 type Props = {
-  blocks: ClipMediaBlock[];
+  blocks: MediaBlock[];
 };
 
 export default ({ blocks }: Props) => {
-  const clipMediaBlock = filterForBlockType(blocks, 'clipMedia');
+  const clipMediaBlock: ClipMediaBlock = filterForBlockType(
+    blocks,
+    'clipMedia',
+  );
 
   if (!clipMediaBlock) return null;
 
-  const { source, urlTemplate: locator } = clipMediaBlock?.model?.images?.[1];
+  const { source, urlTemplate: locator } =
+    clipMediaBlock?.model?.images?.[1] ?? {};
 
-  const originCode = source.replace('Image', '');
+  const originCode = source?.replace('Image', '');
   const versionId = clipMediaBlock?.model?.video?.version?.id;
   const format = clipMediaBlock?.model?.type;
   const clipISO8601Duration = clipMediaBlock?.model?.video?.version?.duration;
@@ -25,9 +29,9 @@ export default ({ blocks }: Props) => {
   const rawDuration = moment.duration(clipISO8601Duration).asSeconds();
 
   const title = clipMediaBlock?.model?.video?.title;
-  const kind = clipMediaBlock?.model?.video?.video?.kind || 'programme';
+  const kind = clipMediaBlock?.model?.video?.version?.kind || 'programme';
   const guidanceMessage =
-    clipMediaBlock?.model?.video?.video?.guidance?.warnings?.short;
+    clipMediaBlock?.model?.video?.version?.guidance?.warnings?.short;
 
   const placeholderSrc = buildIChefURL({
     originCode,

--- a/src/app/components/MediaLoader/configs/livePage.ts
+++ b/src/app/components/MediaLoader/configs/livePage.ts
@@ -2,12 +2,12 @@ import moment from 'moment-timezone';
 
 import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
-import { MediaBlock } from '../types';
+import { ClipMediaBlock } from '../types';
 
 const DEFAULT_WIDTH = 512;
 
 type Props = {
-  blocks: MediaBlock[];
+  blocks: ClipMediaBlock[];
 };
 
 export default ({ blocks }: Props) => {

--- a/src/app/components/MediaLoader/configs/livePage.ts
+++ b/src/app/components/MediaLoader/configs/livePage.ts
@@ -2,22 +2,19 @@ import moment from 'moment-timezone';
 
 import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
-import { ClipMediaBlock, MediaBlock, PlayerConfig } from '../types';
+import {
+  ClipMediaBlock,
+  ConfigBuilderProps,
+  ConfigBuilderReturnProps,
+} from '../types';
 import getCaptionBlock from '../utils/getCaptionBlock';
 
 const DEFAULT_WIDTH = 512;
 
-type Props = {
-  blocks: MediaBlock[];
-  basePlayerConfig: PlayerConfig;
-};
-
-type ReturnProps = {
-  mediaType: string;
-  playerConfig: PlayerConfig;
-} | null;
-
-export default ({ blocks, basePlayerConfig }: Props): ReturnProps => {
+export default ({
+  blocks,
+  basePlayerConfig,
+}: ConfigBuilderProps): ConfigBuilderReturnProps => {
   const clipMediaBlock: ClipMediaBlock = filterForBlockType(
     blocks,
     'clipMedia',

--- a/src/app/components/MediaLoader/configs/livePage.ts
+++ b/src/app/components/MediaLoader/configs/livePage.ts
@@ -27,10 +27,10 @@ export default ({
   const { source, urlTemplate: locator } = images?.[1] ?? {};
 
   const originCode = source?.replace('Image', '');
-  const versionId = video?.version?.id;
+  const versionID = video?.version?.id;
   const clipISO8601Duration = video?.version?.duration;
 
-  const rawDuration = moment.duration(clipISO8601Duration).asSeconds();
+  const duration = moment.duration(clipISO8601Duration).asSeconds();
 
   const title = video?.title;
   const captionBlock = getCaptionBlock(blocks, 'live');
@@ -65,13 +65,7 @@ export default ({
         title,
         summary: caption || '',
         holdingImageURL: placeholderSrc,
-        items: [
-          {
-            versionID: versionId,
-            kind,
-            duration: rawDuration,
-          },
-        ],
+        items: [{ versionID, kind, duration }],
         ...(guidanceMessage && { guidance: guidanceMessage }),
       },
       ui: {

--- a/src/app/components/MediaLoader/configs/livePage.ts
+++ b/src/app/components/MediaLoader/configs/livePage.ts
@@ -2,18 +2,13 @@ import moment from 'moment-timezone';
 
 import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
-import {
-  BasePlayerConfig,
-  ClipMediaBlock,
-  MediaBlock,
-  PlayerConfig,
-} from '../types';
+import { ClipMediaBlock, MediaBlock, PlayerConfig } from '../types';
 
 const DEFAULT_WIDTH = 512;
 
 type Props = {
   blocks: MediaBlock[];
-  basePlayerConfig: BasePlayerConfig;
+  basePlayerConfig: PlayerConfig;
 };
 
 type ReturnProps = {

--- a/src/app/components/MediaLoader/fixture.ts
+++ b/src/app/components/MediaLoader/fixture.ts
@@ -1,4 +1,4 @@
-const sampleBlocks = [
+export const aresMediaBlocks = [
   {
     id: '80e150c0',
     type: 'aresMedia',
@@ -136,4 +136,139 @@ const sampleBlocks = [
   },
 ];
 
-export default sampleBlocks;
+const livePageCaptionBlock = {
+  id: '60db696a',
+  type: 'caption',
+  model: {
+    blocks: [
+      {
+        id: 'ea8e7d84',
+        type: 'text',
+        model: {
+          blocks: [
+            {
+              id: 'c7ca4de7',
+              type: 'paragraph',
+              model: {
+                text: 'BBC launch trailer for We Know Our Place women\'s sport campaign"',
+                blocks: [
+                  {
+                    id: 'b33e4302',
+                    type: 'fragment',
+                    model: {
+                      text: 'BBC launch trailer for We Know Our Place women\'s sport campaign"',
+                      attributes: [],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+const livePageClipMediaBlock = {
+  id: '1ce4d114',
+  type: 'clipMedia',
+  model: {
+    id: 'urn:bbc:pips:pid:p01thw20',
+    urns: {
+      pipsPid: 'urn:bbc:pips:pid:p01thw20',
+    },
+    images: [
+      {
+        url: 'https://ichef.test.bbci.co.uk/images/ic/1024xn/p01thw3g.jpg',
+        urlTemplate:
+          'https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01thw3g.jpg',
+        altText:
+          'BBC launch trailer for We Know Our Place women\'s sport campaign"',
+        type: 'socialImage',
+        source: 'pipsImage',
+      },
+      {
+        url: 'https://ichef.test.bbci.co.uk/images/ic/1024xn/p01thw3g.jpg',
+        urlTemplate:
+          'https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01thw3g.jpg',
+        altText:
+          'BBC launch trailer for We Know Our Place women\'s sport campaign"',
+        type: 'promoImage',
+        source: 'pipsImage',
+      },
+    ],
+    assetPath: 'p01thw20',
+    type: 'video',
+    headlines: {
+      primaryHeadline:
+        "BBC launch trailer for We Know Our Place women's sport campaign",
+      seoHeadline:
+        "BBC launch trailer for We Know Our Place women's sport campaign",
+      promoHeadline:
+        "BBC launch trailer for We Know Our Place women's sport campaign",
+      socialHeadline:
+        "BBC launch trailer for We Know Our Place women's sport campaign",
+    },
+    analytics: {
+      page: {
+        name: 'programmes.av.p01thw20.page',
+        contentId: 'urn:bbc:pips:pid:p01thw20',
+        producer: 'PROGRAMMES',
+      },
+    },
+    description:
+      'BBC launch trailer for We Know Our Place women\'s sport campaign"',
+    summary: {
+      type: 'text',
+      model: {
+        blocks: [
+          {
+            type: 'paragraph',
+            model: {
+              text: 'BBC launch trailer for We Know Our Place women\'s sport campaign"',
+              blocks: [
+                {
+                  type: 'fragment',
+                  model: {
+                    text: 'BBC launch trailer for We Know Our Place women\'s sport campaign"',
+                    attributes: [],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    lastPublished: '2022-07-01T08:56:56Z',
+    firstPublished: null,
+    video: {
+      id: 'p01thw20',
+      title: "BBC launch trailer for We Know Our Place women's sport campaign",
+      holdingImage: {
+        id: 'https://ichef.test.bbci.co.uk/images/ic/$recipe/p01thw3g.jpg',
+        altText:
+          'BBC launch trailer for We Know Our Place women\'s sport campaign"',
+      },
+      version: {
+        id: 'p01thw22',
+        duration: 'PT54S',
+        kind: 'programme',
+        guidance: null,
+        territories: ['nonuk', 'uk'],
+      },
+      isAdvertisingAllowed: true,
+      isEmbeddingAllowed: true,
+      isUnavailable: false,
+    },
+    attributions: null,
+    link: {
+      path: '/programmes/p01thw20',
+    },
+    section: null,
+    isSharingAllowed: true,
+  },
+};
+
+export const clipMediaBlocks = [livePageClipMediaBlock, livePageCaptionBlock];

--- a/src/app/components/MediaLoader/fixture.ts
+++ b/src/app/components/MediaLoader/fixture.ts
@@ -1,142 +1,141 @@
-export const aresMediaBlocks = [
-  {
-    id: '80e150c0',
-    type: 'aresMedia',
-    model: {
-      blocks: [
-        {
-          id: 'c77c0598',
-          blockId: 'urn:bbc:ares::clip:p01k6msm',
-          type: 'aresMediaMetadata',
-          model: {
-            id: 'p01k6msm',
-            subType: 'clip',
-            format: 'video',
-            title: 'Five things ants can teach us about management',
-            synopses: {
-              short:
-                'They may be tiny, but us humans could learn a thing or two from ants.',
-            },
-            imageUrl: 'ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg',
-            imageCopyright: 'BBC',
-            embedding: true,
-            advertising: true,
-            versions: [
-              {
-                versionId: 'p01k6msp',
-                types: ['Original'],
-                duration: 191,
-                durationISO8601: 'PT3M11S',
-                warnings: {
-                  short: 'Contains strong language and adult humour.',
-                  long: 'Contains strong language and adult humour.',
-                },
-                availableTerritories: {
-                  uk: true,
-                  nonUk: true,
-                },
-                availableFrom: 1540218932000,
-              },
-            ],
-            syndication: {
-              destinations: [],
-            },
-            smpKind: 'programme',
-          },
-          position: [5, 2, 1],
-        },
-        {
-          id: 'd8f26383',
-          type: 'image',
-          model: {
-            blocks: [
-              {
-                id: 'fcdba133',
-                type: 'rawImage',
-                model: {
-                  width: 1920,
-                  height: 1080,
-                  locator:
-                    'ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg',
-                  originCode: 'mpv',
-                  copyrightHolder: 'BBC',
-                },
-              },
-              {
-                id: '63679c9e',
-                type: 'altText',
-                model: {
-                  blocks: [
-                    {
-                      id: '33876888',
-                      type: 'text',
-                      model: {
-                        blocks: [
-                          {
-                            id: '26dbfca2',
-                            type: 'paragraph',
-                            model: {
-                              text: 'Ants',
-                              blocks: [
-                                {
-                                  id: 'ed9f30c9',
-                                  type: 'fragment',
-                                  model: {
-                                    text: 'Ants',
-                                    attributes: [],
-                                  },
-                                },
-                              ],
-                            },
-                          },
-                        ],
-                      },
+export const aresMediaCaptionBlock = {
+  id: '31318aec',
+  type: 'caption',
+  model: {
+    blocks: [
+      {
+        id: '8ac45ed2',
+        type: 'text',
+        model: {
+          blocks: [
+            {
+              id: '935f130e',
+              type: 'paragraph',
+              model: {
+                text: 'This is a caption!',
+                blocks: [
+                  {
+                    id: 'deaf6139',
+                    type: 'fragment',
+                    model: {
+                      text: 'This is a caption!',
+                      attributes: [],
                     },
-                  ],
-                },
+                  },
+                ],
               },
-            ],
-          },
+            },
+          ],
         },
-      ],
-    },
+      },
+    ],
   },
-  {
-    id: '31318aec',
-    type: 'caption',
-    model: {
-      blocks: [
-        {
-          id: '8ac45ed2',
-          type: 'text',
-          model: {
-            blocks: [
-              {
-                id: '935f130e',
-                type: 'paragraph',
-                model: {
-                  text: 'This is a caption!',
-                  blocks: [
-                    {
-                      id: 'deaf6139',
-                      type: 'fragment',
-                      model: {
-                        text: 'This is a caption!',
-                        attributes: [],
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-        },
-      ],
-    },
-  },
-];
+};
 
-const livePageCaptionBlock = {
+export const aresMediaBlock = {
+  id: '80e150c0',
+  type: 'aresMedia',
+  model: {
+    blocks: [
+      {
+        id: 'c77c0598',
+        blockId: 'urn:bbc:ares::clip:p01k6msm',
+        type: 'aresMediaMetadata',
+        model: {
+          id: 'p01k6msm',
+          subType: 'clip',
+          format: 'video',
+          title: 'Five things ants can teach us about management',
+          synopses: {
+            short:
+              'They may be tiny, but us humans could learn a thing or two from ants.',
+          },
+          imageUrl: 'ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg',
+          imageCopyright: 'BBC',
+          embedding: true,
+          advertising: true,
+          versions: [
+            {
+              versionId: 'p01k6msp',
+              types: ['Original'],
+              duration: 191,
+              durationISO8601: 'PT3M11S',
+              warnings: {
+                short: 'Contains strong language and adult humour.',
+                long: 'Contains strong language and adult humour.',
+              },
+              availableTerritories: {
+                uk: true,
+                nonUk: true,
+              },
+              availableFrom: 1540218932000,
+            },
+          ],
+          syndication: {
+            destinations: [],
+          },
+          smpKind: 'programme',
+        },
+        position: [5, 2, 1],
+      },
+      {
+        id: 'd8f26383',
+        type: 'image',
+        model: {
+          blocks: [
+            {
+              id: 'fcdba133',
+              type: 'rawImage',
+              model: {
+                width: 1920,
+                height: 1080,
+                locator:
+                  'ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg',
+                originCode: 'mpv',
+                copyrightHolder: 'BBC',
+              },
+            },
+            {
+              id: '63679c9e',
+              type: 'altText',
+              model: {
+                blocks: [
+                  {
+                    id: '33876888',
+                    type: 'text',
+                    model: {
+                      blocks: [
+                        {
+                          id: '26dbfca2',
+                          type: 'paragraph',
+                          model: {
+                            text: 'Ants',
+                            blocks: [
+                              {
+                                id: 'ed9f30c9',
+                                type: 'fragment',
+                                model: {
+                                  text: 'Ants',
+                                  attributes: [],
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+export const livePageCaptionBlock = {
   id: '60db696a',
   type: 'caption',
   model: {
@@ -170,7 +169,7 @@ const livePageCaptionBlock = {
   },
 };
 
-const livePageClipMediaBlock = {
+export const livePageClipMediaBlock = {
   id: '1ce4d114',
   type: 'clipMedia',
   model: {
@@ -271,4 +270,5 @@ const livePageClipMediaBlock = {
   },
 };
 
+export const aresMediaBlocks = [aresMediaBlock, aresMediaCaptionBlock];
 export const clipMediaBlocks = [livePageClipMediaBlock, livePageCaptionBlock];

--- a/src/app/components/MediaLoader/index.stories.tsx
+++ b/src/app/components/MediaLoader/index.stories.tsx
@@ -6,6 +6,7 @@ import MediaLoaderComponent from '.';
 import ThemeProvider from '../ThemeProvider';
 import md from './README.md';
 import { aresMediaBlocks } from './fixture';
+import { MediaBlock } from './types';
 
 type Props = {
   pageType: PageTypes;
@@ -24,7 +25,7 @@ const Component = ({ service, pageType }: Props) => (
       counterName="testCounterName"
     >
       <ThemeProvider service={service}>
-        <MediaLoaderComponent blocks={aresMediaBlocks} />
+        <MediaLoaderComponent blocks={aresMediaBlocks as MediaBlock[]} />
       </ThemeProvider>
     </RequestContextProvider>
   </ServiceContextProvider>

--- a/src/app/components/MediaLoader/index.stories.tsx
+++ b/src/app/components/MediaLoader/index.stories.tsx
@@ -5,15 +5,16 @@ import { ServiceContextProvider } from '../../contexts/ServiceContext';
 import MediaLoaderComponent from '.';
 import ThemeProvider from '../ThemeProvider';
 import md from './README.md';
-import { aresMediaBlocks } from './fixture';
+import { aresMediaBlocks, clipMediaBlocks } from './fixture';
 import { MediaBlock } from './types';
 
 type Props = {
   pageType: PageTypes;
   service: Services;
+  blocks: MediaBlock[];
 };
 
-const Component = ({ service, pageType }: Props) => (
+const Component = ({ service, pageType, blocks }: Props) => (
   <ServiceContextProvider service={service}>
     <RequestContextProvider
       id="testID"
@@ -25,7 +26,7 @@ const Component = ({ service, pageType }: Props) => (
       counterName="testCounterName"
     >
       <ThemeProvider service={service}>
-        <MediaLoaderComponent blocks={aresMediaBlocks as MediaBlock[]} />
+        <MediaLoaderComponent blocks={blocks} />
       </ThemeProvider>
     </RequestContextProvider>
   </ServiceContextProvider>
@@ -45,5 +46,17 @@ export default {
 };
 
 export const ArticleMediaLoader = () => (
-  <Component service="pidgin" pageType="article" />
+  <Component
+    service="pidgin"
+    pageType="article"
+    blocks={aresMediaBlocks as MediaBlock[]}
+  />
+);
+
+export const LivePageMediaLoader = () => (
+  <Component
+    service="pidgin"
+    pageType="live"
+    blocks={clipMediaBlocks as MediaBlock[]}
+  />
 );

--- a/src/app/components/MediaLoader/index.stories.tsx
+++ b/src/app/components/MediaLoader/index.stories.tsx
@@ -5,7 +5,7 @@ import { ServiceContextProvider } from '../../contexts/ServiceContext';
 import MediaLoaderComponent from '.';
 import ThemeProvider from '../ThemeProvider';
 import md from './README.md';
-import sample from './fixture';
+import { aresMediaBlocks } from './fixture';
 
 type Props = {
   pageType: PageTypes;
@@ -24,7 +24,7 @@ const Component = ({ service, pageType }: Props) => (
       counterName="testCounterName"
     >
       <ThemeProvider service={service}>
-        <MediaLoaderComponent className="MediaLoader" blocks={sample} />
+        <MediaLoaderComponent blocks={aresMediaBlocks} />
       </ThemeProvider>
     </RequestContextProvider>
   </ServiceContextProvider>

--- a/src/app/components/MediaLoader/index.test.tsx
+++ b/src/app/components/MediaLoader/index.test.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { act } from '@testing-library/react-hooks';
 import { Helmet } from 'react-helmet';
 import MediaPlayer from '.';
-import sampleBlocks from './fixture';
+import { aresMediaBlocks } from './fixture';
 import { render } from '../react-testing-library-with-providers';
 
 jest.mock('react', () => ({
@@ -21,7 +21,7 @@ describe('MediaLoader', () => {
 
     it('Loads requireJS and Bump4', async () => {
       await act(async () => {
-        render(<MediaPlayer blocks={sampleBlocks} className="mediaLoader" />, {
+        render(<MediaPlayer blocks={aresMediaBlocks} />, {
           id: 'testId',
         });
       });
@@ -44,7 +44,7 @@ describe('MediaLoader', () => {
       window.requirejs = mockRequire;
 
       await act(async () => {
-        render(<MediaPlayer blocks={sampleBlocks} className="mediaLoader" />, {
+        render(<MediaPlayer blocks={aresMediaBlocks} />, {
           id: 'testId',
         });
       });
@@ -62,12 +62,9 @@ describe('MediaLoader', () => {
       let container;
 
       await act(async () => {
-        ({ container } = render(
-          <MediaPlayer blocks={sampleBlocks} className="mediaLoader" />,
-          {
-            id: 'testId',
-          },
-        ));
+        ({ container } = render(<MediaPlayer blocks={aresMediaBlocks} />, {
+          id: 'testId',
+        }));
       });
 
       const button = (container as unknown as HTMLElement).querySelector(
@@ -79,12 +76,9 @@ describe('MediaLoader', () => {
       let container;
 
       await act(async () => {
-        ({ container } = render(
-          <MediaPlayer blocks={sampleBlocks} className="mediaLoader" />,
-          {
-            id: 'testId',
-          },
-        ));
+        ({ container } = render(<MediaPlayer blocks={aresMediaBlocks} />, {
+          id: 'testId',
+        }));
       });
 
       const caption = (container as unknown as HTMLElement).querySelector('p');

--- a/src/app/components/MediaLoader/index.test.tsx
+++ b/src/app/components/MediaLoader/index.test.tsx
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet';
 import MediaPlayer from '.';
 import { aresMediaBlocks } from './fixture';
 import { render } from '../react-testing-library-with-providers';
+import { MediaBlock } from './types';
 
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
@@ -21,7 +22,7 @@ describe('MediaLoader', () => {
 
     it('Loads requireJS and Bump4', async () => {
       await act(async () => {
-        render(<MediaPlayer blocks={aresMediaBlocks} />, {
+        render(<MediaPlayer blocks={aresMediaBlocks as MediaBlock[]} />, {
           id: 'testId',
         });
       });
@@ -44,7 +45,7 @@ describe('MediaLoader', () => {
       window.requirejs = mockRequire;
 
       await act(async () => {
-        render(<MediaPlayer blocks={aresMediaBlocks} />, {
+        render(<MediaPlayer blocks={aresMediaBlocks as MediaBlock[]} />, {
           id: 'testId',
         });
       });
@@ -62,9 +63,12 @@ describe('MediaLoader', () => {
       let container;
 
       await act(async () => {
-        ({ container } = render(<MediaPlayer blocks={aresMediaBlocks} />, {
-          id: 'testId',
-        }));
+        ({ container } = render(
+          <MediaPlayer blocks={aresMediaBlocks as MediaBlock[]} />,
+          {
+            id: 'testId',
+          },
+        ));
       });
 
       const button = (container as unknown as HTMLElement).querySelector(
@@ -76,9 +80,12 @@ describe('MediaLoader', () => {
       let container;
 
       await act(async () => {
-        ({ container } = render(<MediaPlayer blocks={aresMediaBlocks} />, {
-          id: 'testId',
-        }));
+        ({ container } = render(
+          <MediaPlayer blocks={aresMediaBlocks as MediaBlock[]} />,
+          {
+            id: 'testId',
+          },
+        ));
       });
 
       const caption = (container as unknown as HTMLElement).querySelector('p');

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet';
 import Caption from '#app/legacy/containers/Caption';
 import { RequestContext } from '#contexts/RequestContext';
 import { MEDIA_PLAYER_STATUS } from '#app/lib/logger.const';
-import { BumpType, PlayerConfig, Props } from './types';
+import { BumpType, AresMediaBlock, PlayerConfig } from './types';
 import nodeLogger from '../../lib/logger.node';
 import buildConfig from './utils/buildSettings';
 import getCaptionBlock from './utils/getCaptionBlock';
@@ -57,6 +57,11 @@ const Placeholder = ({ setter }: { setter: (value: boolean) => void }) => {
       TODO: CLICK TO SEE VIDEO
     </button>
   );
+};
+
+type Props = {
+  className?: string;
+  blocks: AresMediaBlock[];
 };
 
 const MediaLoader = ({ blocks, className }: Props) => {

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -28,24 +28,17 @@ const BumpLoader = () => (
 
 const MediaContainer = ({ playerConfig }: { playerConfig: PlayerConfig }) => {
   const playerElementRef = useRef<HTMLDivElement>(null);
-  // Used to ensure SMP is only loaded once
-  const smpLoadedRef = useRef(false);
 
   useEffect(() => {
     try {
       window.requirejs(['bump-4'], (Bump: BumpType) => {
-        if (
-          playerElementRef?.current &&
-          !smpLoadedRef.current &&
-          playerConfig
-        ) {
+        if (playerElementRef?.current && playerConfig) {
           const mediaPlayer = Bump.player(
             playerElementRef.current,
             playerConfig,
           );
 
           mediaPlayer.load();
-          smpLoadedRef.current = true;
         }
       });
     } catch (error) {

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -27,17 +27,25 @@ const BumpLoader = () => (
 );
 
 const MediaContainer = ({ playerConfig }: { playerConfig: PlayerConfig }) => {
-  const playerElementRef = useRef(null);
+  const playerElementRef = useRef<HTMLDivElement>(null);
+  // Used to ensure SMP is only loaded once
+  const smpLoadedRef = useRef(false);
 
   useEffect(() => {
     try {
       window.requirejs(['bump-4'], (Bump: BumpType) => {
-        if (playerElementRef && playerElementRef.current && playerConfig) {
+        if (
+          playerElementRef?.current &&
+          !smpLoadedRef.current &&
+          playerConfig
+        ) {
           const mediaPlayer = Bump.player(
             playerElementRef.current,
             playerConfig,
           );
+
           mediaPlayer.load();
+          smpLoadedRef.current = true;
         }
       });
     } catch (error) {

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -3,7 +3,6 @@ import { Helmet } from 'react-helmet';
 import Caption from '#app/legacy/containers/Caption';
 import { RequestContext } from '#contexts/RequestContext';
 import { MEDIA_PLAYER_STATUS } from '#app/lib/logger.const';
-import { ServiceContext } from '#app/contexts/ServiceContext';
 import filterForBlockType from '#app/lib/utilities/blockHandlers';
 import { BumpType, PlayerConfig, Props } from './types';
 import nodeLogger from '../../lib/logger.node';
@@ -63,13 +62,11 @@ const Placeholder = ({ setter }: { setter: (value: boolean) => void }) => {
 const MediaLoader = ({ blocks, className }: Props) => {
   const [isPlaceholder, setIsPlaceholder] = useState(true);
   const { id, pageType, counterName } = useContext(RequestContext);
-  const { translations } = useContext(ServiceContext);
 
   const config = buildConfig({
     id,
     pageType,
     blocks,
-    translations,
     counterName,
   });
 

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet';
 import Caption from '#app/legacy/containers/Caption';
 import { RequestContext } from '#contexts/RequestContext';
 import { MEDIA_PLAYER_STATUS } from '#app/lib/logger.const';
+import { ServiceContext } from '#app/contexts/ServiceContext';
 import { BumpType, PlayerConfig, MediaBlock } from './types';
 import nodeLogger from '../../lib/logger.node';
 import buildConfig from './utils/buildSettings';
@@ -66,13 +67,18 @@ type Props = {
 
 const MediaLoader = ({ blocks, className }: Props) => {
   const [isPlaceholder, setIsPlaceholder] = useState(true);
-  const { id, pageType, counterName } = useContext(RequestContext);
+  const { id, pageType, counterName, isAmp, service } =
+    useContext(RequestContext);
+  const { lang } = useContext(ServiceContext);
 
   const config = buildConfig({
     id,
     pageType,
     blocks,
     counterName,
+    isAmp,
+    service,
+    lang,
   });
 
   if (config === null) return null;

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -80,16 +80,16 @@ const MediaLoader = ({ blocks, className }: Props) => {
   const { lang } = useContext(ServiceContext);
 
   const config = buildConfig({
-    id,
-    pageType,
     blocks,
     counterName,
+    id,
     isAmp,
-    service,
     lang,
+    pageType,
+    service,
   });
 
-  if (config === null) return null;
+  if (!config) return null;
 
   const { mediaType, playerConfig } = config;
 

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -3,6 +3,8 @@ import { Helmet } from 'react-helmet';
 import Caption from '#app/legacy/containers/Caption';
 import { RequestContext } from '#contexts/RequestContext';
 import { MEDIA_PLAYER_STATUS } from '#app/lib/logger.const';
+import { ServiceContext } from '#app/contexts/ServiceContext';
+import filterForBlockType from '#app/lib/utilities/blockHandlers';
 import { BumpType, PlayerConfig, Props } from './types';
 import nodeLogger from '../../lib/logger.node';
 import buildConfig from './utils/buildSettings';
@@ -61,17 +63,21 @@ const Placeholder = ({ setter }: { setter: (value: boolean) => void }) => {
 const MediaLoader = ({ blocks, className }: Props) => {
   const [isPlaceholder, setIsPlaceholder] = useState(true);
   const { id, pageType, counterName } = useContext(RequestContext);
+  const { translations } = useContext(ServiceContext);
 
   const config = buildConfig({
     id,
     pageType,
     blocks,
+    translations,
     counterName,
   });
 
   if (config === null) return null;
 
-  const { mediaInfo, captionBlock, playerConfig } = config;
+  const { mediaType, playerConfig } = config;
+
+  const captionBlock = filterForBlockType(blocks, 'caption');
 
   return (
     <div className={className}>
@@ -81,7 +87,7 @@ const MediaLoader = ({ blocks, className }: Props) => {
       ) : (
         <MediaContainer playerConfig={playerConfig} />
       )}
-      {captionBlock && <Caption block={captionBlock} type={mediaInfo.type} />}
+      {captionBlock && <Caption block={captionBlock} type={mediaType} />}
     </div>
   );
 };

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet';
 import Caption from '#app/legacy/containers/Caption';
 import { RequestContext } from '#contexts/RequestContext';
 import { MEDIA_PLAYER_STATUS } from '#app/lib/logger.const';
-import { BumpType, PlayerConfig, MediaBlocks } from './types';
+import { BumpType, PlayerConfig, MediaBlock } from './types';
 import nodeLogger from '../../lib/logger.node';
 import buildConfig from './utils/buildSettings';
 import getCaptionBlock from './utils/getCaptionBlock';
@@ -61,7 +61,7 @@ const Placeholder = ({ setter }: { setter: (value: boolean) => void }) => {
 
 type Props = {
   className?: string;
-  blocks: MediaBlocks;
+  blocks: MediaBlock[];
 };
 
 const MediaLoader = ({ blocks, className }: Props) => {

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet';
 import Caption from '#app/legacy/containers/Caption';
 import { RequestContext } from '#contexts/RequestContext';
 import { MEDIA_PLAYER_STATUS } from '#app/lib/logger.const';
-import { BumpType, AresMediaBlock, PlayerConfig } from './types';
+import { BumpType, PlayerConfig, MediaBlocks } from './types';
 import nodeLogger from '../../lib/logger.node';
 import buildConfig from './utils/buildSettings';
 import getCaptionBlock from './utils/getCaptionBlock';
@@ -61,7 +61,7 @@ const Placeholder = ({ setter }: { setter: (value: boolean) => void }) => {
 
 type Props = {
   className?: string;
-  blocks: AresMediaBlock[];
+  blocks: MediaBlocks;
 };
 
 const MediaLoader = ({ blocks, className }: Props) => {

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -3,10 +3,10 @@ import { Helmet } from 'react-helmet';
 import Caption from '#app/legacy/containers/Caption';
 import { RequestContext } from '#contexts/RequestContext';
 import { MEDIA_PLAYER_STATUS } from '#app/lib/logger.const';
-import filterForBlockType from '#app/lib/utilities/blockHandlers';
 import { BumpType, PlayerConfig, Props } from './types';
 import nodeLogger from '../../lib/logger.node';
 import buildConfig from './utils/buildSettings';
+import getCaptionBlock from './utils/getCaptionBlock';
 
 const logger = nodeLogger(__filename);
 
@@ -74,7 +74,7 @@ const MediaLoader = ({ blocks, className }: Props) => {
 
   const { mediaType, playerConfig } = config;
 
-  const captionBlock = filterForBlockType(blocks, 'caption');
+  const captionBlock = getCaptionBlock(blocks, pageType);
 
   return (
     <div className={className}>

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -1,6 +1,10 @@
+import { PageTypes } from '#app/models/types/global';
+import { Translations } from '#app/models/types/translations';
+
 export type PlayerConfig = {
   product?: string;
   superResponsive: boolean;
+  enableToucan: boolean;
   counterName?: string;
   playlistObject: {
     title: string;
@@ -49,7 +53,8 @@ export type Props = {
 
 export type BuildConfigProps = {
   id: string | null;
-  pageType: string;
+  pageType: PageTypes;
   blocks: MediaBlock[];
+  translations: Translations;
   counterName: string | null;
 };

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -55,6 +55,6 @@ export type BuildConfigProps = {
   id: string | null;
   pageType: PageTypes;
   blocks: MediaBlock[];
-  translations: Translations;
+  translations?: Translations;
   counterName: string | null;
 };

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -56,7 +56,7 @@ export type AresMediaBlock = {
     title: string;
     blocks: AresMediaBlock[];
     imageUrl: string;
-    format: string;
+    format: 'audio' | 'video';
     versions: {
       versionId: string;
       duration: number;
@@ -74,7 +74,7 @@ export type AresMediaBlock = {
 export type ClipMediaBlock = {
   type: 'clipMedia';
   model: {
-    type: string;
+    type: 'audio' | 'video';
     images: {
       source: string;
       urlTemplate: string;

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -49,7 +49,7 @@ export type CaptionBlock = {
 
 export type AresMediaBlock = {
   type: 'aresMedia';
-  model: Partial<{
+  model: {
     locator: string;
     originCode: string;
     text: string;
@@ -68,12 +68,12 @@ export type AresMediaBlock = {
       warnings?: { [key: string]: string };
     }[];
     smpKind: string;
-  }>;
+  };
 };
 
 export type ClipMediaBlock = {
   type: 'clipMedia';
-  model: Partial<{
+  model: {
     type: string;
     images: {
       source: string;
@@ -88,7 +88,7 @@ export type ClipMediaBlock = {
         guidance: { warnings?: { [key: string]: string } } | null;
       };
     };
-  }>;
+  };
 };
 
 export type MediaBlock = AresMediaBlock | ClipMediaBlock | CaptionBlock;

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -14,8 +14,7 @@ export type PlayerUiConfig = {
   fullscreen: { enabled: boolean };
 };
 
-// Settings that all media players should have
-export type BasePlayerConfig = {
+export type PlayerConfig = {
   autoplay?: boolean;
   preload?: string;
   product?: string;
@@ -23,16 +22,12 @@ export type BasePlayerConfig = {
   enableToucan: boolean;
   counterName?: string;
   appType: 'amp' | 'responsive';
-  appName: string;
+  appName: `news-${Services}` | 'news';
   externalEmbedUrl?: string;
   statsObject?: { clipPID?: string };
   mediator?: { host: string };
   ui: PlayerUiConfig;
-};
-
-// Settings that are specific to the page type
-export type PlayerConfig = BasePlayerConfig & {
-  playlistObject: {
+  playlistObject?: {
     title: string;
     holdingImageURL: string;
     items: Item[];

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -1,6 +1,19 @@
 import { PageTypes, Services } from '#app/models/types/global';
 import { Translations } from '#app/models/types/translations';
 
+export type PlayerUiConfig = {
+  skin?: string;
+  colour?: string;
+  foreColour?: string;
+  baseColour?: string;
+  colourOnBaseColour?: string;
+  fallbackBackgroundColour?: string;
+  controls: { enabled: boolean };
+  locale: { lang: string };
+  subtitles: { enabled: boolean; defaultOn: boolean };
+  fullscreen: { enabled: boolean };
+};
+
 export type BasePlayerConfig = {
   product?: string;
   superResponsive: boolean;
@@ -11,18 +24,7 @@ export type BasePlayerConfig = {
   externalEmbedUrl?: string;
   statsObject?: { clipPID?: string };
   mediator?: { host: string };
-  ui: {
-    skin?: string;
-    colour?: string;
-    foreColour?: string;
-    baseColour?: string;
-    colourOnBaseColour?: string;
-    fallbackBackgroundColour?: string;
-    controls: { enabled: boolean };
-    locale: { lang: string };
-    subtitles: { enabled: boolean; defaultOn: boolean };
-    fullscreen: { enabled: boolean };
-  };
+  ui: PlayerUiConfig;
 };
 
 export type PlayerConfig = BasePlayerConfig & {
@@ -31,6 +33,7 @@ export type PlayerConfig = BasePlayerConfig & {
     holdingImageURL: string;
     items: Item[];
   };
+  ui: PlayerUiConfig;
 };
 
 export type Item = {

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -14,7 +14,10 @@ export type PlayerUiConfig = {
   fullscreen: { enabled: boolean };
 };
 
+// Settings that all media players should have
 export type BasePlayerConfig = {
+  autoplay?: boolean;
+  preload?: string;
   product?: string;
   superResponsive: boolean;
   enableToucan: boolean;
@@ -27,13 +30,13 @@ export type BasePlayerConfig = {
   ui: PlayerUiConfig;
 };
 
+// Settings that are specific to the page type
 export type PlayerConfig = BasePlayerConfig & {
   playlistObject: {
     title: string;
     holdingImageURL: string;
     items: Item[];
   };
-  ui: PlayerUiConfig;
 };
 
 export type Item = {

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -30,15 +30,39 @@ export type BumpType = {
   player: (div: HTMLDivElement | null, config: PlayerConfig) => Player;
 };
 
+export type CaptionBlock = {
+  type: 'caption';
+  model: {
+    blocks: {
+      type: string;
+      model: {
+        blocks: {
+          type: string;
+          model: {
+            text: string;
+          };
+        }[];
+      };
+    }[];
+  };
+};
+
 export type AresMediaBlock = {
-  type: string;
+  type: 'aresMedia';
   model: Partial<{
     locator: string;
+    originCode: string;
     text: string;
     title: string;
     blocks: AresMediaBlock[];
     imageUrl: string;
+    format: string;
     versions: {
+      versionId: string;
+      duration: number;
+      warnings?: { [key: string]: string };
+    }[];
+    webcastVersions: {
       versionId: string;
       duration: number;
       warnings?: { [key: string]: string };
@@ -48,7 +72,7 @@ export type AresMediaBlock = {
 };
 
 export type ClipMediaBlock = {
-  type: string;
+  type: 'clipMedia';
   model: Partial<{
     type: string;
     images: {
@@ -61,28 +85,18 @@ export type ClipMediaBlock = {
         id: string;
         duration: string;
         kind: string;
-        guidance: object | null;
+        guidance: { warnings?: { [key: string]: string } } | null;
       };
     };
   }>;
 };
 
-export type CaptionsBlock = {
-  type: string;
-  model: {
-    blocks: {
-      type: string;
-      model: {
-        text: string;
-      };
-    }[];
-  };
-};
+export type MediaBlock = AresMediaBlock | ClipMediaBlock | CaptionBlock;
 
 export type BuildConfigProps = {
   id: string | null;
   pageType: PageTypes;
-  blocks: ClipMediaBlock[] | AresMediaBlock[];
+  blocks: MediaBlock[];
   translations?: Translations;
   counterName: string | null;
 };

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -30,13 +30,13 @@ export type BumpType = {
   player: (div: HTMLDivElement | null, config: PlayerConfig) => Player;
 };
 
-export type MediaBlock = {
+export type AresMediaBlock = {
   type: string;
   model: Partial<{
     locator: string;
     text: string;
     title: string;
-    blocks: MediaBlock[];
+    blocks: AresMediaBlock[];
     imageUrl: string;
     versions: {
       versionId: string;
@@ -47,15 +47,42 @@ export type MediaBlock = {
   }>;
 };
 
-export type Props = {
-  className: string;
-  blocks: MediaBlock[];
+export type ClipMediaBlock = {
+  type: string;
+  model: Partial<{
+    type: string;
+    images: {
+      source: string;
+      urlTemplate: string;
+    }[];
+    video: {
+      title: string;
+      version: {
+        id: string;
+        duration: string;
+        kind: string;
+        guidance: object | null;
+      };
+    };
+  }>;
+};
+
+export type CaptionsBlock = {
+  type: string;
+  model: {
+    blocks: {
+      type: string;
+      model: {
+        text: string;
+      };
+    }[];
+  };
 };
 
 export type BuildConfigProps = {
   id: string | null;
   pageType: PageTypes;
-  blocks: MediaBlock[];
+  blocks: ClipMediaBlock[] | AresMediaBlock[];
   translations?: Translations;
   counterName: string | null;
 };

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -1,4 +1,4 @@
-import { PageTypes } from '#app/models/types/global';
+import { PageTypes, Services } from '#app/models/types/global';
 import { Translations } from '#app/models/types/translations';
 
 export type PlayerConfig = {
@@ -6,6 +6,7 @@ export type PlayerConfig = {
   superResponsive: boolean;
   enableToucan: boolean;
   counterName?: string;
+  appType: string;
   playlistObject: {
     title: string;
     holdingImageURL: string;
@@ -99,4 +100,7 @@ export type BuildConfigProps = {
   blocks: MediaBlock[];
   translations?: Translations;
   counterName: string | null;
+  isAmp: boolean;
+  service: Services;
+  lang: string;
 };

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -42,6 +42,17 @@ export type Item = {
   live?: boolean;
 };
 
+export type ConfigBuilderProps = {
+  blocks: MediaBlock[];
+  basePlayerConfig: PlayerConfig;
+  pageType: PageTypes;
+};
+
+export type ConfigBuilderReturnProps = {
+  mediaType: string;
+  playerConfig: PlayerConfig;
+} | null;
+
 export type Player = {
   load: () => void;
 };

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -29,6 +29,7 @@ export type PlayerConfig = {
   ui: PlayerUiConfig;
   playlistObject?: {
     title: string;
+    summary?: string;
     holdingImageURL: string;
     items: Item[];
   };

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -1,19 +1,36 @@
 import { PageTypes, Services } from '#app/models/types/global';
 import { Translations } from '#app/models/types/translations';
 
-export type PlayerConfig = {
+export type BasePlayerConfig = {
   product?: string;
   superResponsive: boolean;
   enableToucan: boolean;
   counterName?: string;
-  appType: string;
+  appType: 'amp' | 'responsive';
+  appName: string;
+  externalEmbedUrl?: string;
+  statsObject?: { clipPID?: string };
+  mediator?: { host: string };
+  ui: {
+    skin?: string;
+    colour?: string;
+    foreColour?: string;
+    baseColour?: string;
+    colourOnBaseColour?: string;
+    fallbackBackgroundColour?: string;
+    controls: { enabled: boolean };
+    locale: { lang: string };
+    subtitles: { enabled: boolean; defaultOn: boolean };
+    fullscreen: { enabled: boolean };
+  };
+};
+
+export type PlayerConfig = BasePlayerConfig & {
   playlistObject: {
     title: string;
     holdingImageURL: string;
     items: Item[];
   };
-  statsObject?: { clipPID?: string };
-  mediator?: { host: string };
 };
 
 export type Item = {

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -12,6 +12,7 @@ export type PlayerConfig = {
     items: Item[];
   };
   statsObject?: { clipPID?: string };
+  mediator?: { host: string };
 };
 
 export type Item = {

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -1,19 +1,6 @@
 import { PageTypes, Services } from '#app/models/types/global';
 import { Translations } from '#app/models/types/translations';
 
-export type PlayerUiConfig = {
-  skin?: string;
-  colour?: string;
-  foreColour?: string;
-  baseColour?: string;
-  colourOnBaseColour?: string;
-  fallbackBackgroundColour?: string;
-  controls: { enabled: boolean };
-  locale: { lang: string };
-  subtitles: { enabled: boolean; defaultOn: boolean };
-  fullscreen: { enabled: boolean };
-};
-
 export type PlayerConfig = {
   autoplay?: boolean;
   preload?: string;
@@ -31,11 +18,25 @@ export type PlayerConfig = {
     title: string;
     summary?: string;
     holdingImageURL: string;
-    items: Item[];
+    items: PlaylistItem[];
+    guidance?: string;
   };
 };
 
-export type Item = {
+export type PlayerUiConfig = {
+  skin?: string;
+  colour?: string;
+  foreColour?: string;
+  baseColour?: string;
+  colourOnBaseColour?: string;
+  fallbackBackgroundColour?: string;
+  controls: { enabled: boolean };
+  locale: { lang: string };
+  subtitles: { enabled: boolean; defaultOn: boolean };
+  fullscreen: { enabled: boolean };
+};
+
+export type PlaylistItem = {
   versionID: string;
   kind: string;
   duration: number;

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -1,5 +1,4 @@
 import { PageTypes, Services } from '#app/models/types/global';
-import { Translations } from '#app/models/types/translations';
 
 export type PlayerConfig = {
   autoplay?: boolean;
@@ -126,12 +125,11 @@ export type ClipMediaBlock = {
 export type MediaBlock = AresMediaBlock | ClipMediaBlock | CaptionBlock;
 
 export type BuildConfigProps = {
-  id: string | null;
-  pageType: PageTypes;
   blocks: MediaBlock[];
-  translations?: Translations;
   counterName: string | null;
+  id: string | null;
   isAmp: boolean;
-  service: Services;
   lang: string;
+  pageType: PageTypes;
+  service: Services;
 };

--- a/src/app/components/MediaLoader/utils/buildSetting.test.ts
+++ b/src/app/components/MediaLoader/utils/buildSetting.test.ts
@@ -1,6 +1,16 @@
+import { PageTypes, Services } from '#app/models/types/global';
 import buildSettings from './buildSettings';
 import { aresMediaBlocks, clipMediaBlocks } from '../fixture';
 import { MediaBlock } from '../types';
+
+const baseSettings = {
+  id: 'testID',
+  pageType: 'article' as PageTypes,
+  counterName: null,
+  isAmp: false,
+  lang: 'es',
+  service: 'mundo' as Services,
+};
 
 describe('buildSettings', () => {
   beforeEach(() => {
@@ -17,22 +27,30 @@ describe('buildSettings', () => {
     jest.spyOn(window, 'window', 'get').mockImplementation(() => mockWindowObj);
 
     const result = buildSettings({
-      id: 'testID',
+      ...baseSettings,
       blocks: clipMediaBlocks as MediaBlock[],
       pageType: 'live',
-      counterName: null,
     });
 
     expect(result?.playerConfig).toStrictEqual({
       product: 'news',
       superResponsive: true,
       enableToucan: true,
+      appName: 'news-mundo',
+      appType: 'responsive',
+      externalEmbedUrl: '',
       playlistObject: {
         title:
           "BBC launch trailer for We Know Our Place women's sport campaign",
         holdingImageURL:
           'https://ichef.test.bbci.co.uk/images/ic/512xn/p01thw3g.jpg',
         items: [{ duration: 54, kind: 'programme', versionID: 'p01thw22' }],
+      },
+      ui: {
+        controls: { enabled: true },
+        locale: { lang: 'es' },
+        subtitles: { enabled: true, defaultOn: true },
+        fullscreen: { enabled: true },
       },
     });
   });
@@ -47,22 +65,29 @@ describe('buildSettings', () => {
     jest.spyOn(window, 'window', 'get').mockImplementation(() => mockWindowObj);
 
     const result = buildSettings({
-      id: 'testID',
+      ...baseSettings,
       blocks: aresMediaBlocks as MediaBlock[],
-      pageType: 'article',
-      counterName: null,
     });
 
     expect(result?.playerConfig).toStrictEqual({
       product: 'news',
       superResponsive: true,
       enableToucan: true,
+      appName: 'news-mundo',
+      appType: 'responsive',
+      externalEmbedUrl: '',
       playlistObject: {
         title: 'Five things ants can teach us about management',
         holdingImageURL:
           'https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg',
         items: [{ duration: 191, kind: 'programme', versionID: 'p01k6msp' }],
         guidance: 'Contains strong language and adult humour.',
+      },
+      ui: {
+        controls: { enabled: true },
+        locale: { lang: 'es' },
+        subtitles: { enabled: true, defaultOn: true },
+        fullscreen: { enabled: true },
       },
     });
   });
@@ -78,11 +103,10 @@ describe('buildSettings', () => {
     jest.spyOn(window, 'window', 'get').mockImplementation(() => mockWindowObj);
 
     const result = buildSettings({
-      id: 'testID',
+      ...baseSettings,
       blocks: aresMediaBlocks as MediaBlock[],
-      pageType: 'article',
-      counterName: null,
     });
+
     expect(result?.playerConfig).toHaveProperty('mediator', {
       host: 'open.test.bbc.co.uk',
     });
@@ -101,11 +125,10 @@ describe('buildSettings', () => {
     jest.spyOn(window, 'window', 'get').mockImplementation(() => mockWindowObj);
 
     const result = buildSettings({
-      id: 'testID',
+      ...baseSettings,
       blocks: aresMediaBlocks as MediaBlock[],
-      pageType: 'article',
-      counterName: null,
     });
+
     expect(result?.playerConfig).toHaveProperty('mediator', {
       host: 'open.test.bbc.co.uk',
     });
@@ -122,11 +145,10 @@ describe('buildSettings', () => {
     jest.spyOn(window, 'window', 'get').mockImplementation(() => mockWindowObj);
 
     const result = buildSettings({
-      id: 'testID',
+      ...baseSettings,
       blocks: aresMediaBlocks as MediaBlock[],
-      pageType: 'article',
-      counterName: null,
     });
+
     expect(result?.playerConfig.mediator).toBe(undefined);
   });
 
@@ -140,11 +162,10 @@ describe('buildSettings', () => {
     jest.spyOn(window, 'window', 'get').mockImplementation(() => mockWindowObj);
 
     const result = buildSettings({
-      id: 'testID',
+      ...baseSettings,
       blocks: aresMediaBlocks as MediaBlock[],
-      pageType: 'article',
-      counterName: null,
     });
+
     expect(result?.playerConfig.mediator).toBe(undefined);
   });
 
@@ -155,22 +176,20 @@ describe('buildSettings', () => {
       },
     ];
     const result = buildSettings({
-      id: 'testID',
+      ...baseSettings,
       // @ts-expect-error - we are testing an invalid block
       blocks: sampleBlock,
-      pageType: 'article',
-      counterName: null,
     });
+
     expect(result).toBe(null);
   });
 
   it('Should return super responsive as true, to make the video expand to its parent container.', () => {
     const result = buildSettings({
-      id: 'testID',
+      ...baseSettings,
       blocks: aresMediaBlocks as MediaBlock[],
-      pageType: 'article',
-      counterName: null,
     });
+
     expect(result?.playerConfig.superResponsive).toStrictEqual(true);
   });
 });

--- a/src/app/components/MediaLoader/utils/buildSetting.test.ts
+++ b/src/app/components/MediaLoader/utils/buildSetting.test.ts
@@ -1,6 +1,5 @@
 import buildSettings from './buildSettings';
 import { aresMediaBlocks, clipMediaBlocks } from '../fixture';
-import { AresMediaBlock, ClipMediaBlock } from '../types';
 
 describe('buildSettings', () => {
   beforeEach(() => {
@@ -18,7 +17,7 @@ describe('buildSettings', () => {
 
     const result = buildSettings({
       id: 'testID',
-      blocks: clipMediaBlocks as ClipMediaBlock[],
+      blocks: clipMediaBlocks,
       pageType: 'live',
       counterName: null,
     });
@@ -152,10 +151,11 @@ describe('buildSettings', () => {
     const sampleBlock = [
       {
         model: { blocks: [{ model: { versions: [] } }] },
-      } as unknown as AresMediaBlock,
+      },
     ];
     const result = buildSettings({
       id: 'testID',
+      // @ts-expect-error - we are testing an invalid block
       blocks: sampleBlock,
       pageType: 'article',
       counterName: null,

--- a/src/app/components/MediaLoader/utils/buildSetting.test.ts
+++ b/src/app/components/MediaLoader/utils/buildSetting.test.ts
@@ -33,7 +33,7 @@ describe('buildSettings', () => {
     });
 
     expect(result?.playerConfig).toStrictEqual({
-      autoplay: true,
+      autoplay: false,
       product: 'news',
       superResponsive: true,
       enableToucan: true,
@@ -71,7 +71,7 @@ describe('buildSettings', () => {
     });
 
     expect(result?.playerConfig).toStrictEqual({
-      autoplay: true,
+      autoplay: false,
       product: 'news',
       superResponsive: true,
       enableToucan: true,

--- a/src/app/components/MediaLoader/utils/buildSetting.test.ts
+++ b/src/app/components/MediaLoader/utils/buildSetting.test.ts
@@ -43,6 +43,8 @@ describe('buildSettings', () => {
       playlistObject: {
         title:
           "BBC launch trailer for We Know Our Place women's sport campaign",
+        summary:
+          'BBC launch trailer for We Know Our Place women\'s sport campaign"',
         holdingImageURL:
           'https://ichef.test.bbci.co.uk/images/ic/512xn/p01thw3g.jpg',
         items: [{ duration: 54, kind: 'programme', versionID: 'p01thw22' }],
@@ -80,6 +82,7 @@ describe('buildSettings', () => {
       externalEmbedUrl: '',
       playlistObject: {
         title: 'Five things ants can teach us about management',
+        summary: 'This is a caption!',
         holdingImageURL:
           'https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg',
         items: [{ duration: 191, kind: 'programme', versionID: 'p01k6msp' }],
@@ -120,6 +123,7 @@ describe('buildSettings', () => {
       externalEmbedUrl: '',
       playlistObject: {
         title: 'Five things ants can teach us about management',
+        summary: 'This is a caption!',
         holdingImageURL:
           'https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg',
         items: [{ duration: 191, kind: 'programme', versionID: 'p01k6msp' }],

--- a/src/app/components/MediaLoader/utils/buildSetting.test.ts
+++ b/src/app/components/MediaLoader/utils/buildSetting.test.ts
@@ -17,7 +17,7 @@ describe('buildSettings', () => {
     jest.restoreAllMocks();
   });
 
-  it('Should process a ClipMedia block into a valid playlist item.', () => {
+  it('Should process a ClipMedia block into a valid playlist item for a "Live" page.', () => {
     const mockWindowObj = {
       location: {
         hostname: 'https://www.bbc.com/',
@@ -56,7 +56,7 @@ describe('buildSettings', () => {
     });
   });
 
-  it('Should process an AresMedia block into a valid playlist item.', () => {
+  it('Should process an AresMedia block into a valid playlist item for an "article" page.', () => {
     const mockWindowObj = {
       location: {
         hostname: 'https://www.bbc.com/',
@@ -72,6 +72,46 @@ describe('buildSettings', () => {
 
     expect(result?.playerConfig).toStrictEqual({
       autoplay: true,
+      product: 'news',
+      superResponsive: true,
+      enableToucan: true,
+      appName: 'news-mundo',
+      appType: 'responsive',
+      externalEmbedUrl: '',
+      playlistObject: {
+        title: 'Five things ants can teach us about management',
+        holdingImageURL:
+          'https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg',
+        items: [{ duration: 191, kind: 'programme', versionID: 'p01k6msp' }],
+        guidance: 'Contains strong language and adult humour.',
+      },
+      ui: {
+        controls: { enabled: true },
+        locale: { lang: 'es' },
+        subtitles: { enabled: true, defaultOn: true },
+        fullscreen: { enabled: true },
+      },
+    });
+  });
+
+  it('Should process an AresMedia block into a valid playlist item for a "mediaArticle" page.', () => {
+    const mockWindowObj = {
+      location: {
+        hostname: 'https://www.bbc.com/',
+      },
+    } as Window & typeof globalThis;
+
+    jest.spyOn(window, 'window', 'get').mockImplementation(() => mockWindowObj);
+
+    const result = buildSettings({
+      ...baseSettings,
+      blocks: aresMediaBlocks as MediaBlock[],
+      pageType: 'mediaArticle',
+    });
+
+    expect(result?.playerConfig).toStrictEqual({
+      autoplay: false,
+      preload: 'high',
       product: 'news',
       superResponsive: true,
       enableToucan: true,

--- a/src/app/components/MediaLoader/utils/buildSetting.test.ts
+++ b/src/app/components/MediaLoader/utils/buildSetting.test.ts
@@ -33,6 +33,7 @@ describe('buildSettings', () => {
     });
 
     expect(result?.playerConfig).toStrictEqual({
+      autoplay: true,
       product: 'news',
       superResponsive: true,
       enableToucan: true,
@@ -70,6 +71,7 @@ describe('buildSettings', () => {
     });
 
     expect(result?.playerConfig).toStrictEqual({
+      autoplay: true,
       product: 'news',
       superResponsive: true,
       enableToucan: true,

--- a/src/app/components/MediaLoader/utils/buildSetting.test.ts
+++ b/src/app/components/MediaLoader/utils/buildSetting.test.ts
@@ -33,7 +33,7 @@ describe('buildSettings', () => {
     });
 
     expect(result?.playerConfig).toStrictEqual({
-      autoplay: false,
+      autoplay: true,
       product: 'news',
       superResponsive: true,
       enableToucan: true,
@@ -71,7 +71,7 @@ describe('buildSettings', () => {
     });
 
     expect(result?.playerConfig).toStrictEqual({
-      autoplay: false,
+      autoplay: true,
       product: 'news',
       superResponsive: true,
       enableToucan: true,

--- a/src/app/components/MediaLoader/utils/buildSetting.test.ts
+++ b/src/app/components/MediaLoader/utils/buildSetting.test.ts
@@ -1,5 +1,5 @@
 import { MediaBlock } from '../types';
-import buildConfig from './buildSettings';
+import buildSettings from './buildSettings';
 import blocks from '../fixture';
 
 describe('buildSettings', () => {
@@ -16,15 +16,17 @@ describe('buildSettings', () => {
 
     jest.spyOn(window, 'window', 'get').mockImplementation(() => mockWindowObj);
 
-    const result = buildConfig({
+    const result = buildSettings({
       id: 'testID',
       blocks,
       pageType: 'article',
       counterName: null,
     });
+
     expect(result?.playerConfig).toStrictEqual({
       product: 'news',
       superResponsive: true,
+      enableToucan: true,
       playlistObject: {
         title: 'Five things ants can teach us about management',
         holdingImageURL:
@@ -45,7 +47,7 @@ describe('buildSettings', () => {
 
     jest.spyOn(window, 'window', 'get').mockImplementation(() => mockWindowObj);
 
-    const result = buildConfig({
+    const result = buildSettings({
       id: 'testID',
       blocks,
       pageType: 'article',
@@ -68,7 +70,7 @@ describe('buildSettings', () => {
 
     jest.spyOn(window, 'window', 'get').mockImplementation(() => mockWindowObj);
 
-    const result = buildConfig({
+    const result = buildSettings({
       id: 'testID',
       blocks,
       pageType: 'article',
@@ -89,7 +91,7 @@ describe('buildSettings', () => {
 
     jest.spyOn(window, 'window', 'get').mockImplementation(() => mockWindowObj);
 
-    const result = buildConfig({
+    const result = buildSettings({
       id: 'testID',
       blocks,
       pageType: 'article',
@@ -107,7 +109,7 @@ describe('buildSettings', () => {
 
     jest.spyOn(window, 'window', 'get').mockImplementation(() => mockWindowObj);
 
-    const result = buildConfig({
+    const result = buildSettings({
       id: 'testID',
       blocks,
       pageType: 'article',
@@ -122,7 +124,7 @@ describe('buildSettings', () => {
         model: { blocks: [{ model: { versions: [] } }] },
       } as unknown as MediaBlock,
     ];
-    const result = buildConfig({
+    const result = buildSettings({
       id: 'testID',
       blocks: sampleBlock,
       pageType: 'article',
@@ -132,7 +134,7 @@ describe('buildSettings', () => {
   });
 
   it('Should return super responsive as true, to make the video expand to its parent container.', () => {
-    const result = buildConfig({
+    const result = buildSettings({
       id: 'testID',
       blocks,
       pageType: 'article',

--- a/src/app/components/MediaLoader/utils/buildSetting.test.ts
+++ b/src/app/components/MediaLoader/utils/buildSetting.test.ts
@@ -1,5 +1,6 @@
 import buildSettings from './buildSettings';
 import { aresMediaBlocks, clipMediaBlocks } from '../fixture';
+import { MediaBlock } from '../types';
 
 describe('buildSettings', () => {
   beforeEach(() => {
@@ -17,7 +18,7 @@ describe('buildSettings', () => {
 
     const result = buildSettings({
       id: 'testID',
-      blocks: clipMediaBlocks,
+      blocks: clipMediaBlocks as MediaBlock[],
       pageType: 'live',
       counterName: null,
     });
@@ -47,7 +48,7 @@ describe('buildSettings', () => {
 
     const result = buildSettings({
       id: 'testID',
-      blocks: aresMediaBlocks,
+      blocks: aresMediaBlocks as MediaBlock[],
       pageType: 'article',
       counterName: null,
     });
@@ -78,7 +79,7 @@ describe('buildSettings', () => {
 
     const result = buildSettings({
       id: 'testID',
-      blocks: aresMediaBlocks,
+      blocks: aresMediaBlocks as MediaBlock[],
       pageType: 'article',
       counterName: null,
     });
@@ -101,7 +102,7 @@ describe('buildSettings', () => {
 
     const result = buildSettings({
       id: 'testID',
-      blocks: aresMediaBlocks,
+      blocks: aresMediaBlocks as MediaBlock[],
       pageType: 'article',
       counterName: null,
     });
@@ -122,7 +123,7 @@ describe('buildSettings', () => {
 
     const result = buildSettings({
       id: 'testID',
-      blocks: aresMediaBlocks,
+      blocks: aresMediaBlocks as MediaBlock[],
       pageType: 'article',
       counterName: null,
     });
@@ -140,7 +141,7 @@ describe('buildSettings', () => {
 
     const result = buildSettings({
       id: 'testID',
-      blocks: aresMediaBlocks,
+      blocks: aresMediaBlocks as MediaBlock[],
       pageType: 'article',
       counterName: null,
     });
@@ -166,7 +167,7 @@ describe('buildSettings', () => {
   it('Should return super responsive as true, to make the video expand to its parent container.', () => {
     const result = buildSettings({
       id: 'testID',
-      blocks: aresMediaBlocks,
+      blocks: aresMediaBlocks as MediaBlock[],
       pageType: 'article',
       counterName: null,
     });

--- a/src/app/components/MediaLoader/utils/buildSetting.test.ts
+++ b/src/app/components/MediaLoader/utils/buildSetting.test.ts
@@ -1,10 +1,40 @@
-import { MediaBlock } from '../types';
 import buildSettings from './buildSettings';
-import blocks from '../fixture';
+import { aresMediaBlocks, clipMediaBlocks } from '../fixture';
+import { AresMediaBlock, ClipMediaBlock } from '../types';
 
 describe('buildSettings', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
+  });
+
+  it('Should process a ClipMedia block into a valid playlist item.', () => {
+    const mockWindowObj = {
+      location: {
+        hostname: 'https://www.bbc.com/',
+      },
+    } as Window & typeof globalThis;
+
+    jest.spyOn(window, 'window', 'get').mockImplementation(() => mockWindowObj);
+
+    const result = buildSettings({
+      id: 'testID',
+      blocks: clipMediaBlocks as ClipMediaBlock[],
+      pageType: 'live',
+      counterName: null,
+    });
+
+    expect(result?.playerConfig).toStrictEqual({
+      product: 'news',
+      superResponsive: true,
+      enableToucan: true,
+      playlistObject: {
+        title:
+          "BBC launch trailer for We Know Our Place women's sport campaign",
+        holdingImageURL:
+          'https://ichef.test.bbci.co.uk/images/ic/512xn/p01thw3g.jpg',
+        items: [{ duration: 54, kind: 'programme', versionID: 'p01thw22' }],
+      },
+    });
   });
 
   it('Should process an AresMedia block into a valid playlist item.', () => {
@@ -18,7 +48,7 @@ describe('buildSettings', () => {
 
     const result = buildSettings({
       id: 'testID',
-      blocks,
+      blocks: aresMediaBlocks,
       pageType: 'article',
       counterName: null,
     });
@@ -49,7 +79,7 @@ describe('buildSettings', () => {
 
     const result = buildSettings({
       id: 'testID',
-      blocks,
+      blocks: aresMediaBlocks,
       pageType: 'article',
       counterName: null,
     });
@@ -72,7 +102,7 @@ describe('buildSettings', () => {
 
     const result = buildSettings({
       id: 'testID',
-      blocks,
+      blocks: aresMediaBlocks,
       pageType: 'article',
       counterName: null,
     });
@@ -93,7 +123,7 @@ describe('buildSettings', () => {
 
     const result = buildSettings({
       id: 'testID',
-      blocks,
+      blocks: aresMediaBlocks,
       pageType: 'article',
       counterName: null,
     });
@@ -111,7 +141,7 @@ describe('buildSettings', () => {
 
     const result = buildSettings({
       id: 'testID',
-      blocks,
+      blocks: aresMediaBlocks,
       pageType: 'article',
       counterName: null,
     });
@@ -122,7 +152,7 @@ describe('buildSettings', () => {
     const sampleBlock = [
       {
         model: { blocks: [{ model: { versions: [] } }] },
-      } as unknown as MediaBlock,
+      } as unknown as AresMediaBlock,
     ];
     const result = buildSettings({
       id: 'testID',
@@ -136,7 +166,7 @@ describe('buildSettings', () => {
   it('Should return super responsive as true, to make the video expand to its parent container.', () => {
     const result = buildSettings({
       id: 'testID',
-      blocks,
+      blocks: aresMediaBlocks,
       pageType: 'article',
       counterName: null,
     });

--- a/src/app/components/MediaLoader/utils/buildSettings.ts
+++ b/src/app/components/MediaLoader/utils/buildSettings.ts
@@ -32,11 +32,9 @@ const buildSettings = ({
     ...(isTestRequested() && { mediator: { host: 'open.test.bbc.co.uk' } }),
   };
 
-  const config = configForPageType(pageType)({ blocks });
+  const config = configForPageType(pageType)?.({ blocks });
 
-  if (config === null) {
-    return null;
-  }
+  if (!config) return null;
 
   const { mediaType, pagePlayerSettings } = config;
 

--- a/src/app/components/MediaLoader/utils/buildSettings.ts
+++ b/src/app/components/MediaLoader/utils/buildSettings.ts
@@ -1,5 +1,5 @@
 import onClient from '#app/lib/utilities/onClient';
-import { BuildConfigProps, PlayerConfig } from '../types';
+import { BasePlayerConfig, BuildConfigProps } from '../types';
 import configForPageType from '../configs';
 
 const isTestRequested = () => {
@@ -27,7 +27,8 @@ const buildSettings = ({
 }: BuildConfigProps) => {
   if (id === null) return null;
 
-  const basePlayerSettings = {
+  // Base configuration that all media players should have
+  const basePlayerConfig: BasePlayerConfig = {
     product: 'news',
     superResponsive: true,
     enableToucan: true,
@@ -44,20 +45,12 @@ const buildSettings = ({
     ...(isTestRequested() && { mediator: { host: 'open.test.bbc.co.uk' } }),
   };
 
-  const config = configForPageType(pageType)?.({ blocks });
+  // Additional configuration that is specific to the page type
+  const config = configForPageType(pageType)?.({ blocks, basePlayerConfig });
 
   if (!config) return null;
 
-  const { mediaType, pagePlayerSettings } = config;
-
-  const playerConfig: PlayerConfig = {
-    // Base configuration that all media players should have
-    ...basePlayerSettings,
-    // Additional configuration that is specific to the page type
-    ...pagePlayerSettings,
-  };
-
-  return { mediaType, playerConfig };
+  return config;
 };
 
 export default buildSettings;

--- a/src/app/components/MediaLoader/utils/buildSettings.ts
+++ b/src/app/components/MediaLoader/utils/buildSettings.ts
@@ -1,6 +1,6 @@
 import onClient from '#app/lib/utilities/onClient';
 import { BuildConfigProps, PlayerConfig } from '../types';
-import selectConfig from '../configs';
+import configForPageType from '../configs';
 
 const isTestRequested = () => {
   if (onClient()) {
@@ -25,7 +25,7 @@ const buildConfig = ({
 }: BuildConfigProps) => {
   if (id === null) return null;
 
-  const basePlayerConfig = {
+  const basePlayerSettings = {
     product: 'news',
     superResponsive: true,
     enableToucan: true,
@@ -33,41 +33,22 @@ const buildConfig = ({
     ...(isTestRequested() && { mediator: { host: 'open.test.bbc.co.uk' } }),
   };
 
-  const configBuilder = selectConfig(pageType);
-
-  const pageConfig = configBuilder({
+  const config = configForPageType(pageType)({
     blocks,
     translations,
   });
 
-  if (pageConfig === null) {
+  if (config === null) {
     return null;
   }
 
-  const {
-    clipId,
-    guidanceMessage,
-    kind,
-    mediaType,
-    placeholderSrc,
-    rawDuration,
-    title,
-  } = pageConfig;
+  const { mediaType, pagePlayerSettings } = config;
 
   const playerConfig: PlayerConfig = {
-    ...basePlayerConfig,
-    playlistObject: {
-      title,
-      holdingImageURL: placeholderSrc,
-      items: [
-        {
-          versionID: clipId,
-          kind,
-          duration: rawDuration,
-        },
-      ],
-      ...(guidanceMessage && { guidance: guidanceMessage }),
-    },
+    // Base configuration that all media players should have
+    ...basePlayerSettings,
+    // Additional configuration that is specific to the page type
+    ...pagePlayerSettings,
   };
 
   return { mediaType, playerConfig };

--- a/src/app/components/MediaLoader/utils/buildSettings.ts
+++ b/src/app/components/MediaLoader/utils/buildSettings.ts
@@ -21,7 +21,6 @@ const buildConfig = ({
   blocks,
   pageType,
   counterName,
-  translations,
 }: BuildConfigProps) => {
   if (id === null) return null;
 
@@ -33,10 +32,7 @@ const buildConfig = ({
     ...(isTestRequested() && { mediator: { host: 'open.test.bbc.co.uk' } }),
   };
 
-  const config = configForPageType(pageType)({
-    blocks,
-    translations,
-  });
+  const config = configForPageType(pageType)({ blocks });
 
   if (config === null) {
     return null;

--- a/src/app/components/MediaLoader/utils/buildSettings.ts
+++ b/src/app/components/MediaLoader/utils/buildSettings.ts
@@ -29,6 +29,7 @@ const buildSettings = ({
 
   // Base configuration that all media players should have
   const basePlayerConfig: BasePlayerConfig = {
+    autoplay: true,
     product: 'news',
     superResponsive: true,
     enableToucan: true,
@@ -46,7 +47,11 @@ const buildSettings = ({
   };
 
   // Additional configuration that is specific to the page type
-  const config = configForPageType(pageType)?.({ blocks, basePlayerConfig });
+  const config = configForPageType(pageType)?.({
+    pageType,
+    blocks,
+    basePlayerConfig,
+  });
 
   if (!config) return null;
 

--- a/src/app/components/MediaLoader/utils/buildSettings.ts
+++ b/src/app/components/MediaLoader/utils/buildSettings.ts
@@ -21,6 +21,9 @@ const buildSettings = ({
   blocks,
   pageType,
   counterName,
+  isAmp,
+  service,
+  lang,
 }: BuildConfigProps) => {
   if (id === null) return null;
 
@@ -28,6 +31,15 @@ const buildSettings = ({
     product: 'news',
     superResponsive: true,
     enableToucan: true,
+    appType: isAmp ? 'amp' : 'responsive',
+    appName: service !== 'news' ? `news-${service}` : 'news',
+    externalEmbedUrl: '', // TODO: Check requirements on this, will need added in future when media player has dedicated page for AMP support
+    ui: {
+      controls: { enabled: true },
+      locale: { lang: lang || 'en' },
+      subtitles: { enabled: true, defaultOn: true },
+      fullscreen: { enabled: true },
+    },
     ...(counterName && { counterName }),
     ...(isTestRequested() && { mediator: { host: 'open.test.bbc.co.uk' } }),
   };

--- a/src/app/components/MediaLoader/utils/buildSettings.ts
+++ b/src/app/components/MediaLoader/utils/buildSettings.ts
@@ -29,7 +29,7 @@ const buildSettings = ({
 
   // Base configuration that all media players should have
   const basePlayerConfig: PlayerConfig = {
-    autoplay: true,
+    autoplay: false,
     product: 'news',
     superResponsive: true,
     enableToucan: true,

--- a/src/app/components/MediaLoader/utils/buildSettings.ts
+++ b/src/app/components/MediaLoader/utils/buildSettings.ts
@@ -29,7 +29,7 @@ const buildSettings = ({
 
   // Base configuration that all media players should have
   const basePlayerConfig: PlayerConfig = {
-    autoplay: false,
+    autoplay: true,
     product: 'news',
     superResponsive: true,
     enableToucan: true,

--- a/src/app/components/MediaLoader/utils/buildSettings.ts
+++ b/src/app/components/MediaLoader/utils/buildSettings.ts
@@ -16,7 +16,7 @@ const isTestRequested = () => {
   return false;
 };
 
-const buildConfig = ({
+const buildSettings = ({
   id,
   blocks,
   pageType,
@@ -50,4 +50,4 @@ const buildConfig = ({
   return { mediaType, playerConfig };
 };
 
-export default buildConfig;
+export default buildSettings;

--- a/src/app/components/MediaLoader/utils/buildSettings.ts
+++ b/src/app/components/MediaLoader/utils/buildSettings.ts
@@ -1,5 +1,5 @@
 import onClient from '#app/lib/utilities/onClient';
-import { BasePlayerConfig, BuildConfigProps } from '../types';
+import { BuildConfigProps, PlayerConfig } from '../types';
 import configForPageType from '../configs';
 
 const isTestRequested = () => {
@@ -28,7 +28,7 @@ const buildSettings = ({
   if (id === null) return null;
 
   // Base configuration that all media players should have
-  const basePlayerConfig: BasePlayerConfig = {
+  const basePlayerConfig: PlayerConfig = {
     autoplay: true,
     product: 'news',
     superResponsive: true,
@@ -46,7 +46,7 @@ const buildSettings = ({
     ...(isTestRequested() && { mediator: { host: 'open.test.bbc.co.uk' } }),
   };
 
-  // Additional configuration that is specific to the page type
+  // Augment base configuration with settings that are specific to the page type
   const config = configForPageType(pageType)?.({
     pageType,
     blocks,

--- a/src/app/components/MediaLoader/utils/buildSettings.ts
+++ b/src/app/components/MediaLoader/utils/buildSettings.ts
@@ -17,15 +17,15 @@ const isTestRequested = () => {
 };
 
 const buildSettings = ({
-  id,
   blocks,
-  pageType,
   counterName,
+  id,
   isAmp,
-  service,
   lang,
+  pageType,
+  service,
 }: BuildConfigProps) => {
-  if (id === null) return null;
+  if (!id) return null;
 
   // Base configuration that all media players should have
   const basePlayerConfig: PlayerConfig = {

--- a/src/app/components/MediaLoader/utils/getCaptionBlock.test.ts
+++ b/src/app/components/MediaLoader/utils/getCaptionBlock.test.ts
@@ -1,0 +1,22 @@
+import {
+  aresMediaBlocks,
+  aresMediaCaptionBlock,
+  clipMediaBlocks,
+  livePageCaptionBlock,
+} from '../fixture';
+import { MediaBlock } from '../types';
+import getCaptionBlock from './getCaptionBlock';
+
+describe('getCaptionBlock', () => {
+  it('Should return a valid caption block for an AresMedia block for an article page.', () => {
+    const result = getCaptionBlock(aresMediaBlocks as MediaBlock[], 'article');
+
+    expect(result).toStrictEqual(aresMediaCaptionBlock);
+  });
+
+  it('Should return a valid caption block for a ClipMedia block for a live page.', () => {
+    const result = getCaptionBlock(clipMediaBlocks as MediaBlock[], 'live');
+
+    expect(result).toStrictEqual(livePageCaptionBlock);
+  });
+});

--- a/src/app/components/MediaLoader/utils/getCaptionBlock.ts
+++ b/src/app/components/MediaLoader/utils/getCaptionBlock.ts
@@ -5,7 +5,7 @@ import { CaptionBlock, MediaBlock } from '../types';
 export default function getCaptionBlock(
   blocks: MediaBlock[],
   pageType: PageTypes,
-): CaptionBlock {
+): CaptionBlock | null {
   if (pageType === 'live') {
     return filterForBlockType(blocks, 'caption');
   }

--- a/src/app/components/MediaLoader/utils/getCaptionBlock.ts
+++ b/src/app/components/MediaLoader/utils/getCaptionBlock.ts
@@ -1,11 +1,11 @@
 import filterForBlockType from '#app/lib/utilities/blockHandlers';
 import { PageTypes } from '#app/models/types/global';
-import { MediaBlock } from '../types';
+import { CaptionBlock, MediaBlock } from '../types';
 
 export default function getCaptionBlock(
   blocks: MediaBlock[],
   pageType: PageTypes,
-) {
+): CaptionBlock {
   if (pageType === 'live') {
     return filterForBlockType(blocks, 'caption');
   }

--- a/src/app/components/MediaLoader/utils/getCaptionBlock.ts
+++ b/src/app/components/MediaLoader/utils/getCaptionBlock.ts
@@ -1,0 +1,22 @@
+import filterForBlockType from '#app/lib/utilities/blockHandlers';
+import { PageTypes } from '#app/models/types/global';
+import { MediaBlock } from '../types';
+
+export default function getCaptionBlock(
+  blocks: MediaBlock[],
+  pageType: PageTypes,
+) {
+  if (pageType === 'live') {
+    return filterForBlockType(blocks, 'caption');
+  }
+
+  const aresMediaBlock = filterForBlockType(blocks, 'aresMedia');
+
+  const articleCaptionBlock = filterForBlockType(blocks, 'caption');
+  const cpsCaptionBlock = filterForBlockType(
+    aresMediaBlock?.model?.blocks,
+    'caption',
+  );
+
+  return articleCaptionBlock || cpsCaptionBlock;
+}

--- a/ws-nextjs-app/pages/[service]/live/[id]/Post/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Post/index.tsx
@@ -8,13 +8,16 @@ import Text from '#app/components/Text';
 import Blocks from '#app/legacy/containers/Blocks';
 import Paragraph from '#app/legacy/containers/Paragraph';
 import UnorderedList from '#app/legacy/containers/BulletedList';
-import LegacyMediaPlayer from '#app/components/LegacyLivePageMediaPlayer';
+import MediaLoader from '#app/components/MediaLoader';
 import VisuallyHiddenText from '#app/components/VisuallyHiddenText';
 import ImageWithCaption from '#app/components/ImageWithCaption';
 import { ServiceContext } from '#app/contexts/ServiceContext';
 import isTenHoursAgo from '#app/lib/utilities/isTenHoursAgo';
 import TimeStampContainer from '#app/legacy/psammead/psammead-timestamp-container/src';
 import SocialEmbedContainer from '#app/legacy/containers/SocialEmbed';
+import { MediaBlock } from '#app/components/MediaLoader/types';
+import isLive from '#app/lib/utilities/isLive';
+import LegacyMediaPlayer from '#app/components/LegacyLivePageMediaPlayer';
 import styles from './styles';
 import {
   Post as PostType,
@@ -146,13 +149,12 @@ const PostContent = ({ contentBlocks }: { contentBlocks: OptimoBlock[] }) => {
         position={[9]}
       />
     ),
-    video: (props: ComponentToRenderProps) => (
-      <LegacyMediaPlayer
-        blocks={props.blocks}
-        className="mediaStyles"
-        css={styles.bodyMedia}
-      />
-    ),
+    video: (props: { blocks: MediaBlock[] }) =>
+      isLive() ? (
+        <LegacyMediaPlayer blocks={props.blocks} css={styles.bodyMedia} />
+      ) : (
+        <MediaLoader blocks={props.blocks} css={styles.bodyMedia} />
+      ),
     social: SocialEmbedContainer,
   };
 


### PR DESCRIPTION
Resolves JIRA  https://jira.dev.bbc.co.uk/browse/WSTEAM1-832 and https://jira.dev.bbc.co.uk/browse/WSTEAM1-833

Overall changes
======
- Creates SMP settings builder functions based on the page type requested
- Sets a 'base' configuration which all page types inherit and can then override in their setting builder function
- Note this work is mainly for the Live pages, however there is 'article' and 'mediaArticle' logic here. This is somewhat to test the theory of this config builder approach, as we'll need to do something like this in the near future as we move other page types over to using the new media player

Code changes
======
- Created settings builder functions for live and article page types. These are mostly copies of these functions: https://github.com/bbc/simorgh/blob/ce143285e1c0f2da86f09c7cb26d7427a5058bae/src/app/legacy/containers/MediaPlayer/helpers/propsInference/livePage/index.js with settings stripped back to just what we need for now. These will be extended in separate tickets/PRs as they come about
- Sets a base configuration that is then augmented with settings for the specific page type

Testing
======
1. Visit http://localhost.bbc.com:7081/pidgin/live/c7p765ynk9qt?renderer_env=test
2. Confirm the media player loads when the temporary 'placeholder' button is clicked
3. Ensure the media plays back as expected in the Toucan UI

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
