### PR TITLE
Remove placeholder image from billboard

### DIFF
--- a/src/app/components/Billboard/index.tsx
+++ b/src/app/components/Billboard/index.tsx
@@ -48,6 +48,7 @@ const Billboard = forwardRef(
               imageUrlTemplate={image}
               altText={altText}
               imageWidth={660}
+              showPlaceholder={false}
             />
             <div css={styles.textContainer}>
               <Heading level={2} size="paragon" css={styles.heading} id={id}>

--- a/src/app/components/MaskedImage/index.tsx
+++ b/src/app/components/MaskedImage/index.tsx
@@ -57,6 +57,7 @@ const MaskedImage = ({
         height={533}
         fetchpriority="high"
         preload
+        placeholder={false}
       />
     </div>
   );

--- a/src/app/components/MaskedImage/index.tsx
+++ b/src/app/components/MaskedImage/index.tsx
@@ -14,11 +14,13 @@ const MaskedImage = ({
   imageUrlTemplate,
   imageWidth,
   altText = '',
+  showPlaceholder = true,
 }: {
   imageUrl: string;
   imageUrlTemplate: string;
   imageWidth: number;
   altText?: string;
+  showPlaceholder?: boolean;
 }) => {
   const { dir } = useContext(ServiceContext);
   const { isAmp } = useContext(RequestContext);
@@ -57,7 +59,7 @@ const MaskedImage = ({
         height={533}
         fetchpriority="high"
         preload
-        placeholder={false}
+        placeholder={showPlaceholder}
       />
     </div>
   );


### PR DESCRIPTION
Overall changes
======
Removes the background / placeholder image from the billboard when the image is transparent

Before:
![Screenshot 2024-05-14 at 15 53 05](https://github.com/bbc/simorgh/assets/58214768/422beaff-7dea-4307-b41c-ff16ab6027b4)



Code changes
======
- Pass `placeholder` from Billboard -> MaskedImage - Image component

After:

![Screenshot 2024-05-14 at 16 04 16](https://github.com/bbc/simorgh/assets/58214768/5f5b8d49-dff7-4b59-bd8a-aeec01c99d7b)


Testing
======
- Storybook
- Hindi Homepage (local with live data) 
