### PR TITLE
WSTEAM1-959: Add amp to cpsAsset article fetch

### DIFF
--- a/src/app/routes/cpsAsset/getInitialData/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/index.js
@@ -106,6 +106,7 @@ export default async ({
   pageType,
   toggles,
   isCaf,
+  isAmp,
 }) => {
   try {
     const { service: derivedService, path: derivedPath } =
@@ -119,6 +120,7 @@ export default async ({
       service: derivedService,
       variant,
       pageType: isCaf ? 'article' : 'cpsAsset',
+      isAmp,
     });
 
     if (status !== 200) {


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-959](https://jira.dev.bbc.co.uk/browse/WSTEAM1-959)

Overall changes
======
Adds isAmp param to article fetch through cps.

Code changes
======
- _Adds isAmp param to article fetch through cpsAsset getInitialData._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
