### PR TITLE
Afrique and Urdu elections nav updates

### DIFF
--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -334,6 +334,10 @@ export const service: DefaultServiceConfig = {
         url: '/afrique',
       },
       {
+        title: 'Présidentielle Sénégal 2024',
+        url: '/afrique/topics/c0vj3r1jjd2t',
+      },
+      {
         title: 'Afrique',
         url: '/afrique/topics/cvqxn2k7kv7t',
       },

--- a/src/app/lib/config/services/urdu.ts
+++ b/src/app/lib/config/services/urdu.ts
@@ -348,10 +348,6 @@ export const service: DefaultServiceConfig = {
         url: '/urdu/topics/cjgn7n9zzq7t',
       },
       {
-        title: 'الیکشن 2024',
-        url: '/urdu/topics/cynd7qxprq0t',
-      },
-      {
         title: 'آس پاس',
         url: '/urdu/topics/cl8l9mveql2t',
       },

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
@@ -216,68 +216,75 @@ exports[`AMP Feature Index page Header Navigation link should match text and url
 
 exports[`AMP Feature Index page Header Navigation link should match text and url 2`] = `
 {
+  "text": "Présidentielle Sénégal 2024",
+  "url": "/afrique/topics/c0vj3r1jjd2t",
+}
+`;
+
+exports[`AMP Feature Index page Header Navigation link should match text and url 3`] = `
+{
   "text": "Afrique",
   "url": "/afrique/topics/cvqxn2k7kv7t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 3`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 4`] = `
 {
   "text": "Monde",
   "url": "/afrique/topics/cvqxn21vx11t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 4`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
 {
   "text": "Santé",
   "url": "/afrique/topics/c06gq9jxz3rt",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 6`] = `
 {
   "text": "Bien-être",
   "url": "/afrique/topics/c0vmyy90q8zt",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 6`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 7`] = `
 {
   "text": "Science et technologie",
   "url": "/afrique/topics/crezq2zk0q4t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 7`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 8`] = `
 {
   "text": "Economie",
   "url": "/afrique/topics/cnq687nr9v1t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 8`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 9`] = `
 {
   "text": "Culture",
   "url": "/afrique/topics/cnq687nrrw8t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 9`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 10`] = `
 {
   "text": "Vidéos",
   "url": "/afrique/topics/cz4vn9gyd6rt",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 10`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 11`] = `
 {
   "text": "Nos émissions",
   "url": "/afrique/media-54074891",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 11`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 12`] = `
 {
   "text": "Ecoutez en direct",
   "url": "/afrique/bbc_afrique_radio/liveradio",

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
@@ -75,68 +75,75 @@ exports[`Canonical Feature Index page Header Navigation link should match text a
 
 exports[`Canonical Feature Index page Header Navigation link should match text and url 2`] = `
 {
+  "text": "Présidentielle Sénégal 2024",
+  "url": "/afrique/topics/c0vj3r1jjd2t",
+}
+`;
+
+exports[`Canonical Feature Index page Header Navigation link should match text and url 3`] = `
+{
   "text": "Afrique",
   "url": "/afrique/topics/cvqxn2k7kv7t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 3`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 4`] = `
 {
   "text": "Monde",
   "url": "/afrique/topics/cvqxn21vx11t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
 {
   "text": "Santé",
   "url": "/afrique/topics/c06gq9jxz3rt",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 6`] = `
 {
   "text": "Bien-être",
   "url": "/afrique/topics/c0vmyy90q8zt",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 7`] = `
 {
   "text": "Science et technologie",
   "url": "/afrique/topics/crezq2zk0q4t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 8`] = `
 {
   "text": "Economie",
   "url": "/afrique/topics/cnq687nr9v1t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 9`] = `
 {
   "text": "Culture",
   "url": "/afrique/topics/cnq687nrrw8t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 10`] = `
 {
   "text": "Vidéos",
   "url": "/afrique/topics/cz4vn9gyd6rt",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 11`] = `
 {
   "text": "Nos émissions",
   "url": "/afrique/media-54074891",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 12`] = `
 {
   "text": "Ecoutez en direct",
   "url": "/afrique/bbc_afrique_radio/liveradio",

--- a/src/integration/pages/featureIdxPage/urdu/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/featureIdxPage/urdu/__snapshots__/amp.test.js.snap
@@ -223,47 +223,40 @@ exports[`AMP Feature Index page Header Navigation link should match text and url
 
 exports[`AMP Feature Index page Header Navigation link should match text and url 3`] = `
 {
-  "text": "الیکشن 2024",
-  "url": "/urdu/topics/cynd7qxprq0t",
-}
-`;
-
-exports[`AMP Feature Index page Header Navigation link should match text and url 4`] = `
-{
   "text": "آس پاس",
   "url": "/urdu/topics/cl8l9mveql2t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 4`] = `
 {
   "text": "ورلڈ",
   "url": "/urdu/topics/cw57v2pmll9t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 6`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
 {
   "text": "کھیل",
   "url": "/urdu/topics/c340q0p2585t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 7`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 6`] = `
 {
   "text": "فن فنکار",
   "url": "/urdu/topics/ckdxnx900n5t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 8`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 7`] = `
 {
   "text": "سائنس",
   "url": "/urdu/topics/c40379e2ymxt",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 9`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 8`] = `
 {
   "text": "ویڈیو",
   "url": "/urdu/topics/c1e0mzr3r2yt",

--- a/src/integration/pages/featureIdxPage/urdu/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/urdu/__snapshots__/canonical.test.js.snap
@@ -82,47 +82,40 @@ exports[`Canonical Feature Index page Header Navigation link should match text a
 
 exports[`Canonical Feature Index page Header Navigation link should match text and url 3`] = `
 {
-  "text": "الیکشن 2024",
-  "url": "/urdu/topics/cynd7qxprq0t",
-}
-`;
-
-exports[`Canonical Feature Index page Header Navigation link should match text and url 4`] = `
-{
   "text": "آس پاس",
   "url": "/urdu/topics/cl8l9mveql2t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 4`] = `
 {
   "text": "ورلڈ",
   "url": "/urdu/topics/cw57v2pmll9t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
 {
   "text": "کھیل",
   "url": "/urdu/topics/c340q0p2585t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 6`] = `
 {
   "text": "فن فنکار",
   "url": "/urdu/topics/ckdxnx900n5t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 7`] = `
 {
   "text": "سائنس",
   "url": "/urdu/topics/c40379e2ymxt",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 8`] = `
 {
   "text": "ویڈیو",
   "url": "/urdu/topics/c1e0mzr3r2yt",

--- a/src/integration/pages/mostWatchedPage/afrique/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/afrique/__snapshots__/amp.test.js.snap
@@ -205,68 +205,75 @@ exports[`AMP Most Watched Page Header Navigation link should match text and url 
 
 exports[`AMP Most Watched Page Header Navigation link should match text and url 2`] = `
 {
+  "text": "Présidentielle Sénégal 2024",
+  "url": "/afrique/topics/c0vj3r1jjd2t",
+}
+`;
+
+exports[`AMP Most Watched Page Header Navigation link should match text and url 3`] = `
+{
   "text": "Afrique",
   "url": "/afrique/topics/cvqxn2k7kv7t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 3`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Monde",
   "url": "/afrique/topics/cvqxn21vx11t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 4`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Santé",
   "url": "/afrique/topics/c06gq9jxz3rt",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Bien-être",
   "url": "/afrique/topics/c0vmyy90q8zt",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Science et technologie",
   "url": "/afrique/topics/crezq2zk0q4t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Economie",
   "url": "/afrique/topics/cnq687nr9v1t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Culture",
   "url": "/afrique/topics/cnq687nrrw8t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Vidéos",
   "url": "/afrique/topics/cz4vn9gyd6rt",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 11`] = `
 {
   "text": "Nos émissions",
   "url": "/afrique/media-54074891",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 11`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 12`] = `
 {
   "text": "Ecoutez en direct",
   "url": "/afrique/bbc_afrique_radio/liveradio",

--- a/src/integration/pages/mostWatchedPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/afrique/__snapshots__/canonical.test.js.snap
@@ -75,68 +75,75 @@ exports[`Canonical Most Watched Page Header Navigation link should match text an
 
 exports[`Canonical Most Watched Page Header Navigation link should match text and url 2`] = `
 {
+  "text": "Présidentielle Sénégal 2024",
+  "url": "/afrique/topics/c0vj3r1jjd2t",
+}
+`;
+
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 3`] = `
+{
   "text": "Afrique",
   "url": "/afrique/topics/cvqxn2k7kv7t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 3`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Monde",
   "url": "/afrique/topics/cvqxn21vx11t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Santé",
   "url": "/afrique/topics/c06gq9jxz3rt",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Bien-être",
   "url": "/afrique/topics/c0vmyy90q8zt",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Science et technologie",
   "url": "/afrique/topics/crezq2zk0q4t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Economie",
   "url": "/afrique/topics/cnq687nr9v1t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Culture",
   "url": "/afrique/topics/cnq687nrrw8t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Vidéos",
   "url": "/afrique/topics/cz4vn9gyd6rt",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 11`] = `
 {
   "text": "Nos émissions",
   "url": "/afrique/media-54074891",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 12`] = `
 {
   "text": "Ecoutez en direct",
   "url": "/afrique/bbc_afrique_radio/liveradio",

--- a/src/integration/pages/mostWatchedPage/urdu/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/urdu/__snapshots__/amp.test.js.snap
@@ -212,47 +212,40 @@ exports[`AMP Most Watched Page Header Navigation link should match text and url 
 
 exports[`AMP Most Watched Page Header Navigation link should match text and url 3`] = `
 {
-  "text": "الیکشن 2024",
-  "url": "/urdu/topics/cynd7qxprq0t",
-}
-`;
-
-exports[`AMP Most Watched Page Header Navigation link should match text and url 4`] = `
-{
   "text": "آس پاس",
   "url": "/urdu/topics/cl8l9mveql2t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 4`] = `
 {
   "text": "ورلڈ",
   "url": "/urdu/topics/cw57v2pmll9t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 5`] = `
 {
   "text": "کھیل",
   "url": "/urdu/topics/c340q0p2585t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 6`] = `
 {
   "text": "فن فنکار",
   "url": "/urdu/topics/ckdxnx900n5t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 7`] = `
 {
   "text": "سائنس",
   "url": "/urdu/topics/c40379e2ymxt",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 8`] = `
 {
   "text": "ویڈیو",
   "url": "/urdu/topics/c1e0mzr3r2yt",

--- a/src/integration/pages/mostWatchedPage/urdu/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/urdu/__snapshots__/canonical.test.js.snap
@@ -82,47 +82,40 @@ exports[`Canonical Most Watched Page Header Navigation link should match text an
 
 exports[`Canonical Most Watched Page Header Navigation link should match text and url 3`] = `
 {
-  "text": "الیکشن 2024",
-  "url": "/urdu/topics/cynd7qxprq0t",
-}
-`;
-
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 4`] = `
-{
   "text": "آس پاس",
   "url": "/urdu/topics/cl8l9mveql2t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 4`] = `
 {
   "text": "ورلڈ",
   "url": "/urdu/topics/cw57v2pmll9t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 5`] = `
 {
   "text": "کھیل",
   "url": "/urdu/topics/c340q0p2585t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 6`] = `
 {
   "text": "فن فنکار",
   "url": "/urdu/topics/ckdxnx900n5t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 7`] = `
 {
   "text": "سائنس",
   "url": "/urdu/topics/c40379e2ymxt",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 8`] = `
 {
   "text": "ویڈیو",
   "url": "/urdu/topics/c1e0mzr3r2yt",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
Update Afrique nav to add link to add link to Election topic and Urdu nav to remove the election topic link

Code changes
======

- Edited Navigation section of src/app/lib/config/services/afrique.ts to add election topic link in second position
- Edited Navigation section of src/app/lib/config/services/urdu.ts to remove election topic link from third position

Testing
======

1. Open Afrque's front page, second link in the nav should be Presidentielle Senegal 2024 and open the election topic
2. Open Urdu's front page, الیکشن 2024 should not appear as second link in the nav


<img width="1158" alt="fr-nav" src="https://github.com/bbc/simorgh/assets/10046386/d7589b53-fb32-4c22-ae05-6ccb4e41f8cc">
<img width="643" alt="ur_nav" src="https://github.com/bbc/simorgh/assets/10046386/45cadbdb-150d-453b-9abb-98986bc236f9">
 

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
