### PR TITLE
Add `lite` to platform list

### DIFF
--- a/src/app/components/react-testing-library-with-providers.tsx
+++ b/src/app/components/react-testing-library-with-providers.tsx
@@ -15,6 +15,7 @@ interface Props extends PropsWithChildren {
   id?: string | null;
   isAmp?: boolean;
   isApp?: boolean;
+  isLite?: boolean;
   pageData?: object;
   atiData?: {
     contentId?: string;
@@ -43,6 +44,7 @@ const AllTheProviders: FC<Props> = ({
   id = null,
   isAmp = false,
   isApp = false,
+  isLite = false,
   bbcOrigin = 'https://www.test.bbc.com',
   pageType = 'article',
   derivedPageType,
@@ -69,6 +71,7 @@ const AllTheProviders: FC<Props> = ({
           pageType={pageType}
           isAmp={isAmp}
           isApp={isApp}
+          isLite={isLite}
           isNextJs={isNextJs}
           service={service}
           pathname={pathname}
@@ -98,6 +101,7 @@ const customRender = (
     id,
     isAmp,
     isApp,
+    isLite,
     bbcOrigin,
     pageData,
     pageType,
@@ -120,6 +124,7 @@ const customRender = (
         id={id}
         isAmp={isAmp}
         isApp={isApp}
+        isLite={isLite}
         bbcOrigin={bbcOrigin}
         pageData={pageData}
         atiData={atiData}

--- a/src/app/contexts/RequestContext/index.tsx
+++ b/src/app/contexts/RequestContext/index.tsx
@@ -103,6 +103,8 @@ export const RequestContextProvider = ({
         return 'app';
       case isAmp:
         return 'amp';
+      case isLite:
+        return 'lite';
       default:
         return 'canonical';
     }

--- a/src/app/models/types/global.ts
+++ b/src/app/models/types/global.ts
@@ -2,7 +2,7 @@ import * as PAGE_TYPES from '../../routes/utils/pageTypes';
 
 export type Environments = 'local' | 'test' | 'live';
 
-export type Platforms = 'amp' | 'canonical' | 'app';
+export type Platforms = 'amp' | 'canonical' | 'app' | 'lite';
 
 export type Direction = 'rtl' | 'ltr';
 


### PR DESCRIPTION
Overall changes
======
- Adds `lite` to global `Platforms` type
- Adds check for `isLite` when setting the `platform` in `RequestContext`
- This should trickle down and set the `platform` field in analytics

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
