### PR TITLE
Disables chromatic waiting for animations to end as live radio pulse …

### DIFF
--- a/src/app/pages/LiveRadioPage/index.stories.jsx
+++ b/src/app/pages/LiveRadioPage/index.stories.jsx
@@ -57,6 +57,7 @@ export default {
     chromatic: {
       diffThreshold: 0.2,
       delay: 8000,
+      pauseAnimationAtEnd: false
     },
   },
   decorators: [withServicesDecorator({ defaultService: 'indonesia' })],


### PR DESCRIPTION
…is infinite

Overall changes
======
Implements suggested config [here](https://www.chromatic.com/docs/animations/#css-animations) to pause css animations at the first frame.

Below you can see that the pulse is implemented as a css animation:
![image](https://github.com/bbc/simorgh/assets/9645462/e715549b-6327-4e20-80c3-8aa384f79c3e)

Testing
======
Following the merge of this PR we need to monitor for the Live Radio Page story needing unnecessary chromatic snapshot updates in subsequent PRs.

Helpful Links
======
[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
