### PR TITLE
WSTEAM1-871+872 - Additional media player settings

### DIFF
--- a/src/app/components/MediaLoader/configs/article.ts
+++ b/src/app/components/MediaLoader/configs/article.ts
@@ -59,6 +59,8 @@ export default ({
     aresMediaBlock?.model?.blocks?.[0]?.model?.[versionParameter]?.[0]?.warnings
       ?.short;
 
+  const embeddingAllowed = aresMediaBlock?.model?.blocks?.[0]?.model?.embedding;
+
   return {
     mediaType: format || 'video',
     playerConfig: {
@@ -70,6 +72,7 @@ export default ({
         holdingImageURL: placeholderSrc,
         items: [{ versionID, kind, duration }],
         ...(guidanceMessage && { guidance: guidanceMessage }),
+        ...(embeddingAllowed && { embedRights: 'allowed' }),
       },
       ...(pageType === 'mediaArticle' && { preload: 'high' }),
     },

--- a/src/app/components/MediaLoader/configs/article.ts
+++ b/src/app/components/MediaLoader/configs/article.ts
@@ -48,6 +48,7 @@ export default ({
   });
 
   const title = aresMediaBlock?.model?.blocks?.[0]?.model?.title;
+
   const captionBlock = getCaptionBlock(blocks, pageType);
 
   const caption =
@@ -55,11 +56,13 @@ export default ({
 
   const kind =
     aresMediaBlock?.model?.blocks?.[0]?.model?.smpKind || 'programme';
+
   const guidanceMessage =
     aresMediaBlock?.model?.blocks?.[0]?.model?.[versionParameter]?.[0]?.warnings
       ?.short;
 
-  const embeddingAllowed = aresMediaBlock?.model?.blocks?.[0]?.model?.embedding;
+  const embeddingAllowed =
+    aresMediaBlock?.model?.blocks?.[0]?.model?.embedding ?? false;
 
   return {
     mediaType: format || 'video',

--- a/src/app/components/MediaLoader/configs/livePage.ts
+++ b/src/app/components/MediaLoader/configs/livePage.ts
@@ -27,18 +27,22 @@ export default ({
   const { source, urlTemplate: locator } = images?.[1] ?? {};
 
   const originCode = source?.replace('Image', '');
+
   const versionID = video?.version?.id;
+
   const clipISO8601Duration = video?.version?.duration;
 
   const duration = moment.duration(clipISO8601Duration).asSeconds();
 
   const title = video?.title;
+
   const captionBlock = getCaptionBlock(blocks, 'live');
 
   const caption =
     captionBlock?.model?.blocks?.[0]?.model?.blocks?.[0]?.model?.text;
 
   const kind = video?.version?.kind || 'programme';
+
   const guidanceMessage = video?.version?.guidance?.warnings?.short;
 
   const embeddingAllowed = video?.isEmbeddingAllowed ?? false;

--- a/src/app/components/MediaLoader/configs/livePage.ts
+++ b/src/app/components/MediaLoader/configs/livePage.ts
@@ -41,6 +41,8 @@ export default ({
   const kind = video?.version?.kind || 'programme';
   const guidanceMessage = video?.version?.guidance?.warnings?.short;
 
+  const embeddingAllowed = video?.isEmbeddingAllowed ?? false;
+
   const placeholderSrc = buildIChefURL({
     originCode,
     locator,
@@ -67,6 +69,7 @@ export default ({
         holdingImageURL: placeholderSrc,
         items: [{ versionID, kind, duration }],
         ...(guidanceMessage && { guidance: guidanceMessage }),
+        ...(embeddingAllowed && { embedRights: 'allowed' }),
       },
       ui: {
         ...basePlayerConfig.ui,

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -40,6 +40,7 @@ export type PlaylistItem = {
   kind: string;
   duration: number;
   live?: boolean;
+  embedRights?: 'allowed';
 };
 
 export type ConfigBuilderProps = {
@@ -88,6 +89,7 @@ export type AresMediaBlock = {
     blocks: AresMediaBlock[];
     imageUrl: string;
     format: 'audio' | 'video';
+    embedding: boolean;
     versions: {
       versionId: string;
       duration: number;
@@ -118,6 +120,7 @@ export type ClipMediaBlock = {
         kind: string;
         guidance: { warnings?: { [key: string]: string } } | null;
       };
+      isEmbeddingAllowed: boolean;
     };
   };
 };

--- a/src/app/components/MediaLoader/utils/buildSetting.test.ts
+++ b/src/app/components/MediaLoader/utils/buildSetting.test.ts
@@ -48,6 +48,7 @@ describe('buildSettings', () => {
         holdingImageURL:
           'https://ichef.test.bbci.co.uk/images/ic/512xn/p01thw3g.jpg',
         items: [{ duration: 54, kind: 'programme', versionID: 'p01thw22' }],
+        embedRights: 'allowed',
       },
       ui: {
         controls: { enabled: true },
@@ -87,6 +88,7 @@ describe('buildSettings', () => {
           'https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg',
         items: [{ duration: 191, kind: 'programme', versionID: 'p01k6msp' }],
         guidance: 'Contains strong language and adult humour.',
+        embedRights: 'allowed',
       },
       ui: {
         controls: { enabled: true },
@@ -128,6 +130,7 @@ describe('buildSettings', () => {
           'https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg',
         items: [{ duration: 191, kind: 'programme', versionID: 'p01k6msp' }],
         guidance: 'Contains strong language and adult humour.',
+        embedRights: 'allowed',
       },
       ui: {
         controls: { enabled: true },


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-871](https://jira.dev.bbc.co.uk/browse/WSTEAM1-871) and [WSTEAM1-872](https://jira.dev.bbc.co.uk/browse/WSTEAM1-872)

Overall changes
======
- Adds checks for `embedding` boolean for the article and live page media player configs 
- Audio settings have already been configured in https://github.com/bbc/simorgh/pull/11383

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
