### PR TITLE
WSTEAM1-1013: Add outline none to heading for skip link

### DIFF
--- a/ws-nextjs-app/pages/[service]/send/[id]/UGCPageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/UGCPageLayout.tsx
@@ -29,7 +29,12 @@ const UGCPageLayout = ({ pageData }: PageProps) => {
         <div css={styles.grid}>
           <div css={styles.primaryColumn}>
             <main css={styles.mainContent}>
-              <Heading level={1} id="content" tabIndex={-1}>
+              <Heading
+                level={1}
+                id="content"
+                tabIndex={-1}
+                css={styles.heading}
+              >
                 {title}
               </Heading>
               <div

--- a/ws-nextjs-app/pages/[service]/send/[id]/styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/styles.ts
@@ -37,6 +37,12 @@ export default {
         width: '35rem',
       },
     }),
+  heading: () =>
+    css({
+      '&:focus': {
+        outline: 'none',
+      },
+    }),
   description: ({ palette, spacings, fontVariants, fontSizes, mq }: Theme) =>
     css({
       borderBottom: `${pixelsToRem(1)}rem solid ${palette.GREY_5}`,


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-1013](https://jira.dev.bbc.co.uk/browse/WSTEAM1-1013) - bug noticed after original PR merged

Overall changes
======
Ensures outline does not appear around Heading (to match article page). Note I noticed we are missing this on the Live page currently (have flagged to CG).

Code changes
======
- Adds outline none styling to H1 on focus state.

Testing
======
1. Open storybook UGC permalink or run locally and visit http://localhost.bbc.com:7081/mundo/send/u50853489?renderer_env=live#content
2. Use the Skip to content link in the brand
3. Ensure outline does not appear around heading

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[A11y Acceptance Criteria](https://paper.dropbox.com/doc/Uploader-Accessibility-acceptance-criteria--CPDVHNzUxXMEp1dwUavLnzyFAg-BN1tII16uRaecL0YQQ0pR#:h2=Skip-to-content-link)

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
