### PR TITLE
WSTEAMA-1104: Add support for radio schedule to topic pages

### DIFF
--- a/data/persian/topics/crezq2dg9zwt.json
+++ b/data/persian/topics/crezq2dg9zwt.json
@@ -171,6 +171,49 @@
         "title": "برنامه‌های رادیو",
         "visualProminence": "NORMAL",
         "visualStyle": "COLLECTION"
+      },
+      {
+        "title": "Radio Schedule",
+        "curationId": "urn:bbc:programmes:available-episodes:bbc_dari_radio",
+        "curationType": "available-episodes",
+        "radioSchedule": [
+          {
+            "id": "p0hq1k3j",
+            "state": "next",
+            "startTime": "2024-05-15T16:00:00.000Z",
+            "link": "/persian/bbc_dari_radio/w172zpp9jvgp59x",
+            "brandTitle": "خبر و نظر",
+            "summary": "برنامه نویسی از سرویس بی بی سی فارسی",
+            "duration": "PT29M30S"
+          },
+          {
+            "id": "p0hq0jk4",
+            "state": "onDemand",
+            "startTime": "2024-05-15T14:30:00.000Z",
+            "link": "/persian/bbc_dari_radio/w3ct6m5z",
+            "brandTitle": "بحث هفته",
+            "summary": "در این برنامه، مهم ترین مسایل روز مرتبط به افغانستان وجهان با نگاه ژرف با حضور صاحب نظران و مقامات بررسی می شود.",
+            "duration": "PT29M30S"
+          },
+          {
+            "id": "p0hq0jk2",
+            "state": "onDemand",
+            "startTime": "2024-05-15T14:00:00.000Z",
+            "link": "/persian/bbc_dari_radio/w3ct6lhj",
+            "brandTitle": "مجله شامگاهی",
+            "summary": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها ونگاه موشکافانه به مهم ترین اتفاقات روز.",
+            "duration": "PT30M"
+          },
+          {
+            "id": "p0hpvn00",
+            "state": "onDemand",
+            "startTime": "2024-05-15T02:30:00.000Z",
+            "link": "/persian/bbc_dari_radio/w3ct6l7g",
+            "brandTitle": "چشم انداز بامدادی 1",
+            "summary": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
+            "duration": "PT29M30S"
+          }
+        ]
       }
     ],
     "activePage": 1,

--- a/data/persian/topics/crezq2dg9zwt.json
+++ b/data/persian/topics/crezq2dg9zwt.json
@@ -214,6 +214,18 @@
             "duration": "PT29M30S"
           }
         ]
+      },
+      {
+        "curationId": "urn:bbc:tipo:list:b9b4842d-b1a7-4ada-a14d-52b76c43862f",
+        "curationType": "tipo-curation",
+        "position": 4,
+        "title": "VJ",
+        "visualProminence": "NORMAL",
+        "visualStyle": "BANNER",
+        "link": "https://news.test.files.bbci.co.uk/include/vjsthasia/2308-india-elections-2024-results-page/develop/english/election-banner/embed",
+        "embed": {
+          "html": "<div>hello world</div>"
+        }
       }
     ],
     "activePage": 1,

--- a/data/persian/topics/crezq2dg9zwt.json
+++ b/data/persian/topics/crezq2dg9zwt.json
@@ -224,7 +224,7 @@
         "visualStyle": "BANNER",
         "link": "https://news.test.files.bbci.co.uk/include/vjsthasia/2308-india-elections-2024-results-page/develop/english/election-banner/embed",
         "embed": {
-          "html": "<div>hello world</div>"
+          "html": "<div>VJ Embed</div>"
         }
       }
     ],

--- a/src/app/pages/TopicPage/TopicPage.jsx
+++ b/src/app/pages/TopicPage/TopicPage.jsx
@@ -83,6 +83,7 @@ const TopicPage = ({ pageData }) => {
               position,
               visualStyle,
               embed,
+              radioSchedule,
             }) => {
               const nthCurationByStyleAndProminence =
                 getNthCurationByStyleAndProminence({
@@ -108,6 +109,7 @@ const TopicPage = ({ pageData }) => {
                       nthCurationByStyleAndProminence
                     }
                     embed={embed}
+                    radioSchedule={radioSchedule}
                   />
                 </React.Fragment>
               );

--- a/src/app/pages/TopicPage/index.test.jsx
+++ b/src/app/pages/TopicPage/index.test.jsx
@@ -44,9 +44,6 @@ const getOptionParams = ({
     radioSchedule: {
       enabled: true,
     },
-    mostRead: {
-      enabled: true,
-    },
   },
 });
 

--- a/src/app/pages/TopicPage/index.test.jsx
+++ b/src/app/pages/TopicPage/index.test.jsx
@@ -8,6 +8,7 @@ import {
 } from '#app/models/types/curationData';
 import { Helmet } from 'react-helmet';
 import { data as kyrgyzTopicWithMessageBanners } from '#data/kyrgyz/topics/cvpv9djp9qqt.json';
+import { data as persianAfghanistan } from '#data/persian/topics/crezq2dg9zwt.json';
 import { TOPIC_PAGE } from '../../routes/utils/pageTypes';
 import { render } from '../../components/react-testing-library-with-providers';
 import TopicPage from './TopicPage';
@@ -288,6 +289,17 @@ describe('Topic Page', () => {
       };
 
       expect(getLinkedDataOutput()).toMatchSnapshot();
+    });
+  });
+
+  describe('Radio Schedule', () => {
+    it('should render if there is a curation with radio schedule data', () => {
+      const { getByTestId } = render(
+        <TopicPage pageData={persianAfghanistan} />,
+        getOptionParams({ service: 'persian' }),
+      );
+
+      expect(getByTestId('radio-schedule').toBeInTheDocument());
     });
   });
 });

--- a/src/app/pages/TopicPage/index.test.jsx
+++ b/src/app/pages/TopicPage/index.test.jsx
@@ -41,6 +41,12 @@ const getOptionParams = ({
     ads: {
       enabled: adsToggledOn,
     },
+    radioSchedule: {
+      enabled: true,
+    },
+    mostRead: {
+      enabled: true,
+    },
   },
 });
 
@@ -299,7 +305,18 @@ describe('Topic Page', () => {
         getOptionParams({ service: 'persian' }),
       );
 
-      expect(getByTestId('radio-schedule').toBeInTheDocument());
+      expect(getByTestId('radio-schedule')).toBeInTheDocument();
+    });
+  });
+
+  describe('Embed', () => {
+    it('should render if there is a curation with embed data', () => {
+      const { getByTestId } = render(
+        <TopicPage pageData={persianAfghanistan} />,
+        getOptionParams({ service: 'persian' }),
+      );
+
+      expect(getByTestId('embed')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAMA-1104

Overall changes
======
Add the radio schedule component to topic pages

Code changes
======
- pass radio schedule object from Topic Page -> Curation object
- add unit tests for radio schedule & embed 
- update fixture data for persian afghanistan to include an embed & a radio schedule 

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
