### PR TITLE
Arabic, Mundo, Hausa and Russian Nav updates

### DIFF
--- a/src/app/lib/config/services/arabic.ts
+++ b/src/app/lib/config/services/arabic.ts
@@ -365,7 +365,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'فيديو',
-        url: '/arabic/media-54706728',
+        url: '/arabic/topics/cz9mm6r1q5et',
       },
       {
         title: 'تحقيقات',

--- a/src/app/lib/config/services/hausa.ts
+++ b/src/app/lib/config/services/hausa.ts
@@ -369,7 +369,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'Shirye-shiryen rediyo',
-        url: '/hausa/media-52219055',
+        url: '/hausa/topics/c4nx34q5724t',
       },
     ],
   },

--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -334,7 +334,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'Hay Festival',
-        url: '/mundo/noticias-36795069',
+        url: '/mundo/topics/cr50y7p7qyqt',
       },
       {
         title: 'Economía',
@@ -358,7 +358,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'Centroamérica Cuenta',
-        url: '/mundo/noticias-43826245',
+        url: '/mundo/topics/c404v5z1k8wt',
       },
     ],
   },

--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -376,19 +376,19 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'Истории',
-        url: '/russian/features-50983593',
+        url: '/russian/topics/cv27xky1pppt',
       },
       {
         title: 'Видео',
-        url: '/russian/in-depth-54439028',
+        url: '/russian/topics/c44vyp57qy4t',
       },
       {
         title: 'Фильмы',
-        url: '/russian/in-depth-48104242',
+        url: '/russian/topics/cl4x0jkk3e5t',
       },
       {
         title: 'Подкасты',
-        url: '/russian/media-47937790',
+        url: '/russian/topics/c3l19z3z0p2t',
       },
     ],
   },

--- a/src/integration/pages/homePage/arabic/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/homePage/arabic/__snapshots__/amp.test.js.snap
@@ -284,7 +284,7 @@ exports[`AMP Home Page Header Navigation link should match text and url 5`] = `
 exports[`AMP Home Page Header Navigation link should match text and url 6`] = `
 {
   "text": "فيديو",
-  "url": "/arabic/media-54706728",
+  "url": "/arabic/topics/cz9mm6r1q5et",
 }
 `;
 

--- a/src/integration/pages/homePage/arabic/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/arabic/__snapshots__/canonical.test.js.snap
@@ -123,7 +123,7 @@ exports[`Canonical Home Page Header Navigation link should match text and url 5`
 exports[`Canonical Home Page Header Navigation link should match text and url 6`] = `
 {
   "text": "فيديو",
-  "url": "/arabic/media-54706728",
+  "url": "/arabic/topics/cz9mm6r1q5et",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/amp.test.js.snap
@@ -245,7 +245,7 @@ exports[`AMP Media Asset Page Header Navigation link should match text and url 5
 exports[`AMP Media Asset Page Header Navigation link should match text and url 6`] = `
 {
   "text": "فيديو",
-  "url": "/arabic/media-54706728",
+  "url": "/arabic/topics/cz9mm6r1q5et",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
@@ -111,7 +111,7 @@ exports[`Canonical Media Asset Page Header Navigation link should match text and
 exports[`Canonical Media Asset Page Header Navigation link should match text and url 6`] = `
 {
   "text": "فيديو",
-  "url": "/arabic/media-54706728",
+  "url": "/arabic/topics/cz9mm6r1q5et",
 }
 `;
 

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
@@ -231,7 +231,7 @@ exports[`AMP Most Read Page Header Navigation link should match text and url 3`]
 exports[`AMP Most Read Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Hay Festival",
-  "url": "/mundo/noticias-36795069",
+  "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
@@ -273,7 +273,7 @@ exports[`AMP Most Read Page Header Navigation link should match text and url 9`]
 exports[`AMP Most Read Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Centroamérica Cuenta",
-  "url": "/mundo/noticias-43826245",
+  "url": "/mundo/topics/c404v5z1k8wt",
 }
 `;
 

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
@@ -90,7 +90,7 @@ exports[`Canonical Most Read Page Header Navigation link should match text and u
 exports[`Canonical Most Read Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Hay Festival",
-  "url": "/mundo/noticias-36795069",
+  "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
@@ -132,7 +132,7 @@ exports[`Canonical Most Read Page Header Navigation link should match text and u
 exports[`Canonical Most Read Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Centroamérica Cuenta",
-  "url": "/mundo/noticias-43826245",
+  "url": "/mundo/topics/c404v5z1k8wt",
 }
 `;
 

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
@@ -231,7 +231,7 @@ exports[`AMP Photo Gallery Page Header Navigation link should match text and url
 exports[`AMP Photo Gallery Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Hay Festival",
-  "url": "/mundo/noticias-36795069",
+  "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
@@ -273,7 +273,7 @@ exports[`AMP Photo Gallery Page Header Navigation link should match text and url
 exports[`AMP Photo Gallery Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Centroamérica Cuenta",
-  "url": "/mundo/noticias-43826245",
+  "url": "/mundo/topics/c404v5z1k8wt",
 }
 `;
 

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
@@ -90,7 +90,7 @@ exports[`Canonical Photo Gallery Page Header Navigation link should match text a
 exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Hay Festival",
-  "url": "/mundo/noticias-36795069",
+  "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
@@ -132,7 +132,7 @@ exports[`Canonical Photo Gallery Page Header Navigation link should match text a
 exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Centroamérica Cuenta",
-  "url": "/mundo/noticias-43826245",
+  "url": "/mundo/topics/c404v5z1k8wt",
 }
 `;
 

--- a/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
@@ -231,7 +231,7 @@ exports[`AMP Story Page Header Navigation link should match text and url 3`] = `
 exports[`AMP Story Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Hay Festival",
-  "url": "/mundo/noticias-36795069",
+  "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
@@ -273,7 +273,7 @@ exports[`AMP Story Page Header Navigation link should match text and url 9`] = `
 exports[`AMP Story Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Centroamérica Cuenta",
-  "url": "/mundo/noticias-43826245",
+  "url": "/mundo/topics/c404v5z1k8wt",
 }
 `;
 

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -104,7 +104,7 @@ exports[`Canonical Story Page Header Navigation link should match text and url 3
 exports[`Canonical Story Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Hay Festival",
-  "url": "/mundo/noticias-36795069",
+  "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
@@ -146,7 +146,7 @@ exports[`Canonical Story Page Header Navigation link should match text and url 9
 exports[`Canonical Story Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Centroamérica Cuenta",
-  "url": "/mundo/noticias-43826245",
+  "url": "/mundo/topics/c404v5z1k8wt",
 }
 `;
 


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
Replaced the links to deprecated FIXs to the correct topic links on Arabic, Mundo, Hausa and Russian nav bars to avoid the avoid the redirect


Code changes
======

- Edited the navigation section of src/app/lib/config/services/arabic.ts 
- Edited the navigation section of src/app/lib/config/services/hausa.ts 
- Edited the navigation section of src/app/lib/config/services/mundo.ts 
- Edited the navigation section of src/app/lib/config/services/russian.ts 
- Updated snapshots



Testing
======
1. Open BBC Arabic front page. The sixth link on bar should open the video topic: 
2. Open BBC Hausa front page. The last link on bar should open a topic: 
3. Open BBC Mundo front page. Hay Festival and Centromerica Cuenta links should topic pages: 
4. Open BBC Russian  front page. There should be no links to CPS FIXs on the navigation bar

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
