### PR TITLE
Curation Promos refactor & tidy up types

### DIFF
--- a/src/app/components/Curation/CurationGrid/index.stories.tsx
+++ b/src/app/components/Curation/CurationGrid/index.stories.tsx
@@ -11,7 +11,7 @@ const Component = ({ service, variant }: StoryProps) => {
   return (
     <ThemeProvider service={service} variant={variant}>
       <ServiceContextProvider service={service} variant={variant}>
-        <CurationGrid promos={fixture.data.curations[0].summaries} />
+        <CurationGrid summaries={fixture.data.curations[0].summaries} />
       </ServiceContextProvider>
     </ThemeProvider>
   );

--- a/src/app/components/Curation/CurationGrid/index.tsx
+++ b/src/app/components/Curation/CurationGrid/index.tsx
@@ -5,21 +5,21 @@ import CurationPromo from '../CurationPromo';
 import { CurationGridProps } from '../types';
 
 const CurationGrid = ({
-  promos,
+  summaries,
   headingLevel,
   isFirstCuration,
 }: CurationGridProps) => {
-  const hasMultiplePromos = promos.length > 1;
-  const firstPromo = promos[0];
+  const hasMultiplePromos = summaries.length > 1;
+  const firstPromo = summaries[0];
 
-  if (promos.length === 0) {
+  if (summaries.length === 0) {
     return null;
   }
   return (
     <div data-testid="curation-grid-normal">
       {hasMultiplePromos ? (
         <ul css={styles.list} role="list" data-testid="topic-promos">
-          {promos.map((promo, index) => {
+          {summaries.map((promo, index) => {
             const isFirstPromo = index === 0;
             const lazyLoadImages = !(isFirstPromo && isFirstCuration);
 

--- a/src/app/components/Curation/CurationPromo/index.tsx
+++ b/src/app/components/Curation/CurationPromo/index.tsx
@@ -4,10 +4,10 @@ import moment from 'moment';
 import path from 'ramda/src/path';
 import formatDuration from '#app/lib/utilities/formatDuration';
 import Promo from '#components/Promo';
+import { Summary } from '#app/models/types/curationData';
 import VisuallyHiddenText from '../../VisuallyHiddenText';
 import { ServiceContext } from '../../../contexts/ServiceContext';
 import { RequestContext } from '../../../contexts/RequestContext';
-import { Promo as CurationPromoProps } from '../types';
 import LiveLabel from '../../LiveLabel';
 
 const CurationPromo = ({
@@ -21,7 +21,7 @@ const CurationPromo = ({
   type,
   duration: mediaDuration,
   headingLevel = 2,
-}: CurationPromoProps) => {
+}: Summary) => {
   const { isAmp } = useContext(RequestContext);
   const { translations } = useContext(ServiceContext);
 

--- a/src/app/components/Curation/HierarchicalGrid/index.stories.tsx
+++ b/src/app/components/Curation/HierarchicalGrid/index.stories.tsx
@@ -14,7 +14,7 @@ const Component = ({ service, variant }: StoryProps) => {
       <ServiceContextProvider service={service} variant={variant}>
         <HierarchicalGrid
           headingLevel={2}
-          promos={pidginPromos.slice(
+          summaries={pidginPromos.slice(
             0,
             number('Promo Count', 12, { min: 3, max: 12 }),
           )}

--- a/src/app/components/Curation/HierarchicalGrid/index.test.tsx
+++ b/src/app/components/Curation/HierarchicalGrid/index.test.tsx
@@ -11,7 +11,9 @@ describe('Hierarchical Grid Curation', () => {
 
   const headingLevel = 2;
   it('renders twelve promos when twelve items are provided', async () => {
-    render(<HierarchicalGrid headingLevel={headingLevel} promos={fixture} />);
+    render(
+      <HierarchicalGrid headingLevel={headingLevel} summaries={fixture} />,
+    );
 
     expect(document.querySelectorAll('li').length).toBe(12);
   });
@@ -31,7 +33,7 @@ describe('Hierarchical Grid Curation', () => {
       id: 'e2263a1c-8d5a-4a73-a00c-881acfa34381',
     });
     render(
-      <HierarchicalGrid headingLevel={headingLevel} promos={extraPromos} />,
+      <HierarchicalGrid headingLevel={headingLevel} summaries={extraPromos} />,
     );
 
     expect(document.querySelectorAll('li').length).toBe(12);
@@ -41,14 +43,16 @@ describe('Hierarchical Grid Curation', () => {
     render(
       <HierarchicalGrid
         headingLevel={headingLevel}
-        promos={fixture.splice(0, 2)}
+        summaries={fixture.splice(0, 2)}
       />,
     );
     expect(document.querySelectorAll('li').length).toBe(0);
   });
 
   it('renders list with role of list', async () => {
-    render(<HierarchicalGrid headingLevel={headingLevel} promos={fixture} />);
+    render(
+      <HierarchicalGrid headingLevel={headingLevel} summaries={fixture} />,
+    );
 
     expect(document.querySelectorAll('ul').length).toBe(1);
     expect(document.querySelector('ul')?.getAttribute('role')).toBe('list');
@@ -56,7 +60,7 @@ describe('Hierarchical Grid Curation', () => {
 
   it('should use formatted duration when a valid duration is provided - audio', async () => {
     const container = render(
-      <HierarchicalGrid headingLevel={headingLevel} promos={mediaFixture} />,
+      <HierarchicalGrid headingLevel={headingLevel} summaries={mediaFixture} />,
     );
 
     const durationString = 'Duration, 2,03';
@@ -67,7 +71,7 @@ describe('Hierarchical Grid Curation', () => {
 
   it('should use formatted duration when a valid duration is provided - video', async () => {
     const container = render(
-      <HierarchicalGrid headingLevel={headingLevel} promos={mediaFixture} />,
+      <HierarchicalGrid headingLevel={headingLevel} summaries={mediaFixture} />,
     );
 
     const durationString = 'Duration, 3,43';
@@ -77,16 +81,19 @@ describe('Hierarchical Grid Curation', () => {
   });
 
   it('should render the last published date', async () => {
-    const { getByText } = render(<HierarchicalGrid promos={mediaFixture} />, {
-      service: 'mundo',
-    });
+    const { getByText } = render(
+      <HierarchicalGrid summaries={mediaFixture} />,
+      {
+        service: 'mundo',
+      },
+    );
 
     expect(getByText('29 julio 2023')).toBeInTheDocument();
   });
 
   it('should use role text when using nested spans', async () => {
     render(
-      <HierarchicalGrid headingLevel={headingLevel} promos={mediaFixture} />,
+      <HierarchicalGrid headingLevel={headingLevel} summaries={mediaFixture} />,
     );
 
     expect(document.querySelector('span')?.getAttribute('role')).toBe('text');
@@ -94,7 +101,7 @@ describe('Hierarchical Grid Curation', () => {
 
   it('should use visually hidden text only when type is media i.e video, audio and photogallery', async () => {
     const container = render(
-      <HierarchicalGrid headingLevel={headingLevel} promos={mediaFixture} />,
+      <HierarchicalGrid headingLevel={headingLevel} summaries={mediaFixture} />,
     );
 
     expect(container.queryAllByTestId('visually-hidden-text')).toHaveLength(2);
@@ -102,14 +109,14 @@ describe('Hierarchical Grid Curation', () => {
   });
 
   it('should display LiveLabel on a Live Promo', () => {
-    const container = render(<HierarchicalGrid promos={mediaFixture} />, {
+    const container = render(<HierarchicalGrid summaries={mediaFixture} />, {
       service: 'mundo',
     });
     expect(container.getByText('EN VIVO')).toBeInTheDocument();
   });
 
   it('should not display a timestamp on a Live Promo', () => {
-    const container = render(<HierarchicalGrid promos={liveFixtures} />, {
+    const container = render(<HierarchicalGrid summaries={liveFixtures} />, {
       service: 'mundo',
     });
     expect(container.queryByText('13 noviembre 2022')).not.toBeInTheDocument();

--- a/src/app/components/Curation/HierarchicalGrid/index.tsx
+++ b/src/app/components/Curation/HierarchicalGrid/index.tsx
@@ -32,7 +32,7 @@ const getStyles = (promoCount: number, i: number, mq: Theme['mq']) => {
 };
 
 const HiearchicalGrid = ({
-  promos,
+  summaries,
   headingLevel,
   isFirstCuration,
 }: CurationGridProps) => {
@@ -43,9 +43,9 @@ const HiearchicalGrid = ({
   const videoTranslation = path(['media', 'video'], translations);
   const photoGalleryTranslation = path(['media', 'photogallery'], translations);
   const durationTranslation = path(['media', 'duration'], translations);
-  if (!promos || promos.length < 3) return null;
+  if (!summaries || summaries.length < 3) return null;
 
-  const promoItems = promos.slice(0, 12);
+  const promoItems = summaries.slice(0, 12);
   return (
     <div data-testid="hierarchical-grid">
       <ul role="list" css={styles.list} data-testid="topic-promos">

--- a/src/app/components/Curation/getComponentName/index.ts
+++ b/src/app/components/Curation/getComponentName/index.ts
@@ -1,7 +1,7 @@
 import {
   VISUAL_STYLE,
   VISUAL_PROMINENCE,
-  CurationData,
+  Curation,
 } from '#app/models/types/curationData';
 
 export const COMPONENT_NAMES = {
@@ -28,7 +28,7 @@ export default ({
   visualStyle,
   visualProminence,
   radioSchedule,
-}: Partial<CurationData>) => {
+}: Partial<Curation>) => {
   if (radioSchedule) {
     return RADIO_SCHEDULE;
   }

--- a/src/app/components/Curation/getComponentName/index.ts
+++ b/src/app/components/Curation/getComponentName/index.ts
@@ -1,7 +1,7 @@
 import {
   VISUAL_STYLE,
   VISUAL_PROMINENCE,
-  CurationProps,
+  CurationData,
 } from '#app/models/types/curationData';
 
 export const COMPONENT_NAMES = {
@@ -28,7 +28,7 @@ export default ({
   visualStyle,
   visualProminence,
   radioSchedule,
-}: Partial<CurationProps>) => {
+}: Partial<CurationData>) => {
   if (radioSchedule) {
     return RADIO_SCHEDULE;
   }

--- a/src/app/components/Curation/index.test.tsx
+++ b/src/app/components/Curation/index.test.tsx
@@ -41,7 +41,7 @@ const components = {
     visualProminence: HIGH,
     summaries: mundoFixture.data.curations[0].summaries,
   },
-  'message-banner-1': {
+  'message-banner-': {
     visualStyle: BANNER,
     visualProminence: NORMAL,
     summaries: messageBannerCuration?.summaries,

--- a/src/app/components/Curation/index.test.tsx
+++ b/src/app/components/Curation/index.test.tsx
@@ -41,7 +41,7 @@ const components = {
     visualProminence: HIGH,
     summaries: mundoFixture.data.curations[0].summaries,
   },
-  'message-banner-': {
+  'message-banner-1': {
     visualStyle: BANNER,
     visualProminence: NORMAL,
     summaries: messageBannerCuration?.summaries,

--- a/src/app/components/Curation/index.test.tsx
+++ b/src/app/components/Curation/index.test.tsx
@@ -34,17 +34,17 @@ const components = {
   'curation-grid-normal': {
     visualStyle: NONE,
     visualProminence: NORMAL,
-    promos: fixture.data.curations[0].summaries,
+    summaries: fixture.data.curations[0].summaries,
   },
   'hierarchical-grid': {
     visualStyle: NONE,
     visualProminence: HIGH,
-    promos: mundoFixture.data.curations[0].summaries,
+    summaries: mundoFixture.data.curations[0].summaries,
   },
   'message-banner-': {
     visualStyle: BANNER,
     visualProminence: NORMAL,
-    promos: messageBannerCuration?.summaries,
+    summaries: messageBannerCuration?.summaries,
   },
   'most-read': {
     visualStyle: RANKED,
@@ -61,7 +61,7 @@ const components = {
 interface TestProps {
   visualStyle: VisualStyle;
   visualProminence: VisualProminence;
-  promos?: Summary[];
+  summaries?: Summary[];
   mostRead?: MostReadData;
   radioSchedule?: RadioScheduleData[];
 }
@@ -78,16 +78,17 @@ describe('Curation', () => {
       {
         visualStyle,
         visualProminence,
-        promos,
+        summaries,
         mostRead,
         radioSchedule,
       }: TestProps,
     ) => {
       const { getByTestId } = render(
         <Curation
+          position={0}
           visualStyle={visualStyle}
           visualProminence={visualProminence}
-          promos={promos || []}
+          summaries={summaries || []}
           mostRead={mostRead}
           radioSchedule={radioSchedule}
         />,
@@ -113,6 +114,7 @@ describe('Curation', () => {
     ({ visualStyle, visualProminence }) => {
       const { container } = render(
         <Curation
+          position={0}
           visualStyle={visualStyle}
           visualProminence={visualProminence}
         />,
@@ -134,10 +136,11 @@ describe('Curation', () => {
 
       const { queryByText } = render(
         <Curation
+          position={0}
           visualStyle={visualStyle}
           visualProminence={visualProminence}
           title={title}
-          promos={[]}
+          summaries={[]}
         />,
       );
 
@@ -148,7 +151,12 @@ describe('Curation', () => {
   describe('Message Banner', () => {
     it('should not be displayed if there are no promos', () => {
       render(
-        <Curation visualStyle={BANNER} visualProminence={NORMAL} promos={[]} />,
+        <Curation
+          position={0}
+          visualStyle={BANNER}
+          visualProminence={NORMAL}
+          summaries={[]}
+        />,
       );
 
       expect(
@@ -163,14 +171,14 @@ describe('Curation', () => {
         ({ summaries }) => summaries && summaries.length > 0,
       );
 
-      const promo = curationWithSummary.summaries?.pop();
+      const summary = curationWithSummary.summaries?.pop();
 
       render(
         <Curation
           visualProminence={NORMAL}
           visualStyle={NONE}
-          // @ts-expect-error promo will not be undefined
-          promos={[promo]}
+          // @ts-expect-error summary will not be undefined
+          summaries={[summary]}
           curationLength={2}
         />,
       );

--- a/src/app/components/Curation/index.tsx
+++ b/src/app/components/Curation/index.tsx
@@ -67,9 +67,7 @@ export default ({
   switch (componentName) {
     case NOT_SUPPORTED:
       return null;
-    case MESSAGE_BANNER: {
-      const messageBannerId = `message-banner-${nthCurationByStyleAndProminence}`;
-
+    case MESSAGE_BANNER:
       return summaries.length > 0 ? (
         <MessageBanner
           heading={title}
@@ -77,14 +75,13 @@ export default ({
           link={summaries[0].link}
           linkText={summaries[0].title}
           image={summaries[0].imageUrl}
-          id={messageBannerId}
           eventTrackingData={{
-            componentName: messageBannerId,
+            componentName: `message-banner-${nthCurationByStyleAndProminence}`,
             detailedPlacement: `${position + 1}`,
           }}
         />
       ) : null;
-    }
+
     case MOST_READ:
       return (
         <MostRead

--- a/src/app/components/Curation/index.tsx
+++ b/src/app/components/Curation/index.tsx
@@ -12,7 +12,6 @@ import HierarchicalGrid from './HierarchicalGrid';
 import Subheading from './Subhead';
 import getComponentName, { COMPONENT_NAMES } from './getComponentName';
 import MessageBanner from '../MessageBanner';
-import idSanitiser from '../../lib/utilities/idSanitiser';
 import MostRead from '../MostRead';
 import { GHOST } from '../ThemeProvider/palette';
 
@@ -50,7 +49,7 @@ export default ({
   curationLength = 0,
   mostRead,
   radioSchedule,
-  key = 1,
+  nthCurationByStyleAndProminence = 1,
 }: Curation) => {
   const componentName = getComponentName({
     visualStyle,
@@ -62,12 +61,15 @@ export default ({
 
   const isFirstCuration = position === 0;
   const curationSubheading = title || topStoriesTitle;
-  const id = idSanitiser(curationSubheading);
+  const id =
+    `${visualProminence}-${visualStyle}-${nthCurationByStyleAndProminence}`.toLowerCase();
 
   switch (componentName) {
     case NOT_SUPPORTED:
       return null;
-    case MESSAGE_BANNER:
+    case MESSAGE_BANNER: {
+      const messageBannerId = `message-banner-${nthCurationByStyleAndProminence}`;
+
       return summaries.length > 0 ? (
         <MessageBanner
           heading={title}
@@ -75,12 +77,14 @@ export default ({
           link={summaries[0].link}
           linkText={summaries[0].title}
           image={summaries[0].imageUrl}
+          id={messageBannerId}
           eventTrackingData={{
-            componentName: `message-banner-${key}`,
+            componentName: messageBannerId,
             detailedPlacement: `${position + 1}`,
           }}
         />
       ) : null;
+    }
     case MOST_READ:
       return (
         <MostRead

--- a/src/app/components/Curation/index.tsx
+++ b/src/app/components/Curation/index.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react';
 import {
-  CurationData,
+  Curation,
   VISUAL_STYLE,
   VISUAL_PROMINENCE,
 } from '#app/models/types/curationData';
@@ -38,7 +38,7 @@ const getGridComponent = (componentName: string | null) => {
   }
 };
 
-const Curation = ({
+export default ({
   visualStyle = NONE,
   visualProminence = NORMAL,
   summaries = [],
@@ -50,8 +50,8 @@ const Curation = ({
   curationLength = 0,
   mostRead,
   radioSchedule,
-  nthCurationByStyleAndProminence = 1,
-}: CurationData) => {
+  key = 1,
+}: Curation) => {
   const componentName = getComponentName({
     visualStyle,
     visualProminence,
@@ -76,7 +76,7 @@ const Curation = ({
           linkText={summaries[0].title}
           image={summaries[0].imageUrl}
           eventTrackingData={{
-            componentName: `message-banner-${nthCurationByStyleAndProminence}`,
+            componentName: `message-banner-${key}`,
             detailedPlacement: `${position + 1}`,
           }}
         />
@@ -122,5 +122,3 @@ const Curation = ({
       );
   }
 };
-
-export default Curation;

--- a/src/app/components/Curation/index.tsx
+++ b/src/app/components/Curation/index.tsx
@@ -81,7 +81,6 @@ export default ({
           }}
         />
       ) : null;
-
     case MOST_READ:
       return (
         <MostRead

--- a/src/app/components/Curation/index.tsx
+++ b/src/app/components/Curation/index.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react';
 import {
-  CurationProps,
+  CurationData,
   VISUAL_STYLE,
   VISUAL_PROMINENCE,
 } from '#app/models/types/curationData';
@@ -41,7 +41,7 @@ const getGridComponent = (componentName: string | null) => {
 const Curation = ({
   visualStyle = NONE,
   visualProminence = NORMAL,
-  promos = [],
+  summaries = [],
   title = '',
   topStoriesTitle = '',
   link = '',
@@ -51,7 +51,7 @@ const Curation = ({
   mostRead,
   radioSchedule,
   nthCurationByStyleAndProminence = 1,
-}: CurationProps) => {
+}: CurationData) => {
   const componentName = getComponentName({
     visualStyle,
     visualProminence,
@@ -68,13 +68,13 @@ const Curation = ({
     case NOT_SUPPORTED:
       return null;
     case MESSAGE_BANNER:
-      return promos.length > 0 ? (
+      return summaries.length > 0 ? (
         <MessageBanner
           heading={title}
-          description={promos[0].description}
-          link={promos[0].link}
-          linkText={promos[0].title}
-          image={promos[0].imageUrl}
+          description={summaries[0].description}
+          link={summaries[0].link}
+          linkText={summaries[0].title}
+          image={summaries[0].imageUrl}
           eventTrackingData={{
             componentName: `message-banner-${nthCurationByStyleAndProminence}`,
             detailedPlacement: `${position + 1}`,
@@ -95,7 +95,7 @@ const Curation = ({
     case HIERARCHICAL_CURATION_GRID:
     default:
       return curationLength > 1 &&
-        promos.length > 0 &&
+        summaries.length > 0 &&
         (title || isFirstCuration) ? (
         <section aria-labelledby={id} role="region">
           {isFirstCuration ? (
@@ -108,14 +108,14 @@ const Curation = ({
             </Subheading>
           )}
           <GridComponent
-            promos={promos}
+            summaries={summaries}
             headingLevel={isFirstCuration ? 3 : headingLevel}
             isFirstCuration={isFirstCuration}
           />
         </section>
       ) : (
         <GridComponent
-          promos={promos}
+          summaries={summaries}
           headingLevel={headingLevel}
           isFirstCuration={isFirstCuration}
         />

--- a/src/app/components/Curation/index.tsx
+++ b/src/app/components/Curation/index.tsx
@@ -6,6 +6,7 @@ import {
   VISUAL_PROMINENCE,
 } from '#app/models/types/curationData';
 import RadioSchedule from '#app/legacy/containers/RadioSchedule';
+import idSanitiser from '#app/lib/utilities/idSanitiser';
 import VisuallyHiddenText from '../VisuallyHiddenText';
 import CurationGrid from './CurationGrid';
 import HierarchicalGrid from './HierarchicalGrid';
@@ -61,8 +62,7 @@ export default ({
 
   const isFirstCuration = position === 0;
   const curationSubheading = title || topStoriesTitle;
-  const id =
-    `${visualProminence}-${visualStyle}-${nthCurationByStyleAndProminence}`.toLowerCase();
+  const id = idSanitiser(curationSubheading);
 
   switch (componentName) {
     case NOT_SUPPORTED:

--- a/src/app/components/Curation/types.ts
+++ b/src/app/components/Curation/types.ts
@@ -1,14 +1,7 @@
 import { Summary } from '#app/models/types/curationData';
 
-export interface Promo extends Summary {
-  mediaType?: 'audio' | 'video' | 'photogallery';
-  duration?: string | number;
-  lazy?: boolean;
-  headingLevel?: number;
-}
-
 export interface CurationGridProps {
-  promos: Promo[];
+  summaries: Summary[];
   headingLevel?: number;
   isFirstCuration?: boolean;
 }

--- a/src/app/components/MessageBanner/index.tsx
+++ b/src/app/components/MessageBanner/index.tsx
@@ -3,6 +3,7 @@ import { useContext, forwardRef } from 'react';
 import { jsx } from '@emotion/react';
 import useViewTracker from '#app/hooks/useViewTracker';
 import { EventTrackingMetadata } from '#app/models/types/eventTracking';
+import idSanitiser from '#app/lib/utilities/idSanitiser';
 import Paragraph from '../Paragraph';
 import Heading from '../Heading';
 import Image from '../Image';
@@ -17,7 +18,6 @@ interface MessageBannerProps {
   link?: string;
   linkText: string;
   image?: string;
-  id?: string;
   eventTrackingData?: EventTrackingMetadata;
 }
 
@@ -30,12 +30,13 @@ const Banner = forwardRef(
       linkText,
       image,
       eventTrackingData,
-      id = 'message-banner-1',
     }: MessageBannerProps,
     viewRef,
   ) => {
     const { dir } = useContext(ServiceContext);
     const isRtl = dir === 'rtl';
+
+    const id = `message-banner-${idSanitiser(heading)}`;
 
     return (
       <section
@@ -91,7 +92,6 @@ const MessageBanner = ({
   linkText,
   image,
   eventTrackingData,
-  id,
 }: MessageBannerProps) => {
   const viewRef = useViewTracker(eventTrackingData);
 
@@ -104,7 +104,6 @@ const MessageBanner = ({
       image={image}
       eventTrackingData={eventTrackingData}
       ref={viewRef}
-      id={id}
     />
   );
 };

--- a/src/app/components/MessageBanner/index.tsx
+++ b/src/app/components/MessageBanner/index.tsx
@@ -10,7 +10,6 @@ import styles from './index.styles';
 import { LeftChevron, RightChevron } from '../icons';
 import { ServiceContext } from '../../contexts/ServiceContext';
 import CallToActionLink from '../CallToActionLink';
-import idSanitiser from '../../lib/utilities/idSanitiser';
 
 interface MessageBannerProps {
   heading: string;
@@ -18,6 +17,7 @@ interface MessageBannerProps {
   link?: string;
   linkText: string;
   image?: string;
+  id?: string;
   eventTrackingData?: EventTrackingMetadata;
 }
 
@@ -30,13 +30,12 @@ const Banner = forwardRef(
       linkText,
       image,
       eventTrackingData,
+      id = 'message-banner-1',
     }: MessageBannerProps,
     viewRef,
   ) => {
     const { dir } = useContext(ServiceContext);
     const isRtl = dir === 'rtl';
-
-    const id = `message-banner-${idSanitiser(heading)}`;
 
     return (
       <section
@@ -92,6 +91,7 @@ const MessageBanner = ({
   linkText,
   image,
   eventTrackingData,
+  id,
 }: MessageBannerProps) => {
   const viewRef = useViewTracker(eventTrackingData);
 
@@ -104,6 +104,7 @@ const MessageBanner = ({
       image={image}
       eventTrackingData={eventTrackingData}
       ref={viewRef}
+      id={id}
     />
   );
 };

--- a/src/app/lib/seoUtils/getItemList/index.ts
+++ b/src/app/lib/seoUtils/getItemList/index.ts
@@ -1,10 +1,10 @@
-import { CurationData } from '../../../models/types/curationData';
+import { Curation } from '../../../models/types/curationData';
 
 export default ({
   curations,
   name,
 }: {
-  curations: CurationData[];
+  curations: Curation[];
   name: string;
 }) => {
   const itemListElement = curations

--- a/src/app/models/types/curationData.ts
+++ b/src/app/models/types/curationData.ts
@@ -41,6 +41,8 @@ export const VISUAL_PROMINENCE = {
 export type VisualStyle = keyof typeof VISUAL_STYLE;
 
 export type VisualProminence = keyof typeof VISUAL_PROMINENCE;
+
+// This maps to the Curation type definition in the BFF
 export interface BaseCuration {
   summaries?: Summary[];
   visualStyle?: VisualStyle | string;

--- a/src/app/models/types/curationData.ts
+++ b/src/app/models/types/curationData.ts
@@ -62,5 +62,5 @@ export interface Curation extends BaseCuration {
   headingLevel?: number;
   topStoriesTitle?: string;
   curationLength?: number;
-  key?: number;
+  nthCurationByStyleAndProminence?: number;
 }

--- a/src/app/models/types/curationData.ts
+++ b/src/app/models/types/curationData.ts
@@ -1,7 +1,8 @@
 import { RadioScheduleData } from '#app/models/types/radioSchedule';
 import { MostReadData } from '../../components/MostRead/types';
 
-export interface Summary {
+// This maps to the Summary type definition from the BFF
+interface BaseSummary {
   imageUrl?: string;
   link?: string;
   imageAlt?: string;
@@ -11,6 +12,13 @@ export interface Summary {
   type: string;
   firstPublished?: string | number;
   lastPublished?: string | number;
+  duration?: string | number;
+}
+
+export interface Summary extends BaseSummary {
+  mediaType?: 'audio' | 'video' | 'photogallery';
+  lazy?: boolean;
+  headingLevel?: number;
 }
 
 export const VISUAL_STYLE = {
@@ -33,27 +41,11 @@ export const VISUAL_PROMINENCE = {
 export type VisualStyle = keyof typeof VISUAL_STYLE;
 
 export type VisualProminence = keyof typeof VISUAL_PROMINENCE;
-
-export interface CurationProps {
-  visualStyle: VisualStyle;
-  visualProminence: VisualProminence;
-  promos?: Summary[];
-  title?: string;
-  link?: string;
-  headingLevel?: number;
-  position?: number;
-  topStoriesTitle?: string;
-  curationLength?: number;
-  mostRead?: MostReadData;
-  nthCurationByStyleAndProminence?: number;
-  radioSchedule?: RadioScheduleData[];
-}
-
-export interface CurationData {
+export interface BaseCuration {
   summaries?: Summary[];
   visualStyle?: VisualStyle | string;
   visualProminence: VisualProminence | string;
-  curationId: string;
+  curationId?: string;
   title?: string;
   link?: string;
   position: number;
@@ -62,4 +54,11 @@ export interface CurationData {
   curationType?: string;
   mostRead?: MostReadData;
   radioSchedule?: RadioScheduleData[];
+}
+
+export interface CurationData extends BaseCuration {
+  headingLevel?: number;
+  topStoriesTitle?: string;
+  curationLength?: number;
+  nthCurationByStyleAndProminence?: number;
 }

--- a/src/app/models/types/curationData.ts
+++ b/src/app/models/types/curationData.ts
@@ -58,9 +58,9 @@ export interface BaseCuration {
   radioSchedule?: RadioScheduleData[];
 }
 
-export interface CurationData extends BaseCuration {
+export interface Curation extends BaseCuration {
   headingLevel?: number;
   topStoriesTitle?: string;
   curationLength?: number;
-  nthCurationByStyleAndProminence?: number;
+  key?: number;
 }

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -107,7 +107,7 @@ const HomePage = ({ pageData }: HomePageProps) => {
                       headingLevel={curationTitle ? 3 : 2}
                       visualStyle={visualStyle as VisualStyle}
                       visualProminence={visualProminence as VisualProminence}
-                      promos={summaries || []}
+                      summaries={summaries || []}
                       title={curationTitle}
                       topStoriesTitle={topStoriesTitle}
                       position={position}

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -10,7 +10,7 @@ import {
   VisualStyle,
 } from '../../models/types/curationData';
 import { ATIData } from '../../components/ATIAnalytics/types';
-import CurationComponent from '../../components/Curation';
+import HomeCuration from '../../components/Curation';
 import Ad from '../../components/Ad';
 import MPU from '../../components/Ad/MPU';
 import { ServiceContext } from '../../contexts/ServiceContext';
@@ -103,7 +103,7 @@ const HomePage = ({ pageData }: HomePageProps) => {
                   });
                 return (
                   <React.Fragment key={`${curationId}-${position}`}>
-                    <CurationComponent
+                    <HomeCuration
                       headingLevel={curationTitle ? 3 : 2}
                       visualStyle={visualStyle as VisualStyle}
                       visualProminence={visualProminence as VisualProminence}
@@ -115,7 +115,9 @@ const HomePage = ({ pageData }: HomePageProps) => {
                       curationLength={curations && curations.length}
                       mostRead={mostRead}
                       radioSchedule={radioSchedule}
-                      key={nthCurationByStyleAndProminence}
+                      nthCurationByStyleAndProminence={
+                        nthCurationByStyleAndProminence
+                      }
                     />
                     {index === 0 && <MPU />}
                   </React.Fragment>

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -5,12 +5,12 @@ import { jsx } from '@emotion/react';
 import VisuallyHiddenText from '#app/components/VisuallyHiddenText';
 import ATIAnalytics from '../../components/ATIAnalytics';
 import {
-  CurationData,
+  Curation,
   VisualProminence,
   VisualStyle,
 } from '../../models/types/curationData';
 import { ATIData } from '../../components/ATIAnalytics/types';
-import Curation from '../../components/Curation';
+import CurationComponent from '../../components/Curation';
 import Ad from '../../components/Ad';
 import MPU from '../../components/Ad/MPU';
 import { ServiceContext } from '../../contexts/ServiceContext';
@@ -25,7 +25,7 @@ export interface HomePageProps {
   pageData: {
     id?: string;
     title: string;
-    curations: CurationData[];
+    curations: Curation[];
     description: string;
     metadata: {
       atiAnalytics: ATIData;
@@ -103,7 +103,7 @@ const HomePage = ({ pageData }: HomePageProps) => {
                   });
                 return (
                   <React.Fragment key={`${curationId}-${position}`}>
-                    <Curation
+                    <CurationComponent
                       headingLevel={curationTitle ? 3 : 2}
                       visualStyle={visualStyle as VisualStyle}
                       visualProminence={visualProminence as VisualProminence}
@@ -115,9 +115,7 @@ const HomePage = ({ pageData }: HomePageProps) => {
                       curationLength={curations && curations.length}
                       mostRead={mostRead}
                       radioSchedule={radioSchedule}
-                      nthCurationByStyleAndProminence={
-                        nthCurationByStyleAndProminence
-                      }
+                      key={nthCurationByStyleAndProminence}
                     />
                     {index === 0 && <MPU />}
                   </React.Fragment>

--- a/src/app/pages/HomePage/index.stories.tsx
+++ b/src/app/pages/HomePage/index.stories.tsx
@@ -4,7 +4,7 @@ import Url from 'url-parse';
 import { withKnobs } from '@storybook/addon-knobs';
 import { HOME_PAGE } from '#app/routes/utils/pageTypes';
 import fetch from 'node-fetch';
-import { CurationData } from '#app/models/types/curationData';
+import { Curation } from '#app/models/types/curationData';
 import { Services } from '#app/models/types/global';
 import { ServiceContextProvider } from '../../contexts/ServiceContext';
 import { withServicesKnob } from '../../legacy/psammead/psammead-storybook-helpers/src';
@@ -15,7 +15,7 @@ import HomePage from '.';
 const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
 
 const overrideRadioSchedule = (
-  data: { curations: CurationData[] },
+  data: { curations: Curation[] },
   service: Services,
 ) => {
   const { radioSchedule } =

--- a/src/app/pages/TopicPage/TopicPage.jsx
+++ b/src/app/pages/TopicPage/TopicPage.jsx
@@ -98,7 +98,7 @@ const TopicPage = ({ pageData }) => {
                     headingLevel={curationTitle && 3}
                     visualStyle={visualStyle}
                     visualProminence={visualProminence}
-                    promos={summaries}
+                    summaries={summaries}
                     title={curationTitle}
                     topStoriesTitle={topStoriesTitle}
                     position={position}

--- a/src/app/pages/utils/getNthCurationByStyleAndProminence/index.test.ts
+++ b/src/app/pages/utils/getNthCurationByStyleAndProminence/index.test.ts
@@ -1,12 +1,12 @@
 import {
-  CurationData,
+  Curation,
   VISUAL_PROMINENCE,
   VISUAL_STYLE,
 } from '#app/models/types/curationData';
 import getNthCurationByStyleAndProminence from '.';
 
 describe('getNthCurationByStyleAndProminence', () => {
-  const curations: CurationData[] = [
+  const curations: Curation[] = [
     {
       visualStyle: VISUAL_STYLE.COLLECTION,
       visualProminence: VISUAL_PROMINENCE.HIGH,

--- a/src/app/pages/utils/getNthCurationByStyleAndProminence/index.test.ts
+++ b/src/app/pages/utils/getNthCurationByStyleAndProminence/index.test.ts
@@ -11,25 +11,21 @@ describe('getNthCurationByStyleAndProminence', () => {
       visualStyle: VISUAL_STYLE.COLLECTION,
       visualProminence: VISUAL_PROMINENCE.HIGH,
       position: 0,
-      curationId: 'curationId',
     },
     {
       visualStyle: VISUAL_STYLE.BANNER,
       visualProminence: VISUAL_PROMINENCE.NORMAL,
       position: 1,
-      curationId: 'curationId',
     },
     {
       visualStyle: VISUAL_STYLE.COLLECTION,
       visualProminence: VISUAL_PROMINENCE.NORMAL,
       position: 2,
-      curationId: 'curationId',
     },
     {
       visualStyle: VISUAL_STYLE.BANNER,
       visualProminence: VISUAL_PROMINENCE.NORMAL,
       position: 3,
-      curationId: 'curationId',
     },
   ];
 

--- a/src/app/pages/utils/getNthCurationByStyleAndProminence/index.ts
+++ b/src/app/pages/utils/getNthCurationByStyleAndProminence/index.ts
@@ -1,12 +1,10 @@
 import {
-  CurationData,
+  Curation,
   VisualProminence,
   VisualStyle,
 } from '#app/models/types/curationData';
 
-const getPositionsOfCurationsByStyleAndProminence = (
-  curations: CurationData[],
-) => {
+const getPositionsOfCurationsByStyleAndProminence = (curations: Curation[]) => {
   const positionsOfCurationsByStyleAndProminence = new Map();
 
   curations.forEach(({ visualStyle, visualProminence, position }) => {
@@ -22,7 +20,7 @@ const getPositionsOfCurationsByStyleAndProminence = (
 };
 
 interface NthCurationByStyleAndProminence {
-  curations: CurationData[];
+  curations: Curation[];
   visualStyle?: VisualStyle | string;
   visualProminence: VisualProminence | string;
   position: number;


### PR DESCRIPTION
Overall changes
======
- Consolidating the CurationData & CurationProps types
- Renaming references of promos -> summaries, so that the props more closely match what is returned from the BFF

Code changes
======
- Update `HomePage` & `TopicPage` to pass the correct params to the `Curation` component
- Update all references of `CurationData` and `CurationProps` to `Curation`
- Update all references of `promos` to `summaries` within the `Curation` component (and its dependencies)
- Update unit tests

Testing
======
Home Pages & Topic Pages render as expected