### PR TITLE
WSTEAM1-969: Fix skip to content link

### DIFF
--- a/ws-nextjs-app/pages/[service]/send/[id]/UGCPageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/UGCPageLayout.tsx
@@ -29,7 +29,9 @@ const UGCPageLayout = ({ pageData }: PageProps) => {
         <div css={styles.grid}>
           <div css={styles.primaryColumn}>
             <main css={styles.mainContent}>
-              <Heading level={1}>{title}</Heading>
+              <Heading level={1} id="content" tabIndex={-1}>
+                {title}
+              </Heading>
               <div
                 // TODO: This is a security risk, we should sanitize the HTML
                 // eslint-disable-next-line react/no-danger


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-1013](https://jira.dev.bbc.co.uk/browse/WSTEAM1-1013)

Overall changes
======
Meet AAC as per https://paper.dropbox.com/doc/Uploader-Accessibility-acceptance-criteria--CPDVHNzUxXMEp1dwUavLnzyFAg-BN1tII16uRaecL0YQQ0pR#:h2=Skip-to-content-link

Code changes
======
- Adds id="content" and tabIndex="-1" to H1

Testing
======
1. Open storybook UGC permalink or run locally and visit http://localhost.bbc.com:7081/mundo/send/u50853489?renderer_env=live#content
2. Use the Skip to content link in the brand

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[A11y Acceptance Criteria](https://paper.dropbox.com/doc/Uploader-Accessibility-acceptance-criteria--CPDVHNzUxXMEp1dwUavLnzyFAg-BN1tII16uRaecL0YQQ0pR#:h2=Skip-to-content-link)

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
