### PR TITLE
Summary/key points block structure check

### DIFF
--- a/ws-nextjs-app/pages/[service]/live/[id]/KeyPoints/fixture.ts
+++ b/ws-nextjs-app/pages/[service]/live/[id]/KeyPoints/fixture.ts
@@ -184,3 +184,137 @@ export const multipleKeyPoints = {
     ],
   },
 };
+
+export const multipleKeyPointsWithEmptyParagraph = {
+  model: {
+    blocks: [
+      {
+        id: 'b329001a',
+        type: 'text',
+        model: {
+          blocks: [
+            {
+              id: '9322ebbf',
+              type: 'paragraph',
+              model: {
+                text: '',
+                blocks: [
+                  {
+                    id: '4083fc93',
+                    type: 'fragment',
+                    model: {
+                      text: '',
+                      attributes: [],
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              id: '5ebffdca',
+              type: 'unorderedList',
+              model: {
+                blocks: [
+                  {
+                    id: '3c096af1',
+                    type: 'listItem',
+                    model: {
+                      blocks: [
+                        {
+                          id: 'a4b2ec0b',
+                          type: 'paragraph',
+                          model: {
+                            text: 'I am the summary box',
+                            blocks: [
+                              {
+                                id: '5f43c969',
+                                type: 'fragment',
+                                model: {
+                                  text: 'I am the summary box',
+                                  attributes: [],
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  {
+                    id: '0822012f',
+                    type: 'listItem',
+                    model: {
+                      blocks: [
+                        {
+                          id: '7b1cd1c0',
+                          type: 'paragraph',
+                          model: {
+                            text: 'I need to include bulletpoints',
+                            blocks: [
+                              {
+                                id: '60633e01',
+                                type: 'fragment',
+                                model: {
+                                  text: 'I need to include bulletpoints',
+                                  attributes: [],
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  {
+                    id: '5ffdc35a',
+                    type: 'listItem',
+                    model: {
+                      blocks: [
+                        {
+                          id: '110c3e12',
+                          type: 'paragraph',
+                          model: {
+                            text: 'I want to link to somebody',
+                            blocks: [
+                              {
+                                id: '1371aa79',
+                                type: 'fragment',
+                                model: {
+                                  text: 'I want to ',
+                                  attributes: [],
+                                },
+                              },
+                              {
+                                id: 'b0c705da',
+                                type: 'urlLink',
+                                model: {
+                                  text: 'link to somebody',
+                                  blocks: [
+                                    {
+                                      id: '2aae7757',
+                                      type: 'fragment',
+                                      model: {
+                                        text: 'link to somebody',
+                                        attributes: [],
+                                      },
+                                    },
+                                  ],
+                                  locator: 'https://www.bbc.com/pidgin',
+                                  isExternal: false,
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+};

--- a/ws-nextjs-app/pages/[service]/live/[id]/KeyPoints/index.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/KeyPoints/index.test.tsx
@@ -5,11 +5,18 @@ import {
   act,
 } from '#app/components/react-testing-library-with-providers';
 import KeyPoints from '.';
-import { singleKeyPoint, multipleKeyPoints, emptyKeyPoints } from './fixture';
+import {
+  singleKeyPoint,
+  multipleKeyPoints,
+  emptyKeyPoints,
+  multipleKeyPointsWithEmptyParagraph,
+} from './fixture';
 
 const singleKeyPointBlocks = singleKeyPoint.model.blocks;
 const multipleKeyPointsBlocks = multipleKeyPoints.model.blocks;
 const emptyKeyPointsBlocks = emptyKeyPoints.model.blocks;
+const multipleKeyPointsWithEmptyParagraphBlocks =
+  multipleKeyPointsWithEmptyParagraph.model.blocks;
 
 describe('Key Points', () => {
   it('should render a section with data-e2e, role and aria-label attributes', async () => {
@@ -66,5 +73,23 @@ describe('Key Points', () => {
     });
 
     expect(container.querySelector('[data-e2e="key-points"]')).toBeFalsy();
+  });
+
+  it('should render other key points if given a malformed block', async () => {
+    await act(async () => {
+      render(
+        <KeyPoints
+          // @ts-expect-error - we are testing the component with a malformed block
+          keyPointsContent={multipleKeyPointsWithEmptyParagraphBlocks}
+        />,
+      );
+    });
+
+    expect(screen.getByText('I am the summary box')).toBeInTheDocument();
+    expect(
+      screen.getByText('I need to include bulletpoints'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('list')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
   });
 });

--- a/ws-nextjs-app/pages/[service]/live/[id]/KeyPoints/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/KeyPoints/index.tsx
@@ -27,8 +27,11 @@ const KeyPoints = ({
   } = useContext(ServiceContext);
 
   const listItems = keyPointsContent?.[0]?.model?.blocks?.[0]?.model?.blocks;
+
   if (!listItems || listItems.length === 0) return null;
-  const hasSingleKeyPoint = listItems.length === 1;
+
+  const hasSingleKeyPoint =
+    listItems.length === 1 && listItems?.[0]?.model?.blocks;
   const singleKeyPointComponentsToRender = { paragraph: LegacyParagraph };
 
   const componentsToRender = () => ({
@@ -57,7 +60,7 @@ const KeyPoints = ({
       <div css={styles.bodyStyles}>
         {hasSingleKeyPoint ? (
           <Blocks
-            blocks={listItems[0].model.blocks}
+            blocks={listItems[0].model.blocks ?? []}
             componentsToRender={singleKeyPointComponentsToRender}
           />
         ) : (


### PR DESCRIPTION
Overall changes
======
- Checks the structure of the first block in the summary/key points section to ensure it has content before attempting to use it as a 'single key point'
- The CMS can potentially return an "empty" nested block structure, so we need to double check it before trying to access and render it

Testing
======
1. Visit https://www.test.bbc.com/pidgin/live/cx747l228kjt. The page should be blank as it is erroring
2. Visit http://localhost:7081/pidgin/live/cx747l228kjt?renderer_env=test
3. Confirm that the page renders with the key points panel populated and the page is rendering correctly

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
