### PR TITLE
Render live page links in Top Stories

### DIFF
--- a/src/app/models/propTypes/storyItem/index.js
+++ b/src/app/models/propTypes/storyItem/index.js
@@ -1,4 +1,4 @@
-import { shape, string, number, arrayOf } from 'prop-types';
+import { shape, string, bool, number, arrayOf } from 'prop-types';
 
 export const storyItemImage = {
   path: string,
@@ -21,6 +21,12 @@ export const storyItem = {
   summary: string,
   timestamp: number,
   indexImage: shape(storyItemImage),
+};
+
+export const tipoLiveStoryItem = {
+  headline: string,
+  destinationUrl: string,
+  isLive: bool,
 };
 
 export const optimoStoryItem = {

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/TopStoriesItem/index.jsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/TopStoriesItem/index.jsx
@@ -1,8 +1,8 @@
 import React, { useContext, forwardRef } from 'react';
-import { shape, string } from 'prop-types';
+import { shape, string, oneOfType } from 'prop-types';
 import pathOr from 'ramda/src/pathOr';
 import isEmpty from 'ramda/src/isEmpty';
-import { storyItem } from '#models/propTypes/storyItem';
+import { storyItem, tipoLiveStoryItem } from '#models/propTypes/storyItem';
 import { getIsLive } from '#lib/utilities/getStoryPromoInfo';
 import Promo from '#components/OptimoPromos';
 import { ServiceContext } from '../../../../../contexts/ServiceContext';
@@ -138,7 +138,7 @@ const TopStoriesItem = forwardRef(
 );
 
 TopStoriesItem.propTypes = {
-  item: shape(storyItem).isRequired,
+  item: oneOfType([shape(storyItem), shape(tipoLiveStoryItem)]).isRequired,
   ariaLabelledBy: string.isRequired,
   eventTrackingData: shape({ block: shape({ componentName: string }) }),
 };

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/TopStoriesItem/index.jsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/TopStoriesItem/index.jsx
@@ -78,6 +78,7 @@ const TopStoriesItem = forwardRef(
     const itemExtractor = {
       optimo: getArticleTopStoryItem,
       cps: getArticleTopStoryItem,
+      link: getArticleTopStoryItem,
       'tipo-live': getLiveTopStoryItem,
     }[item?.type];
 

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/TopStoriesItem/index.test.jsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/TopStoriesItem/index.test.jsx
@@ -12,6 +12,7 @@ import {
   topStoriesLiveLabelItem,
   topStoriesMediaContentItem,
   tipoFormattedTopStoriesItem,
+  tipoLivePageTopStoriesItem,
 } from '../fixture';
 
 // eslint-disable-next-line react/prop-types
@@ -63,6 +64,23 @@ describe('Optimo Top Stories Promo Item', () => {
 
     expect(heading).toBeInTheDocument();
     expect(timestamp).toBeInTheDocument();
+  });
+
+  it('should render Top Stories item when data is from Tipo Live page', () => {
+    render(
+      <TopStoriesItemFixture
+        service="hindi"
+        fixtureData={tipoLivePageTopStoriesItem}
+      />,
+    );
+
+    const heading = screen.getByText(
+      'ईवीएम के मॉक टेस्ट में बीजेपी को वोट जाने की रिपोर्ट पर ईसी ने सुप्रीम कोर्ट में दिया जवाब',
+    );
+    const liveLabel = screen.getByText('लाइव');
+
+    expect(heading).toBeInTheDocument();
+    expect(liveLabel).toBeInTheDocument();
   });
 
   it('should return null if no data is passed', () => {

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/fixture/index.js
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/fixture/index.js
@@ -680,3 +680,27 @@ export const tipoFormattedTopStoriesItem = {
   id: 'urn:bbc:ares::article:c6vdqkm8yyvo',
   type: 'optimo',
 };
+
+export const tipoLivePageTopStoriesItem = {
+  headline:
+    'ईवीएम के मॉक टेस्ट में बीजेपी को वोट जाने की रिपोर्ट पर ईसी ने सुप्रीम कोर्ट में दिया जवाब',
+  destinationUrl: '/hindi/live/c0dewwj3lk1t',
+  isLive: true,
+  summary:
+    '17 अप्रैल को ऑनमनोरमा ने एक रिपोर्ट की थी कि केरल में ईवीएम ने गलती से मॉक टेस्ट में बीजेपी के पक्ष में वोट रजिस्टर किये.',
+  image: {
+    id: '6763c8e4-5f99-4101-acde-d0b91ccf41b0',
+    subType: 'promo',
+    href: 'http://c.files.bbci.co.uk/ec16/live/5a7550d0-fd21-11ee-97f7-e98b193ef1b8.jpg',
+    path: '/cpsprodpb/ec16/live/5a7550d0-fd21-11ee-97f7-e98b193ef1b8.jpg',
+    height: 682,
+    width: 1024,
+    altText: 'बाढ़',
+    copyrightHolder: 'Getty Images',
+    originCode: 'cpsprodpb',
+    type: 'image',
+  },
+  serviceIdentifier: 'hindi',
+  id: 'urn:bbc:tipo:topic:c0dewwj3lk1t',
+  type: 'tipo-live',
+};

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.jsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { useTheme } from '@emotion/react';
-import { arrayOf, shape } from 'prop-types';
-import { storyItem } from '#models/propTypes/storyItem';
+import { arrayOf, shape, oneOfType } from 'prop-types';
+import { storyItem, tipoLiveStoryItem } from '#models/propTypes/storyItem';
 import pathOr from 'ramda/src/pathOr';
 import path from 'ramda/src/path';
 import isEmpty from 'ramda/src/isEmpty';
@@ -107,7 +107,12 @@ const TopStoriesSection = ({ content }) => {
   );
 };
 
-TopStoriesSection.propTypes = { content: arrayOf(shape(storyItem)) };
+TopStoriesSection.propTypes = {
+  content: oneOfType([
+    arrayOf(shape(storyItem)),
+    arrayOf(shape(tipoLiveStoryItem)),
+  ]),
+};
 
 TopStoriesSection.defaultProps = { content: [] };
 

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.stories.jsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.stories.jsx
@@ -10,6 +10,7 @@ import {
   topStoriesItem,
   tipoFormattedTopStoriesItem,
   tipoLivePageTopStoriesItem,
+  topStoriesLiveLabelItem,
 } from './fixture';
 import metadata from './metadata.json';
 import readme from './README.md';
@@ -60,6 +61,7 @@ export const ListTopStoriesMixedDataSources = () => (
       topStoriesItem,
       tipoFormattedTopStoriesItem,
       tipoLivePageTopStoriesItem,
+      topStoriesLiveLabelItem,
     ]}
     service="news"
   />

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.stories.jsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.stories.jsx
@@ -7,6 +7,9 @@ import {
   topStoriesSingleItem,
   topStoriesListRtl,
   topStoriesSingleItemRtl,
+  topStoriesItem,
+  tipoFormattedTopStoriesItem,
+  tipoLivePageTopStoriesItem,
 } from './fixture';
 import metadata from './metadata.json';
 import readme from './README.md';
@@ -49,4 +52,15 @@ export const SingleTopStories = () => (
 
 export const SingleTopStoriesRtl = () => (
   <RelatedContentComponent content={topStoriesSingleItemRtl} service="arabic" />
+);
+
+export const ListTopStoriesMixedDataSources = () => (
+  <RelatedContentComponent
+    content={[
+      topStoriesItem,
+      tipoFormattedTopStoriesItem,
+      tipoLivePageTopStoriesItem,
+    ]}
+    service="news"
+  />
 );

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.test.jsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.test.jsx
@@ -55,12 +55,21 @@ describe('Optimo Top Stories Promo', () => {
       <TopStoriesSectionFixture service="hindi" fixtureData={mixtureFixture} />,
     );
 
-    const heading = screen.getByText(
+    const cpsHeading = screen.getByText(
+      'Covid antibodies in 1 in 10 people in December',
+    );
+    const optimoHeading = screen.getByText(
+      'Published at 12:19 - Индиянын Улуттук Конгресс партиясынын жаңы лидери шайланды',
+    );
+    const tipoLiveHeading = screen.getByText(
       'ईवीएम के मॉक टेस्ट में बीजेपी को वोट जाने की रिपोर्ट पर ईसी ने सुप्रीम कोर्ट में दिया जवाब',
     );
     const liveLabel = screen.getByText('लाइव');
 
-    expect(heading).toBeInTheDocument();
+    expect(cpsHeading).toBeInTheDocument();
+    expect(optimoHeading).toBeInTheDocument();
+    expect(tipoLiveHeading).toBeInTheDocument();
+
     expect(liveLabel).toBeInTheDocument();
   });
 

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.test.jsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.test.jsx
@@ -15,6 +15,7 @@ import {
   topStoriesItem,
   tipoFormattedTopStoriesItem,
   tipoLivePageTopStoriesItem,
+  topStoriesLiveLabelItem,
 } from './fixture';
 
 // eslint-disable-next-line react/prop-types
@@ -49,6 +50,7 @@ describe('Optimo Top Stories Promo', () => {
       topStoriesItem,
       tipoFormattedTopStoriesItem,
       tipoLivePageTopStoriesItem,
+      topStoriesLiveLabelItem,
     ];
 
     render(
@@ -64,13 +66,18 @@ describe('Optimo Top Stories Promo', () => {
     const tipoLiveHeading = screen.getByText(
       'ईवीएम के मॉक टेस्ट में बीजेपी को वोट जाने की रिपोर्ट पर ईसी ने सुप्रीम कोर्ट में दिया जवाब',
     );
-    const liveLabel = screen.getByText('लाइव');
+    const cpsLiveHeading = screen.getByText(
+      "Covid death toll in UK 'now close to 96,000'",
+    );
+
+    const liveLabel = screen.getAllByText('लाइव');
 
     expect(cpsHeading).toBeInTheDocument();
     expect(optimoHeading).toBeInTheDocument();
     expect(tipoLiveHeading).toBeInTheDocument();
+    expect(cpsLiveHeading).toBeInTheDocument();
 
-    expect(liveLabel).toBeInTheDocument();
+    expect(liveLabel).toHaveLength(2);
   });
 
   it('should render a default title if translations are not available', () => {

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.test.jsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.test.jsx
@@ -9,7 +9,13 @@ import {
 } from '../../../../components/react-testing-library-with-providers';
 import { ServiceContextProvider } from '../../../../contexts/ServiceContext';
 import TopStoriesSection from '.';
-import { topStoriesList, topStoriesSingleItem } from './fixture';
+import {
+  topStoriesList,
+  topStoriesSingleItem,
+  topStoriesItem,
+  tipoFormattedTopStoriesItem,
+  tipoLivePageTopStoriesItem,
+} from './fixture';
 
 // eslint-disable-next-line react/prop-types
 const TopStoriesSectionFixture = ({ fixtureData, service = 'mundo' }) => (
@@ -36,6 +42,26 @@ describe('Optimo Top Stories Promo', () => {
     const list = container.querySelector('ul');
     expect(listItems.length).toBe(3);
     expect(list).toBeInTheDocument();
+  });
+
+  it('should render a mixture of Top Stories items for CPS, Optimo and Tipo data', () => {
+    const mixtureFixture = [
+      topStoriesItem,
+      tipoFormattedTopStoriesItem,
+      tipoLivePageTopStoriesItem,
+    ];
+
+    render(
+      <TopStoriesSectionFixture service="hindi" fixtureData={mixtureFixture} />,
+    );
+
+    const heading = screen.getByText(
+      'ईवीएम के मॉक टेस्ट में बीजेपी को वोट जाने की रिपोर्ट पर ईसी ने सुप्रीम कोर्ट में दिया जवाब',
+    );
+    const liveLabel = screen.getByText('लाइव');
+
+    expect(heading).toBeInTheDocument();
+    expect(liveLabel).toBeInTheDocument();
   });
 
   it('should render a default title if translations are not available', () => {


### PR DESCRIPTION
Overall changes
======
- Adds logic to check for the `tipo-live` top story item in the Top Stories list

Code changes
======
- Adds data transformer for `tipo-live` top story type and abstracts out the existing Optimo/CPS types into their own transformer (retaining existing logic)
- Updates tests and prop-types for the Top Stories list components

Testing
======
1. Visit http://localhost:7080/hindi/articles/cqeny5qm5j1o?renderer_env=live and http://localhost:7080/news/articles/cj7xrxz0e8zo?renderer_env=live
2. Confirm that the Live page link appears in the Top Stories list and has a valid link

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
