### PR TITLE
Billboard Uses Content Summaries Summary title instead of Topic returned title for Heading

### DIFF
--- a/src/app/components/Curation/index.tsx
+++ b/src/app/components/Curation/index.tsx
@@ -109,7 +109,7 @@ export default ({
         ) : (
           <div css={styles.billboardContainer}>
             <Billboard
-              heading={title}
+              heading={firstSummary.title}
               description={description}
               link={summaryLink}
               image={imageUrl}


### PR DESCRIPTION
Linked to https://jira.dev.bbc.co.uk/browse/WSTEAMA-1189 

As described. No test updates or coverage increases required.
