### PR TITLE
 WSTEAMA-749: Update service worker tests and URL generation logic

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -12,7 +12,7 @@ self.addEventListener('install', event => {
 
 const fetchEventHandler = async event => {
   if (
-    /^https:\/\/ichef(\.test)?\.bbci\.co\.uk\/(news|ace\/(standard|ws))\/.+(\.jpg|\.png).webp$/.test(
+    /^https:\/\/ichef(\.test)?\.bbci\.co\.uk\/(news|ace\/(standard|ws))\/.+.webp$/.test(
       event.request.url,
     )
   ) {

--- a/public/sw.js
+++ b/public/sw.js
@@ -12,7 +12,7 @@ self.addEventListener('install', event => {
 
 const fetchEventHandler = async event => {
   if (
-    /^https:\/\/ichef(\.test)?\.bbci\.co\.uk\/(news|ace\/(standard|ws))\/.+\.webp$/.test(
+    /^https:\/\/ichef(\.test)?\.bbci\.co\.uk\/(news|ace\/(standard|ws))\/.+(\.jpg|\.png)\.webp$/.test(
       event.request.url,
     )
   ) {

--- a/public/sw.js
+++ b/public/sw.js
@@ -12,7 +12,9 @@ self.addEventListener('install', event => {
 
 const fetchEventHandler = async event => {
   if (
-    /^https:\/\/ichef(\.test)?\.bbci\.co\.uk\/.+\.webp$/.test(event.request.url)
+    /^https:\/\/ichef(\.test)?\.bbci\.co\.uk\/(news|ace\/(standard|ws))\/.+(\.jpg|\.png).webp$/.test(
+      event.request.url,
+    )
   ) {
     const req = event.request.clone();
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -12,7 +12,7 @@ self.addEventListener('install', event => {
 
 const fetchEventHandler = async event => {
   if (
-    /^https:\/\/ichef(\.test)?\.bbci\.co\.uk\/(news|ace\/(standard|ws))\/.+.webp$/.test(
+    /^https:\/\/ichef(\.test)?\.bbci\.co\.uk\/(news|images|ace\/(standard|ws))\/.+.webp$/.test(
       event.request.url,
     )
   ) {

--- a/src/app/lib/utilities/ichefURL/index.js
+++ b/src/app/lib/utilities/ichefURL/index.js
@@ -1,12 +1,17 @@
 import { getEnvConfig } from '../getEnvConfig';
 
-const webpSupportedPatterns = [
-  /^https:\/\/ichef(?:\.test)?\.bbci\.co\.uk\/(?:news|ace\/(?:standard|ws))\/.+(?:\.jpg|\.png)$/,
-  /\/ace\/(?:standard|ws)\/.+(?:\/amz\/worldservice\/)?.*/,
-];
+// const webpSupportedPatterns = [
+//   /^https:\/\/ichef(?:\.test)?\.bbci\.co\.uk\/(?:news|ace\/(?:standard|ws))\/.+(?:\.jpg|\.png)$/,
+//   /\/ace\/(?:standard|ws)\/.+(?:\/amz\/worldservice\/)?.*/,
+// ];
 
-const isSupportedWebpUrl = url =>
-  webpSupportedPatterns.every(pattern => pattern.test(url));
+const isSupportedWebpUrl = url => {
+  return (
+    /^https:\/\/ichef(?:\.test)?\.bbci\.co\.uk\/(?:news|ace\/(?:standard|ws))\/.+(?:\.jpg|\.png)$/.test(
+      url,
+    ) && !/\/news\/.+\/amz\/worldservice\/.*/.test(url)
+  );
+};
 
 const buildPlaceholderSrc = (src, resolution) => {
   const imageSrc =
@@ -27,15 +32,19 @@ const buildPlaceholderSrc = (src, resolution) => {
   return `https://${newUrl.join('/')}`;
 };
 
-const buildIChefURL = ({ originCode, locator, resolution }) => {
+const buildIChefURL = ({
+  originCode,
+  locator,
+  resolution,
+  ichefSubdomain = 'ace/ws',
+}) => {
   if (originCode === 'mpv' || originCode === 'pips') {
     return buildPlaceholderSrc(locator, resolution);
   }
 
   const url = [
     getEnvConfig().SIMORGH_ICHEF_BASE_URL || 'https://ichef.bbci.co.uk',
-    'ace',
-    'ws',
+    ichefSubdomain,
     resolution,
     originCode,
     locator,

--- a/src/app/lib/utilities/ichefURL/index.js
+++ b/src/app/lib/utilities/ichefURL/index.js
@@ -2,7 +2,7 @@ import { getEnvConfig } from '../getEnvConfig';
 
 const webpSupportedPatterns = [
   /^https:\/\/ichef(\.test)?\.bbci\.co\.uk\/(news|ace\/(standard|ws))\/.+(\.jpg|\.png)$/,
-  /\/ace\/(standard|ws)\/.+\/amz\/worldservice\/.*/,
+  /\/ace\/(standard|ws)\/.+(\/amz\/worldservice\/)?.*/,
 ];
 
 const isSupportedWebpUrl = url =>
@@ -43,9 +43,7 @@ const buildIChefURL = ({ originCode, locator, resolution }) => {
     .filter(Boolean)
     .join('/');
 
-  return url.endsWith('.webp') || !isSupportedWebpUrl(url)
-    ? url
-    : `${url}.webp`;
+  return isSupportedWebpUrl(url) ? `${url}.webp` : url;
 };
 
 export default buildIChefURL;

--- a/src/app/lib/utilities/ichefURL/index.js
+++ b/src/app/lib/utilities/ichefURL/index.js
@@ -1,5 +1,20 @@
 import { getEnvConfig } from '../getEnvConfig';
 
+/*
+The pattern below:
+matches
+  https://ichef.test.bbci.co.uk/news/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg
+  https://ichef.bbci.co.uk/news/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg
+  https://ichef.test.bbci.co.uk/ace/ws/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg
+  https://ichef.bbci.co.uk/ace/standard/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png
+  https://ichef.test.bbci.co.uk/ace/ws/660/amz/worldservice/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg
+  https://ichef.bbci.co.uk/ace/standard/660/amz/worldservice/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png
+
+does not match
+  https://ichef.test.bbci.co.uk/news/660/amz/worldservice/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg
+  https://ichef.bbci.co.uk/news/660/amz/worldservice/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png
+*/
+
 const webpSupportedPatterns = [
   /^https:\/\/ichef(?:\.test)?\.bbci\.co\.uk\/(?:news|ace\/(?:standard|ws))\/.+(?:\.jpg|\.png)$/,
   /(?:\/ace\/(?:standard|ws)\/.+\/(?:amz\/worldservice\/)?|\/news\/(?!.+\/amz\/worldservice\/)).*/,

--- a/src/app/lib/utilities/ichefURL/index.js
+++ b/src/app/lib/utilities/ichefURL/index.js
@@ -1,5 +1,13 @@
 import { getEnvConfig } from '../getEnvConfig';
 
+const webpSupportedPatterns = [
+  /^https:\/\/ichef(\.test)?\.bbci\.co\.uk\/(news|ace\/(standard|ws))\/.+(\.jpg|\.png)$/,
+  /\/ace\/(standard|ws)\/.+\/amz\/worldservice\/.*/,
+];
+
+const isSupportedWebpUrl = url =>
+  webpSupportedPatterns.every(pattern => pattern.test(url));
+
 const buildPlaceholderSrc = (src, resolution) => {
   const imageSrc =
     src || 'https://ichef.bbci.co.uk/images/ic/640xn/p0b36kgx.png';
@@ -35,8 +43,7 @@ const buildIChefURL = ({ originCode, locator, resolution }) => {
     .filter(Boolean)
     .join('/');
 
-  return url.endsWith('.webp') ||
-    (url.includes('amz/worldservice') && !url.includes('ace/standard'))
+  return url.endsWith('.webp') || !isSupportedWebpUrl(url)
     ? url
     : `${url}.webp`;
 };

--- a/src/app/lib/utilities/ichefURL/index.js
+++ b/src/app/lib/utilities/ichefURL/index.js
@@ -1,8 +1,8 @@
 import { getEnvConfig } from '../getEnvConfig';
 
 const webpSupportedPatterns = [
-  /^https:\/\/ichef(\.test)?\.bbci\.co\.uk\/(news|ace\/(standard|ws))\/.+(\.jpg|\.png)$/,
-  /\/ace\/(standard|ws)\/.+(\/amz\/worldservice\/)?.*/,
+  /^https:\/\/ichef(?:\.test)?\.bbci\.co\.uk\/(?:news|ace\/(?:standard|ws))\/.+(?:\.jpg|\.png)$/,
+  /\/ace\/(?:standard|ws)\/.+(?:\/amz\/worldservice\/)?.*/,
 ];
 
 const isSupportedWebpUrl = url =>

--- a/src/app/lib/utilities/ichefURL/index.js
+++ b/src/app/lib/utilities/ichefURL/index.js
@@ -1,17 +1,12 @@
 import { getEnvConfig } from '../getEnvConfig';
 
-// const webpSupportedPatterns = [
-//   /^https:\/\/ichef(?:\.test)?\.bbci\.co\.uk\/(?:news|ace\/(?:standard|ws))\/.+(?:\.jpg|\.png)$/,
-//   /\/ace\/(?:standard|ws)\/.+(?:\/amz\/worldservice\/)?.*/,
-// ];
+const webpSupportedPatterns = [
+  /^https:\/\/ichef(?:\.test)?\.bbci\.co\.uk\/(?:news|ace\/(?:standard|ws))\/.+(?:\.jpg|\.png)$/,
+  /(?:\/ace\/(?:standard|ws)\/.+\/(?:amz\/worldservice\/)?|\/news\/(?!.+\/amz\/worldservice\/)).*/,
+];
 
-const isSupportedWebpUrl = url => {
-  return (
-    /^https:\/\/ichef(?:\.test)?\.bbci\.co\.uk\/(?:news|ace\/(?:standard|ws))\/.+(?:\.jpg|\.png)$/.test(
-      url,
-    ) && !/\/news\/.+\/amz\/worldservice\/.*/.test(url)
-  );
-};
+const isSupportedWebpUrl = url =>
+  webpSupportedPatterns.every(pattern => pattern.test(url));
 
 const buildPlaceholderSrc = (src, resolution) => {
   const imageSrc =

--- a/src/app/lib/utilities/ichefURL/index.test.js
+++ b/src/app/lib/utilities/ichefURL/index.test.js
@@ -49,6 +49,38 @@ describe('getIchefURL', () => {
         expect(getIChefURL(input)).toEqual(expectedURL);
       },
     );
+
+    it.each`
+      ichefSubdomain    | originCode     | locator                                                                                                   | expectedURL
+      ${undefined}      | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp'}                                              | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${undefined}      | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp'}                                              | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${undefined}      | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp'}                                              | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${undefined}      | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp'}                                              | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${undefined}      | ${'amz'}       | ${'worldservice/live/assets/images/2013/08/19/130819164754_ardeshir_zahedi_112x63_bbc_nocredit.jpg.webp'} | ${`${BASE_IMAGE_URL}/ace/ws/660/amz/worldservice/live/assets/images/2013/08/19/130819164754_ardeshir_zahedi_112x63_bbc_nocredit.jpg.webp`}
+      ${undefined}      | ${'amz'}       | ${'worldservice/live/assets/images/2015/05/08/150508054332_cameron_624x351_afp.png.webp'}                 | ${`${BASE_IMAGE_URL}/ace/ws/660/amz/worldservice/live/assets/images/2015/05/08/150508054332_cameron_624x351_afp.png.webp`}
+      ${'ace/standard'} | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp'}                                              | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'ace/standard'} | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp'}                                              | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${'ace/standard'} | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp'}                                              | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'ace/standard'} | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp'}                                              | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${'ace/standard'} | ${'amz'}       | ${'worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp'}                                           | ${`${BASE_IMAGE_URL}/ace/standard/660/amz/worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'ace/standard'} | ${'amz'}       | ${'worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp'}                                           | ${`${BASE_IMAGE_URL}/ace/standard/660/amz/worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${'news'}         | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp'}                                              | ${`${BASE_IMAGE_URL}/news/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'news'}         | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp'}                                              | ${`${BASE_IMAGE_URL}/news/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${'news'}         | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp'}                                              | ${`${BASE_IMAGE_URL}/news/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'news'}         | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp'}                                              | ${`${BASE_IMAGE_URL}/news/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+    `(
+      `the .webp extension is not appended to the URL for $locator`,
+      ({ ichefSubdomain, originCode, locator, expectedURL }) => {
+        const input = {
+          originCode,
+          locator,
+          resolution: '660',
+          ichefSubdomain,
+        };
+
+        expect(getIChefURL(input)).toEqual(expectedURL);
+      },
+    );
   });
 
   it('builds standard ichef img url with originCode mpv', () => {

--- a/src/app/lib/utilities/ichefURL/index.test.js
+++ b/src/app/lib/utilities/ichefURL/index.test.js
@@ -17,18 +17,33 @@ describe('getIchefURL', () => {
     const BASE_IMAGE_URL = 'https://ichef.bbci.co.uk';
 
     it.each`
-      originCode     | locator                                                                                              | expectedURL
-      ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                              | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
-      ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                              | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
-      ${'amz'}       | ${'worldservice/live/assets/images/2013/08/19/130819164754_ardeshir_zahedi_112x63_bbc_nocredit.jpg'} | ${`${BASE_IMAGE_URL}/ace/ws/660/amz/worldservice/live/assets/images/2013/08/19/130819164754_ardeshir_zahedi_112x63_bbc_nocredit.jpg.webp`}
-      ${'amz'}       | ${'worldservice/live/assets/images/2015/05/08/150508054332_cameron_624x351_afp.png'}                 | ${`${BASE_IMAGE_URL}/ace/ws/660/amz/worldservice/live/assets/images/2015/05/08/150508054332_cameron_624x351_afp.png.webp`}
+      ichefSubdomain    | originCode     | locator                                                                                                    | expectedURL
+      ${undefined}      | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                                    | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${undefined}      | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                                    | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${undefined}      | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                                    | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${undefined}      | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                                    | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${undefined}      | ${'amz'}       | ${'worldservice/live/assets/images/2013/08/19/130819164754_ardeshir_zahedi_112x63_bbc_nocredit.jpg'}       | ${`${BASE_IMAGE_URL}/ace/ws/660/amz/worldservice/live/assets/images/2013/08/19/130819164754_ardeshir_zahedi_112x63_bbc_nocredit.jpg.webp`}
+      ${undefined}      | ${'amz'}       | ${'worldservice/live/assets/images/2015/05/08/150508054332_cameron_624x351_afp.png'}                       | ${`${BASE_IMAGE_URL}/ace/ws/660/amz/worldservice/live/assets/images/2015/05/08/150508054332_cameron_624x351_afp.png.webp`}
+      ${'ace/standard'} | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                                    | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'ace/standard'} | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                                    | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${'ace/standard'} | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                                    | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'ace/standard'} | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                                    | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${'ace/standard'} | ${'amz'}       | ${'worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                                 | ${`${BASE_IMAGE_URL}/ace/standard/660/amz/worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'ace/standard'} | ${'amz'}       | ${'worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                                 | ${`${BASE_IMAGE_URL}/ace/standard/660/amz/worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${'news'}         | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                                    | ${`${BASE_IMAGE_URL}/news/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'news'}         | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                                    | ${`${BASE_IMAGE_URL}/news/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${'news'}         | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                                    | ${`${BASE_IMAGE_URL}/news/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'news'}         | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                                    | ${`${BASE_IMAGE_URL}/news/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${'news'}         | ${'amz'}       | ${'worldservice/live/assets/images/2013/09/19/130919124553_srivilliputhur_temple_112x63_bbc_nocredit.jpg'} | ${`${BASE_IMAGE_URL}/news/660/amz/worldservice/live/assets/images/2013/09/19/130919124553_srivilliputhur_temple_112x63_bbc_nocredit.jpg`}
+      ${'news'}         | ${'amz'}       | ${'worldservice/live/assets/images/2013/09/19/130919124553_srivilliputhur_temple_112x63_bbc_nocredit.png'} | ${`${BASE_IMAGE_URL}/news/660/amz/worldservice/live/assets/images/2013/09/19/130919124553_srivilliputhur_temple_112x63_bbc_nocredit.png`}
     `(
-      `for $originCode the expected URL is $expectedURL`,
-      ({ originCode, locator, expectedURL }) => {
+      `for the subdomain $ichefSubdomain and origin code $originCode the expected URL is $expectedURL`,
+      ({ ichefSubdomain, originCode, locator, expectedURL }) => {
         const input = {
           originCode,
           locator,
           resolution: '660',
+          ichefSubdomain,
         };
 
         expect(getIChefURL(input)).toEqual(expectedURL);

--- a/src/app/lib/utilities/ichefURL/index.test.js
+++ b/src/app/lib/utilities/ichefURL/index.test.js
@@ -17,27 +17,43 @@ describe('getIchefURL', () => {
     const BASE_IMAGE_URL = 'https://ichef.bbci.co.uk';
 
     it.each`
-      ichefSubdomain    | originCode     | locator                                                                                                    | expectedURL
-      ${undefined}      | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                                    | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
-      ${undefined}      | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                                    | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
-      ${undefined}      | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                                    | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
-      ${undefined}      | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                                    | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
-      ${undefined}      | ${'amz'}       | ${'worldservice/live/assets/images/2013/08/19/130819164754_ardeshir_zahedi_112x63_bbc_nocredit.jpg'}       | ${`${BASE_IMAGE_URL}/ace/ws/660/amz/worldservice/live/assets/images/2013/08/19/130819164754_ardeshir_zahedi_112x63_bbc_nocredit.jpg.webp`}
-      ${undefined}      | ${'amz'}       | ${'worldservice/live/assets/images/2015/05/08/150508054332_cameron_624x351_afp.png'}                       | ${`${BASE_IMAGE_URL}/ace/ws/660/amz/worldservice/live/assets/images/2015/05/08/150508054332_cameron_624x351_afp.png.webp`}
-      ${'ace/standard'} | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                                    | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
-      ${'ace/standard'} | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                                    | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
-      ${'ace/standard'} | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                                    | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
-      ${'ace/standard'} | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                                    | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
-      ${'ace/standard'} | ${'amz'}       | ${'worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                                 | ${`${BASE_IMAGE_URL}/ace/standard/660/amz/worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
-      ${'ace/standard'} | ${'amz'}       | ${'worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                                 | ${`${BASE_IMAGE_URL}/ace/standard/660/amz/worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
-      ${'news'}         | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                                    | ${`${BASE_IMAGE_URL}/news/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
-      ${'news'}         | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                                    | ${`${BASE_IMAGE_URL}/news/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
-      ${'news'}         | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                                    | ${`${BASE_IMAGE_URL}/news/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
-      ${'news'}         | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                                    | ${`${BASE_IMAGE_URL}/news/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
-      ${'news'}         | ${'amz'}       | ${'worldservice/live/assets/images/2013/09/19/130919124553_srivilliputhur_temple_112x63_bbc_nocredit.jpg'} | ${`${BASE_IMAGE_URL}/news/660/amz/worldservice/live/assets/images/2013/09/19/130919124553_srivilliputhur_temple_112x63_bbc_nocredit.jpg`}
-      ${'news'}         | ${'amz'}       | ${'worldservice/live/assets/images/2013/09/19/130919124553_srivilliputhur_temple_112x63_bbc_nocredit.png'} | ${`${BASE_IMAGE_URL}/news/660/amz/worldservice/live/assets/images/2013/09/19/130919124553_srivilliputhur_temple_112x63_bbc_nocredit.png`}
+      ichefSubdomain    | originCode     | locator                                                                                              | expectedURL
+      ${undefined}      | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                              | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${undefined}      | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                              | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${undefined}      | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                              | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${undefined}      | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                              | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${undefined}      | ${'amz'}       | ${'worldservice/live/assets/images/2013/08/19/130819164754_ardeshir_zahedi_112x63_bbc_nocredit.jpg'} | ${`${BASE_IMAGE_URL}/ace/ws/660/amz/worldservice/live/assets/images/2013/08/19/130819164754_ardeshir_zahedi_112x63_bbc_nocredit.jpg.webp`}
+      ${undefined}      | ${'amz'}       | ${'worldservice/live/assets/images/2015/05/08/150508054332_cameron_624x351_afp.png'}                 | ${`${BASE_IMAGE_URL}/ace/ws/660/amz/worldservice/live/assets/images/2015/05/08/150508054332_cameron_624x351_afp.png.webp`}
+      ${'ace/standard'} | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                              | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'ace/standard'} | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                              | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${'ace/standard'} | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                              | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'ace/standard'} | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                              | ${`${BASE_IMAGE_URL}/ace/standard/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${'ace/standard'} | ${'amz'}       | ${'worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                           | ${`${BASE_IMAGE_URL}/ace/standard/660/amz/worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'ace/standard'} | ${'amz'}       | ${'worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                           | ${`${BASE_IMAGE_URL}/ace/standard/660/amz/worldservice/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${'news'}         | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                              | ${`${BASE_IMAGE_URL}/news/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'news'}         | ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                              | ${`${BASE_IMAGE_URL}/news/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${'news'}         | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                              | ${`${BASE_IMAGE_URL}/news/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'news'}         | ${'cpsdevpb'}  | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                              | ${`${BASE_IMAGE_URL}/news/660/cpsdevpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
     `(
       `for the subdomain $ichefSubdomain and origin code $originCode the expected URL is $expectedURL`,
+      ({ ichefSubdomain, originCode, locator, expectedURL }) => {
+        const input = {
+          originCode,
+          locator,
+          resolution: '660',
+          ichefSubdomain,
+        };
+
+        expect(getIChefURL(input)).toEqual(expectedURL);
+      },
+    );
+
+    it.each`
+      ichefSubdomain | originCode | locator                                                                                                    | expectedURL
+      ${'news'}      | ${'amz'}   | ${'worldservice/live/assets/images/2013/09/19/130919124553_srivilliputhur_temple_112x63_bbc_nocredit.jpg'} | ${`${BASE_IMAGE_URL}/news/660/amz/worldservice/live/assets/images/2013/09/19/130919124553_srivilliputhur_temple_112x63_bbc_nocredit.jpg`}
+      ${'news'}      | ${'amz'}   | ${'worldservice/live/assets/images/2013/09/19/130919124553_srivilliputhur_temple_112x63_bbc_nocredit.png'} | ${`${BASE_IMAGE_URL}/news/660/amz/worldservice/live/assets/images/2013/09/19/130919124553_srivilliputhur_temple_112x63_bbc_nocredit.png`}
+    `(
+      `by not adding .webp to the URL for the path $locator which does not support WebP`,
       ({ ichefSubdomain, originCode, locator, expectedURL }) => {
         const input = {
           originCode,

--- a/src/app/lib/utilities/ichefURL/index.test.js
+++ b/src/app/lib/utilities/ichefURL/index.test.js
@@ -13,32 +13,27 @@ describe('getIchefURL', () => {
     expect(getIChefURL(input)).toEqual(expectedOutput);
   });
 
-  it('builds WebP ichef img url based on originCode, locator, resolution and isWebP passed', () => {
-    const input = {
-      originCode: 'cpsprodpb',
-      locator: 'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg',
-      resolution: '660',
-      isWebP: true,
-    };
-    const expectedOutput =
-      'https://ichef.bbci.co.uk/ace/ws/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp';
+  describe('builds WebP ichef img url based on originCode, locator and resolution passed', () => {
+    const BASE_IMAGE_URL = 'https://ichef.bbci.co.uk';
 
-    expect(getIChefURL(input)).toEqual(expectedOutput);
-  });
+    it.each`
+      originCode     | locator                                                                                              | expectedURL
+      ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg'}                                              | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.jpg.webp`}
+      ${'cpsprodpb'} | ${'cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png'}                                              | ${`${BASE_IMAGE_URL}/ace/ws/660/cpsprodpb/cc66/live/5b34d420-b382-11e9-b6fd-e3056fffd1f1.png.webp`}
+      ${'amz'}       | ${'worldservice/live/assets/images/2013/08/19/130819164754_ardeshir_zahedi_112x63_bbc_nocredit.jpg'} | ${`${BASE_IMAGE_URL}/ace/ws/660/amz/worldservice/live/assets/images/2013/08/19/130819164754_ardeshir_zahedi_112x63_bbc_nocredit.jpg.webp`}
+      ${'amz'}       | ${'worldservice/live/assets/images/2015/05/08/150508054332_cameron_624x351_afp.png'}                 | ${`${BASE_IMAGE_URL}/ace/ws/660/amz/worldservice/live/assets/images/2015/05/08/150508054332_cameron_624x351_afp.png.webp`}
+    `(
+      `for $originCode the expected URL is $expectedURL`,
+      ({ originCode, locator, expectedURL }) => {
+        const input = {
+          originCode,
+          locator,
+          resolution: '660',
+        };
 
-  it('builds standard ichef img url based on originCode, locator, resolution and isWebP passed', () => {
-    const input = {
-      originCode: 'amz',
-      locator:
-        'worldservice/live/assets/images/2013/08/19/130819164754_ardeshir_zahedi_112x63_bbc_nocredit.jpg',
-      resolution: '660',
-      isWebP: true,
-    };
-
-    const expectedOutput =
-      'https://ichef.bbci.co.uk/ace/ws/660/amz/worldservice/live/assets/images/2013/08/19/130819164754_ardeshir_zahedi_112x63_bbc_nocredit.jpg';
-
-    expect(getIChefURL(input)).toEqual(expectedOutput);
+        expect(getIChefURL(input)).toEqual(expectedURL);
+      },
+    );
   });
 
   it('builds standard ichef img url with originCode mpv', () => {

--- a/src/sw.test.js
+++ b/src/sw.test.js
@@ -87,7 +87,7 @@ describe('Service Worker', () => {
         ({ fetchEventHandler } = await import('./service-worker-test'));
 
         const event = {
-          request: new Request(image, headers),
+          request: new Request(image, { headers }),
         };
 
         event.respondWith = jest.fn();

--- a/src/sw.test.js
+++ b/src/sw.test.js
@@ -112,14 +112,6 @@ describe('Service Worker', () => {
         ${`${BASE_IMAGE_URL}/ace/ws/puppies.jpg.webp`}        | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
         ${`${BASE_IMAGE_URL}/ace/ws/puppies.png.webp`}        | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
       `(`for $image because $reason`, async ({ image, headers }) => {
-        // ${`${TEST_IMAGE_URL}/news/amz/puppies.jpeg`}          | ${{ accept: 'webp' }} | ${'image url must not include amz'}
-        // ${`${TEST_IMAGE_URL}/news/worldservice/puppies.jpeg`} | ${{ accept: 'webp' }} | ${'image url must not include worldservice'}
-        // ${`${TEST_IMAGE_URL}/news/puppies.jpg`}               | ${{}}                 | ${`webp not supported in request headers`}
-
-        // ${`${BASE_IMAGE_URL}/news/amz/puppies.jpeg`}          | ${{ accept: 'webp' }} | ${'image url must not include amz'}
-        // ${`${BASE_IMAGE_URL}/news/worldservice/puppies.jpeg`} | ${{ accept: 'webp' }} | ${'image url must not include worldservice'}
-        // ${`${BASE_IMAGE_URL}/news/puppies.jpg`}               | ${{}}                 | ${`webp not supported in request headers`}
-
         ({ fetchEventHandler } = await import('./service-worker-test'));
 
         const event = {

--- a/src/sw.test.js
+++ b/src/sw.test.js
@@ -30,27 +30,31 @@ describe('Service Worker', () => {
 
     describe('image extension (.webp) is stripped and the fallback image is requested when webp not supported', () => {
       it.each`
-        image                                                                                      | expectedUrl
-        ${`${TEST_IMAGE_URL}/news/puppies.jpg.webp`}                                               | ${`${TEST_IMAGE_URL}/news/puppies.jpg`}
-        ${`${TEST_IMAGE_URL}/news/puppies.png.webp`}                                               | ${`${TEST_IMAGE_URL}/news/puppies.png`}
-        ${`${TEST_IMAGE_URL}/ace/standard/puppies.jpg.webp`}                                       | ${`${TEST_IMAGE_URL}/ace/standard/puppies.jpg`}
-        ${`${TEST_IMAGE_URL}/ace/standard/puppies.png.webp`}                                       | ${`${TEST_IMAGE_URL}/ace/standard/puppies.png`}
-        ${`${TEST_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.jpg.webp`} | ${`${TEST_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.jpg`}
-        ${`${TEST_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.png.webp`} | ${`${TEST_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.png`}
-        ${`${TEST_IMAGE_URL}/ace/ws/puppies.jpg.webp`}                                             | ${`${TEST_IMAGE_URL}/ace/ws/puppies.jpg`}
-        ${`${TEST_IMAGE_URL}/ace/ws/puppies.png.webp`}                                             | ${`${TEST_IMAGE_URL}/ace/ws/puppies.png`}
-        ${`${TEST_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.jpg.webp`}         | ${`${TEST_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.jpg`}
-        ${`${TEST_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.png.webp`}         | ${`${TEST_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.png`}
-        ${`${BASE_IMAGE_URL}/news/puppies.jpg.webp`}                                               | ${`${BASE_IMAGE_URL}/news/puppies.jpg`}
-        ${`${BASE_IMAGE_URL}/news/puppies.png.webp`}                                               | ${`${BASE_IMAGE_URL}/news/puppies.png`}
-        ${`${BASE_IMAGE_URL}/ace/standard/puppies.jpg.webp`}                                       | ${`${BASE_IMAGE_URL}/ace/standard/puppies.jpg`}
-        ${`${BASE_IMAGE_URL}/ace/standard/puppies.png.webp`}                                       | ${`${BASE_IMAGE_URL}/ace/standard/puppies.png`}
-        ${`${BASE_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.jpg.webp`} | ${`${BASE_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.jpg`}
-        ${`${BASE_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.png.webp`} | ${`${BASE_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.png`}
-        ${`${BASE_IMAGE_URL}/ace/ws/puppies.jpg.webp`}                                             | ${`${BASE_IMAGE_URL}/ace/ws/puppies.jpg`}
-        ${`${BASE_IMAGE_URL}/ace/ws/puppies.png.webp`}                                             | ${`${BASE_IMAGE_URL}/ace/ws/puppies.png`}
-        ${`${BASE_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.jpg.webp`}         | ${`${BASE_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.jpg`}
-        ${`${BASE_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.png.webp`}         | ${`${BASE_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.png`}
+        image                                                                                              | expectedUrl
+        ${`${TEST_IMAGE_URL}/news/puppies.jpg.webp`}                                                       | ${`${TEST_IMAGE_URL}/news/puppies.jpg`}
+        ${`${TEST_IMAGE_URL}/news/puppies.png.webp`}                                                       | ${`${TEST_IMAGE_URL}/news/puppies.png`}
+        ${`${TEST_IMAGE_URL}/ace/standard/puppies.jpg.webp`}                                               | ${`${TEST_IMAGE_URL}/ace/standard/puppies.jpg`}
+        ${`${TEST_IMAGE_URL}/ace/standard/puppies.png.webp`}                                               | ${`${TEST_IMAGE_URL}/ace/standard/puppies.png`}
+        ${`${TEST_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.jpg.webp`}         | ${`${TEST_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.jpg`}
+        ${`${TEST_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.png.webp`}         | ${`${TEST_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.png`}
+        ${`${TEST_IMAGE_URL}/ace/ws/puppies.jpg.webp`}                                                     | ${`${TEST_IMAGE_URL}/ace/ws/puppies.jpg`}
+        ${`${TEST_IMAGE_URL}/ace/ws/puppies.png.webp`}                                                     | ${`${TEST_IMAGE_URL}/ace/ws/puppies.png`}
+        ${`${TEST_IMAGE_URL}/ace/ws/160/cpsdevpb/c6b6/test/0363c8d0-08a2-11ef-a801-47fbecfec49f.png.webp`} | ${`${TEST_IMAGE_URL}/ace/ws/160/cpsdevpb/c6b6/test/0363c8d0-08a2-11ef-a801-47fbecfec49f.png`}
+        ${`${TEST_IMAGE_URL}/images/ic/256x256/p08b22y1.png.webp`}                                         | ${`${TEST_IMAGE_URL}/images/ic/256x256/p08b22y1.png`}
+        ${`${TEST_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.jpg.webp`}                 | ${`${TEST_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.jpg`}
+        ${`${TEST_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.png.webp`}                 | ${`${TEST_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.png`}
+        ${`${BASE_IMAGE_URL}/news/puppies.jpg.webp`}                                                       | ${`${BASE_IMAGE_URL}/news/puppies.jpg`}
+        ${`${BASE_IMAGE_URL}/news/puppies.png.webp`}                                                       | ${`${BASE_IMAGE_URL}/news/puppies.png`}
+        ${`${BASE_IMAGE_URL}/ace/standard/puppies.jpg.webp`}                                               | ${`${BASE_IMAGE_URL}/ace/standard/puppies.jpg`}
+        ${`${BASE_IMAGE_URL}/ace/standard/puppies.png.webp`}                                               | ${`${BASE_IMAGE_URL}/ace/standard/puppies.png`}
+        ${`${BASE_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.jpg.webp`}         | ${`${BASE_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.jpg`}
+        ${`${BASE_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.png.webp`}         | ${`${BASE_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.png`}
+        ${`${BASE_IMAGE_URL}/ace/ws/puppies.jpg.webp`}                                                     | ${`${BASE_IMAGE_URL}/ace/ws/puppies.jpg`}
+        ${`${BASE_IMAGE_URL}/ace/ws/puppies.png.webp`}                                                     | ${`${BASE_IMAGE_URL}/ace/ws/puppies.png`}
+        ${`${BASE_IMAGE_URL}/ace/ws/160/cpsdevpb/c6b6/test/0363c8d0-08a2-11ef-a801-47fbecfec49f.png.webp`} | ${`${BASE_IMAGE_URL}/ace/ws/160/cpsdevpb/c6b6/test/0363c8d0-08a2-11ef-a801-47fbecfec49f.png`}
+        ${`${BASE_IMAGE_URL}/images/ic/256x256/p08b22y1.png.webp`}                                         | ${`${BASE_IMAGE_URL}/images/ic/256x256/p08b22y1.png`}
+        ${`${BASE_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.jpg.webp`}                 | ${`${BASE_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.jpg`}
+        ${`${BASE_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.png.webp`}                 | ${`${BASE_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.png`}
       `(
         `for $image the expected fallback is $expectedUrl`,
         async ({ image, expectedUrl }) => {

--- a/src/sw.test.js
+++ b/src/sw.test.js
@@ -28,58 +28,98 @@ describe('Service Worker', () => {
     const TEST_IMAGE_URL = 'https://ichef.test.bbci.co.uk';
     const BASE_IMAGE_URL = 'https://ichef.bbci.co.uk';
 
-    // .webp is removed from the url when the url contains .web already and webp is not supported
-    describe('image requested in sw when url ends in webp and webp not supported', () => {
+    describe('image extension (.webp) is stripped and the fallback image is requested when webp not supported', () => {
       it.each`
-        image                                        | expectedUrl
-        ${`${TEST_IMAGE_URL}/news/puppies.jpg.webp`} | ${`${TEST_IMAGE_URL}/news/puppies.jpg`}
-        ${`${BASE_IMAGE_URL}/news/puppies.jpg.webp`} | ${`${BASE_IMAGE_URL}/news/puppies.jpg`}
-        ${`${TEST_IMAGE_URL}/news/puppies.png.webp`} | ${`${TEST_IMAGE_URL}/news/puppies.png`}
-        ${`${BASE_IMAGE_URL}/news/puppies.png.webp`} | ${`${BASE_IMAGE_URL}/news/puppies.png`}
-      `(`for $image is $expectedUrl`, async ({ image, expectedUrl }) => {
-        ({ fetchEventHandler } = await import('./service-worker-test'));
+        image                                                                                      | expectedUrl
+        ${`${TEST_IMAGE_URL}/news/puppies.jpg.webp`}                                               | ${`${TEST_IMAGE_URL}/news/puppies.jpg`}
+        ${`${TEST_IMAGE_URL}/news/puppies.png.webp`}                                               | ${`${TEST_IMAGE_URL}/news/puppies.png`}
+        ${`${TEST_IMAGE_URL}/ace/standard/puppies.jpg.webp`}                                       | ${`${TEST_IMAGE_URL}/ace/standard/puppies.jpg`}
+        ${`${TEST_IMAGE_URL}/ace/standard/puppies.png.webp`}                                       | ${`${TEST_IMAGE_URL}/ace/standard/puppies.png`}
+        ${`${TEST_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.jpg.webp`} | ${`${TEST_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.jpg`}
+        ${`${TEST_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.png.webp`} | ${`${TEST_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.png`}
+        ${`${TEST_IMAGE_URL}/ace/ws/puppies.jpg.webp`}                                             | ${`${TEST_IMAGE_URL}/ace/ws/puppies.jpg`}
+        ${`${TEST_IMAGE_URL}/ace/ws/puppies.png.webp`}                                             | ${`${TEST_IMAGE_URL}/ace/ws/puppies.png`}
+        ${`${TEST_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.jpg.webp`}         | ${`${TEST_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.jpg`}
+        ${`${TEST_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.png.webp`}         | ${`${TEST_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.png`}
+        ${`${BASE_IMAGE_URL}/news/puppies.jpg.webp`}                                               | ${`${BASE_IMAGE_URL}/news/puppies.jpg`}
+        ${`${BASE_IMAGE_URL}/news/puppies.png.webp`}                                               | ${`${BASE_IMAGE_URL}/news/puppies.png`}
+        ${`${BASE_IMAGE_URL}/ace/standard/puppies.jpg.webp`}                                       | ${`${BASE_IMAGE_URL}/ace/standard/puppies.jpg`}
+        ${`${BASE_IMAGE_URL}/ace/standard/puppies.png.webp`}                                       | ${`${BASE_IMAGE_URL}/ace/standard/puppies.png`}
+        ${`${BASE_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.jpg.webp`} | ${`${BASE_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.jpg`}
+        ${`${BASE_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.png.webp`} | ${`${BASE_IMAGE_URL}/ace/standard/assets/images/2015/01/08/150108141819_puppies.png`}
+        ${`${BASE_IMAGE_URL}/ace/ws/puppies.jpg.webp`}                                             | ${`${BASE_IMAGE_URL}/ace/ws/puppies.jpg`}
+        ${`${BASE_IMAGE_URL}/ace/ws/puppies.png.webp`}                                             | ${`${BASE_IMAGE_URL}/ace/ws/puppies.png`}
+        ${`${BASE_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.jpg.webp`}         | ${`${BASE_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.jpg`}
+        ${`${BASE_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.png.webp`}         | ${`${BASE_IMAGE_URL}/news/assets/images/2015/01/08/150108141819_puppies.png`}
+      `(
+        `for $image the expected fallback is $expectedUrl`,
+        async ({ image, expectedUrl }) => {
+          ({ fetchEventHandler } = await import('./service-worker-test'));
 
-        const event = {
-          request: new Request(image),
-        };
+          const event = {
+            request: new Request(image),
+          };
 
-        event.respondWith = jest.fn();
+          event.respondWith = jest.fn();
 
-        await fetchEventHandler(event);
+          await fetchEventHandler(event);
 
-        expect(event.respondWith).toHaveBeenCalled();
-        expect(fetchSpy).toHaveBeenCalledWith(expectedUrl, { mode: 'no-cors' });
-      });
-    });
-
-    describe('image not requested in sw when url ends in webp and webp supported', () => {
-      it.each`
-        image                                        | headers
-        ${`${TEST_IMAGE_URL}/news/puppies.jpg.webp`} | ${{ accept: 'webp' }}
-        ${`${BASE_IMAGE_URL}/news/puppies.png.webp`} | ${{ accept: 'webp' }}
-      `(`for $image is $expectedUrl`, async ({ image, headers }) => {
-        ({ fetchEventHandler } = await import('./service-worker-test'));
-
-        const event = {
-          request: new Request(image, { headers }),
-        };
-        // , { headers: { accept: 'jpg' } })
-        event.respondWith = jest.fn();
-
-        await fetchEventHandler(event);
-
-        expect(event.respondWith).not.toHaveBeenCalled();
-      });
+          expect(event.respondWith).toHaveBeenCalled();
+          expect(fetchSpy).toHaveBeenCalledWith(expectedUrl, {
+            mode: 'no-cors',
+          });
+        },
+      );
     });
 
     describe('image is not requested in sw', () => {
       it.each`
-        image                                                | headers               | reason
-        ${`${TEST_IMAGE_URL}/sport/puppies.jpg`}             | ${{}}                 | ${'image url must end with webp'}
-        ${`${TEST_IMAGE_URL}/ace/standard/puppies.jpg.webp`} | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
-        ${`${BASE_IMAGE_URL}/sport/puppies.jpg`}             | ${{}}                 | ${'image url must end with webp'}
-        ${`${BASE_IMAGE_URL}/ace/standard/puppies.jpg.webp`} | ${{ accept: 'webp' }} | ${`webp not supported in request headers`}
+        image                                                 | headers               | reason
+        ${`${TEST_IMAGE_URL}/sport/puppies.jpg.webp`}         | ${{ accept: 'webp' }} | ${'image url must include news, ace/standard or ace/ws'}
+        ${`${TEST_IMAGE_URL}/ace/stndard/puppies.jpg.webp`}   | ${{ accept: 'webp' }} | ${'image url must include news, ace/standard or ace/ws'}
+        ${`${TEST_IMAGE_URL}/ace/sw/puppies.jpg.webp`}        | ${{ accept: 'webp' }} | ${'image url must include news, ace/standard or ace/ws'}
+        ${`${TEST_IMAGE_URL}/news/puppies.jpeg.webp`}         | ${{ accept: 'webp' }} | ${'image extension must be jpg or png'}
+        ${`${TEST_IMAGE_URL}/ace/standard/puppies.jpeg.webp`} | ${{ accept: 'webp' }} | ${'image extension must be jpg or png'}
+        ${`${TEST_IMAGE_URL}/ace/ws/puppies.jpeg.webp`}       | ${{ accept: 'webp' }} | ${'image extension must be jpg or png'}
+        ${`${TEST_IMAGE_URL}/news/puppies.jpg`}               | ${{}}                 | ${'image url must end with webp'}
+        ${`${TEST_IMAGE_URL}/news/puppies.png`}               | ${{}}                 | ${'image url must end with webp'}
+        ${`${TEST_IMAGE_URL}/ace/standard/puppies.jpg`}       | ${{}}                 | ${'image url must end with webp'}
+        ${`${TEST_IMAGE_URL}/ace/standard/puppies.png`}       | ${{}}                 | ${'image url must end with webp'}
+        ${`${TEST_IMAGE_URL}/ace/ws/puppies.jpg`}             | ${{}}                 | ${'image url must end with webp'}
+        ${`${TEST_IMAGE_URL}/ace/ws/puppies.png`}             | ${{}}                 | ${'image url must end with webp'}
+        ${`${TEST_IMAGE_URL}/news/puppies.jpg.webp`}          | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
+        ${`${TEST_IMAGE_URL}/news/puppies.png.webp`}          | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
+        ${`${TEST_IMAGE_URL}/ace/standard/puppies.jpg.webp`}  | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
+        ${`${TEST_IMAGE_URL}/ace/standard/puppies.png.webp`}  | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
+        ${`${TEST_IMAGE_URL}/ace/ws/puppies.jpg.webp`}        | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
+        ${`${TEST_IMAGE_URL}/ace/ws/puppies.png.webp`}        | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
+        ${`${BASE_IMAGE_URL}/sport/puppies.jpg.webp`}         | ${{ accept: 'webp' }} | ${'image url must include news, ace/standard or ace/ws'}
+        ${`${BASE_IMAGE_URL}/ace/stndard/puppies.jpg.webp`}   | ${{ accept: 'webp' }} | ${'image url must include news, ace/standard or ace/ws'}
+        ${`${BASE_IMAGE_URL}/ace/sw/puppies.jpg.webp`}        | ${{ accept: 'webp' }} | ${'image url must include news, ace/standard or ace/ws'}
+        ${`${BASE_IMAGE_URL}/news/puppies.jpeg.webp`}         | ${{ accept: 'webp' }} | ${'image extension must be jpg or png'}
+        ${`${BASE_IMAGE_URL}/ace/standard/puppies.jpeg.webp`} | ${{ accept: 'webp' }} | ${'image extension must be jpg or png'}
+        ${`${BASE_IMAGE_URL}/ace/ws/puppies.jpeg.webp`}       | ${{ accept: 'webp' }} | ${'image extension must be jpg or png'}
+        ${`${BASE_IMAGE_URL}/news/puppies.jpg`}               | ${{}}                 | ${'image url must end with webp'}
+        ${`${BASE_IMAGE_URL}/news/puppies.png`}               | ${{}}                 | ${'image url must end with webp'}
+        ${`${BASE_IMAGE_URL}/ace/standard/puppies.jpg`}       | ${{}}                 | ${'image url must end with webp'}
+        ${`${BASE_IMAGE_URL}/ace/standard/puppies.png`}       | ${{}}                 | ${'image url must end with webp'}
+        ${`${BASE_IMAGE_URL}/ace/ws/puppies.jpg`}             | ${{}}                 | ${'image url must end with webp'}
+        ${`${BASE_IMAGE_URL}/ace/ws/puppies.png`}             | ${{}}                 | ${'image url must end with webp'}
+        ${`${BASE_IMAGE_URL}/news/puppies.jpg.webp`}          | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
+        ${`${BASE_IMAGE_URL}/news/puppies.png.webp`}          | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
+        ${`${BASE_IMAGE_URL}/ace/standard/puppies.jpg.webp`}  | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
+        ${`${BASE_IMAGE_URL}/ace/standard/puppies.png.webp`}  | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
+        ${`${BASE_IMAGE_URL}/ace/ws/puppies.jpg.webp`}        | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
+        ${`${BASE_IMAGE_URL}/ace/ws/puppies.png.webp`}        | ${{ accept: 'webp' }} | ${'webp supported in request headers'}
       `(`for $image because $reason`, async ({ image, headers }) => {
+        // ${`${TEST_IMAGE_URL}/news/amz/puppies.jpeg`}          | ${{ accept: 'webp' }} | ${'image url must not include amz'}
+        // ${`${TEST_IMAGE_URL}/news/worldservice/puppies.jpeg`} | ${{ accept: 'webp' }} | ${'image url must not include worldservice'}
+        // ${`${TEST_IMAGE_URL}/news/puppies.jpg`}               | ${{}}                 | ${`webp not supported in request headers`}
+
+        // ${`${BASE_IMAGE_URL}/news/amz/puppies.jpeg`}          | ${{ accept: 'webp' }} | ${'image url must not include amz'}
+        // ${`${BASE_IMAGE_URL}/news/worldservice/puppies.jpeg`} | ${{ accept: 'webp' }} | ${'image url must not include worldservice'}
+        // ${`${BASE_IMAGE_URL}/news/puppies.jpg`}               | ${{}}                 | ${`webp not supported in request headers`}
+
         ({ fetchEventHandler } = await import('./service-worker-test'));
 
         const event = {


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
_Add a list of ._

Code changes
======
`public/sw.js`
- Limits `.webp` URLs pattern to only match images with `.jpg` and `.png`
as the fallback image extension.

`src/app/lib/utilities/ichefURL/index.js`
- Add a regex pattern to ensure `.webp` is only added to 
```
/news/.../cpsprodpb/<image_name>.jpg
/news/.../cpsprodpb/<image_name>.png
/news/.../cpsdevpb/<image_name>.jpg
/news/.../cpsdevpb/<image_name>.png

/ace/ws/.../cpsprodpb/<image_name>.jpg
/ace/ws/.../cpsprodpb/<image_name>.png
/ace/ws/.../cpsdevpb/<image_name>.jpg
/ace/ws/.../cpsdevpb/<image_name>.png

/ace/standard/.../cpsprodpb/<image_name>.jpg
/ace/standard/.../cpsprodpb/<image_name>.png
/ace/standard/.../cpsdevpb/<image_name>.jpg
/ace/standard/.../cpsdevpb/<image_name>.png

/ace/ws/.../amz/worldservice/<image_name>.jpg
/ace/ws/.../amz/worldservice/<image_name>.png
/ace/standard/.../amz/worldservice/<image_name>.jpg
/ace/standard/.../amz/worldservice/<image_name>.png
```
and excluded from
```
/news/.../amz/worldservice/<image_name>.jpg
/news/.../amz/worldservice/<image_name>.png
```

`src/app/lib/utilities/ichefURL/index.test.js` & `src/sw.test.js`
- Add the pertinent tests for the logic changes above.

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
