### PR TITLE
Simplify caf id e2e extraction

### DIFF
--- a/cypress/support/commands/application.js
+++ b/cypress/support/commands/application.js
@@ -121,9 +121,9 @@ export const getPageData = ({ service, pageType, variant = 'default', id }) => {
     const ctxServEnv = ctxEnv || env;
 
     const assetId =
-      id ||
-      getOptimoOrTipoId(Cypress.env('currentPath')) ||
-      `${Cypress.env('currentPath')}`;
+      id || // passed in as an argument
+      getOptimoOrTipoId(Cypress.env('currentPath')) || // Extract Optimo or Tipo ID from the current path
+      `${Cypress.env('currentPath')}`; // Extract the current path as the asset ID (typically CPS pages)
 
     const bffUrl = `https://web-cdn.${
       env === 'live' ? '' : `${env}.`

--- a/cypress/support/commands/application.js
+++ b/cypress/support/commands/application.js
@@ -6,8 +6,6 @@
 // - Certain types of network error are retried automatically (retryOnNetworkFailure)
 import config from '../config/services';
 
-const getCpsId = path =>
-  path.match(/([0-9]{5,9}|[a-z0-9\-_]+-[0-9]{5,9})$/)?.[1];
 const getOptimoId = path => path.match(/(c[a-zA-Z0-9]{10}(o|t))/)?.[1];
 
 export const testResponseCodeAndType = ({
@@ -122,9 +120,9 @@ export const getPageData = ({ service, pageType, variant = 'default', id }) => {
     }
     const ctxServEnv = ctxEnv || env;
 
-    const articleAssetId = getCpsId(Cypress.env('currentPath'))
-      ? `${service}/${getCpsId(Cypress.env('currentPath'))}`
-      : getOptimoId(Cypress.env('currentPath'));
+    const articleAssetId =
+      getOptimoId(Cypress.env('currentPath')) ||
+      `${Cypress.env('currentPath')}`;
 
     const pageTypeId =
       id ||

--- a/cypress/support/commands/application.js
+++ b/cypress/support/commands/application.js
@@ -6,7 +6,7 @@
 // - Certain types of network error are retried automatically (retryOnNetworkFailure)
 import config from '../config/services';
 
-const getOptimoId = path => path.match(/(c[a-zA-Z0-9]{10}(o|t))/)?.[1];
+const getOptimoOrTipoId = path => path.match(/(c[a-zA-Z0-9]{10}(o|t))/)?.[1];
 
 export const testResponseCodeAndType = ({
   path,
@@ -120,17 +120,14 @@ export const getPageData = ({ service, pageType, variant = 'default', id }) => {
     }
     const ctxServEnv = ctxEnv || env;
 
-    const articleAssetId =
-      getOptimoId(Cypress.env('currentPath')) ||
-      `${Cypress.env('currentPath')}`;
-
-    const pageTypeId =
+    const assetId =
       id ||
-      (pageType === 'cpsAsset' ? Cypress.env('currentPath') : articleAssetId);
+      getOptimoOrTipoId(Cypress.env('currentPath')) ||
+      `${Cypress.env('currentPath')}`;
 
     const bffUrl = `https://web-cdn.${
       env === 'live' ? '' : `${env}.`
-    }api.bbci.co.uk/fd/simorgh-bff?pageType=${pageType}&id=${pageTypeId}&service=${service}${
+    }api.bbci.co.uk/fd/simorgh-bff?pageType=${pageType}&id=${assetId}&service=${service}${
       variant !== 'default' ? `&variant=${variant}` : ''
     }`;
     return cy.request({


### PR DESCRIPTION
Overall changes
======
- Simplify overall logic of getting the ID for the asset in Test/Live E2Es

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
