### PR TITLE
WSTEAMA-1122: Adding component health to the footer component

### DIFF
--- a/src/app/legacy/containers/Footer/index.stories.tsx
+++ b/src/app/legacy/containers/Footer/index.stories.tsx
@@ -6,6 +6,7 @@ import Footer from '.';
 import ThemeProvider from '../../../components/ThemeProvider';
 import { StoryProps } from '../../../models/types/storybook';
 import { RequestContextProvider } from '../../../contexts/RequestContext';
+import metadata from './metadata.json';
 
 interface Props extends StoryProps {
   isAmp?: boolean;
@@ -49,6 +50,7 @@ export default {
         1280, // Group 5
       ],
     },
+    metadata,
   },
 };
 

--- a/src/app/legacy/containers/Footer/metadata.json
+++ b/src/app/legacy/containers/Footer/metadata.json
@@ -1,0 +1,28 @@
+{
+  "lastUpdated": {
+    "day": 2,
+    "month": "April",
+    "year": 2024
+  },
+  "uxAccessibilityDoc": {
+    "done": true,
+    "reference": {
+      "url": "https://www.figma.com/file/dT9dPptb5PqGiHvY6ed7Ci/Legal-footer-credit-on-Indian-websites-PW?type=design&node-id=104%3A10&mode=design&t=ENGpSKATLxZ0NCwB-1",
+      "label": "Screen Reader UX"
+    }
+  },
+  "acceptanceCriteria": {
+    "done": true,
+    "reference": {
+      "url": "https://paper.dropbox.com/doc/Footer-additional-credit-on-6-Indian-sites-A11y-acceptance-criteria--CMeMVMf5WxRZA_U5L5ACqcr8Ag-sSKuqs9Vsss0ZXWKbAcki",
+      "label": "Accessibility Acceptance Criteria"
+    }
+  },
+  "swarm": {
+    "done": true,
+    "reference": {
+      "url": "https://paper.dropbox.com/doc/A11Y-Swarm-Footer-with-Legal-Credit-for-Indian-Services-Hdr4jK1smhwRXegcQQsjl",
+      "label": "A11y swarm notes"
+    }
+  }
+}


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAMA-1122

Overall changes
======
Adds component health to the footer component

Code changes
======
- Add metadata.json file for the footer component
- Add link to metadata file in the Footer component stories file

Testing
======
Component Health should be all green for the Footer container: 

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
