### PR TITLE
Add "Latest video" heading

### DIFF
--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -254,7 +254,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: '주요 뉴스',
       featuresAnalysisTitle: '이 시간 이슈',
-      latestMediaTitle: '최신',
+      latestMediaTitle: '최신 뉴스',
     },
     mostRead: {
       header: 'TOP 뉴스',

--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -256,6 +256,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'Principales noticias',
       featuresAnalysisTitle: 'No te lo pierdas',
+      latestMediaTitle: 'Más videos',
     },
     mostRead: {
       header: 'Más leídas',

--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -236,6 +236,7 @@ export const mainTranslations = {
   },
   topStoriesTitle: 'Главное',
   featuresAnalysisTitle: 'Не пропустите',
+  latestMediaTitle: 'Актуальное',
   infoBannerLabel: 'Информация',
 };
 


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
Add "Latest video" heading to the Russian, Mundo and Korean video experience pages

Code changes
======

-Added latestMediaTitle value to /src/app/lib/config/services/russian.ts
-Added latestMediaTitle value to /src/app/lib/config/services/mundo.ts
-Modified latestMediaTitle value in /src/app/lib/config/services/korean.ts

Testing
======
1. Open a Russian video exp. (cxezx7pz82eo), the heading of the recent videos section on the rhs column should be "Актуальное"
2. Open a Mundo video exp. (cjqg1vd210lo), the heading of the recent videos section on the rhs column should be "Más videos"
3.Open a Korean video exp. (cn0ndvn2x0lo), the heading of the recent videos section on the rhs column should be "최신 뉴스"

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
