### PR TITLE
WSTEAM1-925 - Adds missing metadata and ati value for PGL render via Article page

### DIFF
--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -66,8 +66,12 @@ import { getPromoHeadline } from '../../lib/analyticsUtils/article';
 
 const ArticlePage = ({ pageData }) => {
   const { isApp } = useContext(RequestContext);
-  const { articleAuthor, isTrustProjectParticipant, showRelatedTopics } =
-    useContext(ServiceContext);
+  const {
+    articleAuthor,
+    isTrustProjectParticipant,
+    showRelatedTopics,
+    brandName,
+  } = useContext(ServiceContext);
   const { enabled: preloadLeadImageToggle } = useToggle('preloadLeadImage');
 
   const {
@@ -109,6 +113,11 @@ const ArticlePage = ({ pageData }) => {
     metadata: { atiAnalytics },
     mostRead: mostReadInitialData,
   } = pageData;
+
+  const atiData = {
+    ...atiAnalytics,
+    ...(isPGL && { pageTitle: `${atiAnalytics.pageTitle} - ${brandName}` }),
+  };
 
   const componentsToRender = {
     visuallyHiddenHeadline,
@@ -183,7 +192,7 @@ const ArticlePage = ({ pageData }) => {
 
   return (
     <div css={styles.pageWrapper}>
-      <ATIAnalytics atiData={atiAnalytics} />
+      <ATIAnalytics atiData={atiData} />
       <ChartbeatAnalytics
         sectionName={pageData?.relatedContent?.section?.name}
         title={getPromoHeadline(pageData)}
@@ -208,7 +217,11 @@ const ArticlePage = ({ pageData }) => {
       <LinkedData
         showAuthor
         bylineLinkedData={bylineLinkedData}
-        type={categoryName(isTrustProjectParticipant, taggings, formats)}
+        type={
+          !isPGL
+            ? categoryName(isTrustProjectParticipant, taggings, formats)
+            : 'Article'
+        }
         seoTitle={headline}
         headline={headline}
         description={description}

--- a/src/app/pages/ArticlePage/fixtureData.js
+++ b/src/app/pages/ArticlePage/fixtureData.js
@@ -38,6 +38,7 @@ const articleDataBuilder = (
   allowAdvertising = false,
   articleBlocksPopulator = blocksWithHeadlineAndText,
   atiAnalytics = {},
+  type = 'article',
 ) => ({
   metadata: {
     id: `urn:bbc:ares::article:${id}`,
@@ -48,7 +49,7 @@ const articleDataBuilder = (
     analyticsLabels: {
       contentId: 'urn:bbc:optimo:c0000000001o',
     },
-    type: 'article',
+    type,
     createdBy,
     created: 1514808060000,
     firstPublished: 1514808060000,
@@ -672,6 +673,33 @@ export const articleDataPidginWithByline = articleDataBuilder(
   emptyThings,
   undefined,
   blocksWithHeadlineTexAndByline,
+);
+
+export const articlePglDataPidgin = articleDataBuilder(
+  'cwl08rd38l6o',
+  'Pidgin',
+  'pcm',
+  'http://www.bbc.co.uk/ontologies/passport/home/Pidgin',
+  ['Article Headline in Pidgin', 'A paragraph in Pidgin.'],
+  'Article PGL Headline for SEO in Pidgin',
+  'Article PGL Headline for Promo in Pidgin',
+  'Article PGL summary in Pidgin',
+  emptyThings,
+  false,
+  blocksWithHeadlineAndText,
+  {
+    categoryName: null,
+    contentId: 'urn:bbc:optimo:c0000000001o',
+    language: 'pcm',
+    ldpThingIds: null,
+    ldpThingLabels: null,
+    nationsProducer: null,
+    pageIdentifier: null,
+    timePublished: '2018-01-01T12:01:00.000Z',
+    timeUpdated: '2018-01-01T14:00:00.000Z',
+    pageTitle: 'Article Headline for SEO in Pidgin',
+  },
+  'PGL',
 );
 
 export const bylineWithNoRole = [

--- a/src/app/pages/ArticlePage/index.test.jsx
+++ b/src/app/pages/ArticlePage/index.test.jsx
@@ -583,6 +583,40 @@ describe('Article Page', () => {
     expect(getByText('UGC Core Features 1 - Custom Form')).toBeInTheDocument();
   });
   describe('when rendering a PGL page', () => {
+    it('should not render secondary column', async () => {
+      const pageDataWithSecondaryColumn = {
+        ...articlePglDataPidgin,
+        secondaryColumn: {
+          topStories: [],
+          features: [],
+        },
+      };
+
+      const { queryByTestId } = render(
+        <Context service="pidgin">
+          <ArticlePage pageData={pageDataWithSecondaryColumn} />
+        </Context>,
+      );
+
+      expect(queryByTestId('top-stories')).not.toBeInTheDocument();
+      expect(queryByTestId('features')).not.toBeInTheDocument();
+    });
+
+    it('should not render most read', async () => {
+      const pageDataWithMostRead = {
+        ...articlePglDataPidgin,
+        mostRead: newsMostReadData,
+      };
+
+      const { queryByTestId } = render(
+        <Context service="pidgin">
+          <ArticlePage pageData={pageDataWithMostRead} />
+        </Context>,
+      );
+
+      expect(queryByTestId('most-read')).not.toBeInTheDocument();
+    });
+
     it('should add brandname to page title in atiAnalytics', async () => {
       ATIAnalytics.mockImplementation(() => <div />);
 
@@ -610,6 +644,7 @@ describe('Article Page', () => {
         {},
       );
     });
+
     it('should have schema metadata @type as Article', async () => {
       render(
         <Context service="pidgin">


### PR DESCRIPTION
Part of JIRA [WSTEAM1-925](https://jira.dev.bbc.co.uk/browse/WSTEAM1-925)

Overall changes
======
Adds missing pageTitle and corrects metadata type for PGL pages rendered with Article Page component via CAF

Code changes
======

- Adds missing pageTitle in ATI data for PGL
- Adds `Article` type for schema metadata for PGL

Testing
======
1. Start Simorgh
2. Visit http://localhost:7080/pidgin/50913502?renderer_env=live and http://localhost:7080/pidgin/50913502?renderer_env=caflive
3. Compare the schema metadata with an extension like Detailed SEO
4. Look at Network tab for ATI data

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
