### PR TITLE
Return `path` if CPS and Optimo ID checks fail

### DIFF
--- a/src/app/routes/article/getInitialData/index.test.ts
+++ b/src/app/routes/article/getInitialData/index.test.ts
@@ -243,29 +243,6 @@ describe('Articles - BFF Fetching', () => {
     });
   });
 
-  it('should throw an error if the article ID is malformed', async () => {
-    const fetchDataSpy = jest.spyOn(fetchPageData, 'default');
-    fetchDataSpy.mockImplementation(() =>
-      Promise.resolve({
-        status: 200,
-        json: JSON.stringify(bffArticleJson),
-      }),
-    );
-
-    await getInitialData({
-      path: '/kyrgyz/articles/somethingelse',
-      service: 'kyrgyz',
-      pageType: ARTICLE_PAGE,
-    });
-
-    expect(nodeLogger.error).toHaveBeenCalledWith(BFF_FETCH_ERROR, {
-      pathname: '/kyrgyz/articles/somethingelse',
-      service: 'kyrgyz',
-      message: 'Article ID is invalid',
-      status: 500,
-    });
-  });
-
   it('should throw an error if the article metadata is malformed', async () => {
     const malformedBffArticleJson = {
       metadata: {},

--- a/src/app/routes/utils/constructPageFetchUrl/index.test.ts
+++ b/src/app/routes/utils/constructPageFetchUrl/index.test.ts
@@ -133,14 +133,12 @@ describe('constructPageFetchUrl', () => {
   );
 
   it.each`
-    pageType        | service        | pathname                             | expected
-    ${ARTICLE_PAGE} | ${'ukrainian'} | ${'/ukrainian/articles/foo'}         | ${'Article ID is invalid'}
-    ${ARTICLE_PAGE} | ${'ukrainian'} | ${'/ukrainian/articles/c000000000o'} | ${'Article ID is invalid'}
-    ${HOME_PAGE}    | ${'foo'}       | ${'/foo/c0000000000t'}               | ${'Home ID is invalid'}
-    ${LIVE_PAGE}    | ${'ukrainian'} | ${'foo'}                             | ${'Live ID is invalid'}
-    ${TOPIC_PAGE}   | ${'ukrainian'} | ${'/ukrainian/topics/foo'}           | ${'Topic ID is invalid'}
-    ${TOPIC_PAGE}   | ${'ukrainian'} | ${'/ukrainian/topics/c000000000t'}   | ${'Topic ID is invalid'}
-    ${'foo'}        | ${'ukrainian'} | ${'/ukrainian/topics/c0000000000t'}  | ${'Foo ID is invalid'}
+    pageType      | service        | pathname                            | expected
+    ${HOME_PAGE}  | ${'foo'}       | ${'/foo/c0000000000t'}              | ${'Home ID is invalid'}
+    ${LIVE_PAGE}  | ${'ukrainian'} | ${'foo'}                            | ${'Live ID is invalid'}
+    ${TOPIC_PAGE} | ${'ukrainian'} | ${'/ukrainian/topics/foo'}          | ${'Topic ID is invalid'}
+    ${TOPIC_PAGE} | ${'ukrainian'} | ${'/ukrainian/topics/c000000000t'}  | ${'Topic ID is invalid'}
+    ${'foo'}      | ${'ukrainian'} | ${'/ukrainian/topics/c0000000000t'} | ${'Foo ID is invalid'}
   `(
     `should throw a 500 with message $expected, when pageType $pageType asset ID is incorrect with service of $service`,
     ({ pageType, service, pathname, expected }) => {

--- a/src/app/routes/utils/constructPageFetchUrl/index.ts
+++ b/src/app/routes/utils/constructPageFetchUrl/index.ts
@@ -75,7 +75,7 @@ const getId = ({ pageType, service, variant, env }: GetIdProps) => {
         if (isOptimoId) return getArticleId(path);
         if (isCpsId) return getCpsId(path);
 
-        return null;
+        return path;
       };
       break;
     case CPS_ASSET:


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Always returns some kind of `path` from the `ARTICLE_PAGE` case, as we now support much more types of IDs for this page type. 

Removed test to check `invalid article`, as we will always get a `path` and will let our API propagate errors. 

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
