### PR TITLE
Extract CPS ID for CAF assets in Cypress E2Es

### DIFF
--- a/cypress/support/commands/application.js
+++ b/cypress/support/commands/application.js
@@ -122,13 +122,13 @@ export const getPageData = ({ service, pageType, variant = 'default', id }) => {
     }
     const ctxServEnv = ctxEnv || env;
 
-    const optimoAssetId = getCpsId(Cypress.env('currentPath'))
+    const articleAssetId = getCpsId(Cypress.env('currentPath'))
       ? `${service}/${getCpsId(Cypress.env('currentPath'))}`
       : getOptimoId(Cypress.env('currentPath'));
 
     const pageTypeId =
       id ||
-      (pageType === 'cpsAsset' ? Cypress.env('currentPath') : optimoAssetId);
+      (pageType === 'cpsAsset' ? Cypress.env('currentPath') : articleAssetId);
 
     const bffUrl = `https://web-cdn.${
       env === 'live' ? '' : `${env}.`

--- a/cypress/support/commands/application.js
+++ b/cypress/support/commands/application.js
@@ -6,6 +6,10 @@
 // - Certain types of network error are retried automatically (retryOnNetworkFailure)
 import config from '../config/services';
 
+const getCpsId = path =>
+  path.match(/([0-9]{5,9}|[a-z0-9\-_]+-[0-9]{5,9})$/)?.[1];
+const getOptimoId = path => path.match(/(c[a-zA-Z0-9]{10}(o|t))/)?.[1];
+
 export const testResponseCodeAndType = ({
   path,
   responseCode,
@@ -117,11 +121,15 @@ export const getPageData = ({ service, pageType, variant = 'default', id }) => {
         : 'live';
     }
     const ctxServEnv = ctxEnv || env;
+
+    const optimoAssetId = getCpsId(Cypress.env('currentPath'))
+      ? `${service}/${getCpsId(Cypress.env('currentPath'))}`
+      : getOptimoId(Cypress.env('currentPath'));
+
     const pageTypeId =
       id ||
-      (pageType === 'cpsAsset'
-        ? Cypress.env('currentPath')
-        : Cypress.env('currentPath').match(/(c[a-zA-Z0-9]{10}(o|t))/)?.[1]);
+      (pageType === 'cpsAsset' ? Cypress.env('currentPath') : optimoAssetId);
+
     const bffUrl = `https://web-cdn.${
       env === 'live' ? '' : `${env}.`
     }api.bbci.co.uk/fd/simorgh-bff?pageType=${pageType}&id=${pageTypeId}&service=${service}${


### PR DESCRIPTION
Overall changes
======
- Adds ID extraction logic for Test/Live E2Es to get the correct asset ID for CPS and Optimo assets in CAF.

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
