### PR TITLE
Adds missing brandName in ATI page title for CPS CAF pages

### DIFF
--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -108,6 +108,8 @@ const ArticlePage = ({ pageData }) => {
   );
   const recommendationsData = pathOr([], ['recommendations'], pageData);
   const isPGL = pageData?.metadata?.type === 'PGL';
+  const isSTY = pageData?.metadata?.type === 'STY';
+  const isCPS = isPGL || isSTY;
 
   const {
     metadata: { atiAnalytics },
@@ -116,7 +118,7 @@ const ArticlePage = ({ pageData }) => {
 
   const atiData = {
     ...atiAnalytics,
-    ...(isPGL && { pageTitle: `${atiAnalytics.pageTitle} - ${brandName}` }),
+    ...(isCPS && { pageTitle: `${atiAnalytics.pageTitle} - ${brandName}` }),
   };
 
   const componentsToRender = {

--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -38,6 +38,7 @@ import NielsenAnalytics from '#containers/NielsenAnalytics';
 import ScrollablePromo from '#components/ScrollablePromo';
 import CpsRecommendations from '#containers/CpsRecommendations';
 import InlinePodcastPromo from '#containers/PodcastPromo/Inline';
+import { PHOTO_GALLERY_PAGE, STORY_PAGE } from '#app/routes/utils/pageTypes';
 import ImageWithCaption from '../../components/ImageWithCaption';
 import AdContainer from '../../components/Ad';
 import EmbedImages from '../../components/Embeds/EmbedImages';
@@ -107,8 +108,8 @@ const ArticlePage = ({ pageData }) => {
     pageData,
   );
   const recommendationsData = pathOr([], ['recommendations'], pageData);
-  const isPGL = pageData?.metadata?.type === 'PGL';
-  const isSTY = pageData?.metadata?.type === 'STY';
+  const isPGL = pageData?.metadata?.type === PHOTO_GALLERY_PAGE;
+  const isSTY = pageData?.metadata?.type === STORY_PAGE;
   const isCPS = isPGL || isSTY;
 
   const {

--- a/src/app/pages/ArticlePage/fixtureData.js
+++ b/src/app/pages/ArticlePage/fixtureData.js
@@ -702,6 +702,33 @@ export const articlePglDataPidgin = articleDataBuilder(
   'PGL',
 );
 
+export const articleStyDataPidgin = articleDataBuilder(
+  'cwl08rd38l6o',
+  'Pidgin',
+  'pcm',
+  'http://www.bbc.co.uk/ontologies/passport/home/Pidgin',
+  ['Article Headline in Pidgin', 'A paragraph in Pidgin.'],
+  'Article PGL Headline for SEO in Pidgin',
+  'Article PGL Headline for Promo in Pidgin',
+  'Article PGL summary in Pidgin',
+  emptyThings,
+  false,
+  blocksWithHeadlineAndText,
+  {
+    categoryName: null,
+    contentId: 'urn:bbc:optimo:c0000000001o',
+    language: 'pcm',
+    ldpThingIds: null,
+    ldpThingLabels: null,
+    nationsProducer: null,
+    pageIdentifier: null,
+    timePublished: '2018-01-01T12:01:00.000Z',
+    timeUpdated: '2018-01-01T14:00:00.000Z',
+    pageTitle: 'Article Headline for SEO in Pidgin',
+  },
+  'STY',
+);
+
 export const bylineWithNoRole = [
   {
     type: 'contributor',

--- a/src/app/pages/ArticlePage/index.test.jsx
+++ b/src/app/pages/ArticlePage/index.test.jsx
@@ -15,6 +15,7 @@ import {
   promoSample,
   sampleRecommendations,
   articlePglDataPidgin,
+  articleStyDataPidgin,
 } from '#pages/ArticlePage/fixtureData';
 import { data as newsMostReadData } from '#data/news/mostRead/index.json';
 import { data as persianMostReadData } from '#data/persian/mostRead/index.json';
@@ -658,6 +659,35 @@ describe('Article Page', () => {
       ][0]['@type'];
 
       expect(schemaType).toEqual('Article');
+    });
+  });
+  describe('when rendering an STY page', () => {
+    it('should add brandname to page title in atiAnalytics', async () => {
+      ATIAnalytics.mockImplementation(() => <div />);
+
+      render(
+        <Context service="pidgin">
+          <ArticlePage pageData={articleStyDataPidgin} />
+        </Context>,
+      );
+
+      expect(ATIAnalytics).toHaveBeenLastCalledWith(
+        {
+          atiData: {
+            categoryName: null,
+            contentId: 'urn:bbc:optimo:c0000000001o',
+            language: 'pcm',
+            ldpThingIds: null,
+            ldpThingLabels: null,
+            nationsProducer: null,
+            pageIdentifier: null,
+            pageTitle: 'Article Headline for SEO in Pidgin - BBC News Pidgin',
+            timePublished: '2018-01-01T12:01:00.000Z',
+            timeUpdated: '2018-01-01T14:00:00.000Z',
+          },
+        },
+        {},
+      );
     });
   });
 });

--- a/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
@@ -5,6 +5,7 @@ import path from 'ramda/src/path';
 import pathOr from 'ramda/src/pathOr';
 import { jsx, useTheme, Theme } from '@emotion/react';
 import { OEmbedProps } from '#app/components/Embeds/types';
+import { MEDIA_ASSET_PAGE } from '#app/routes/utils/pageTypes';
 import useToggle from '../../hooks/useToggle';
 import {
   getArticleId,
@@ -120,7 +121,7 @@ const MediaArticlePage = ({ pageData }: MediaArticlePageProps) => {
     metadata: { atiAnalytics, type },
   } = pageData;
 
-  const isMap = type === 'MAP';
+  const isMap = type === MEDIA_ASSET_PAGE;
 
   const atiData = {
     ...atiAnalytics,

--- a/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
@@ -71,8 +71,12 @@ import {
 } from './types';
 
 const MediaArticlePage = ({ pageData }: MediaArticlePageProps) => {
-  const { articleAuthor, isTrustProjectParticipant, showRelatedTopics } =
-    useContext(ServiceContext);
+  const {
+    articleAuthor,
+    isTrustProjectParticipant,
+    showRelatedTopics,
+    brandName,
+  } = useContext(ServiceContext);
   const { enabled: preloadLeadImageToggle } = useToggle('preloadLeadImage');
 
   const {
@@ -117,6 +121,11 @@ const MediaArticlePage = ({ pageData }: MediaArticlePageProps) => {
   } = pageData;
 
   const isMap = type === 'MAP';
+
+  const atiData = {
+    ...atiAnalytics,
+    ...(isMap && { pageTitle: `${atiAnalytics.pageTitle} - ${brandName}` }),
+  };
 
   const componentsToRender = {
     fauxHeadline,
@@ -189,7 +198,7 @@ const MediaArticlePage = ({ pageData }: MediaArticlePageProps) => {
 
   return (
     <div css={styles.pageWrapper}>
-      <ATIAnalytics atiData={atiAnalytics} />
+      <ATIAnalytics atiData={atiData} />
       <ChartbeatAnalytics
         categoryName={pageData?.metadata?.passport?.category?.categoryName}
         title={headline}


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Builds on adding `brandName` to page title for pages rendered using CAF

Code changes
======

- Adds `brandName` to page title for STY pages
- Adds `brandName` to page title for MAP (Media Article Pages)
- Adds unit tests

Testing
======
1. Visit an STY or MAP page rendered via CAF
2. Check the x9 value of the ATI payload

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
