### PR TITLE
WSTEAM1-1029 - Form uploading screen

### DIFF
--- a/src/app/components/PageLayoutWrapper/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/PageLayoutWrapper/__snapshots__/index.test.tsx.snap
@@ -491,6 +491,7 @@ exports[`PageLayoutWrapper should render default page wrapper with children 1`] 
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  position: relative;
 }
 
 .emotion-30 {

--- a/src/app/components/PageLayoutWrapper/index.styles.ts
+++ b/src/app/components/PageLayoutWrapper/index.styles.ts
@@ -11,5 +11,6 @@ export default {
     }),
   content: css({
     flexGrow: 1,
+    position: 'relative',
   }),
 };

--- a/ws-nextjs-app/pages/[service]/send/[id]/Form/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/Form/index.tsx
@@ -26,15 +26,8 @@ export default function Form({
 }: Props) {
   const { handleSubmit, submissionError, submitted } = useFormContext();
 
-  const formFields = fields?.map(({ id, label, type, htmlType, textArea }) => (
-    <FormField
-      key={id}
-      id={id}
-      label={label}
-      type={type}
-      htmlType={htmlType}
-      textArea={textArea}
-    />
+  const formFields = fields?.map(({ id, label, htmlType }) => (
+    <FormField key={id} id={id} label={label} htmlType={htmlType} />
   ));
 
   return (
@@ -43,7 +36,6 @@ export default function Form({
         {title}
       </Heading>
       <div
-        // TODO: This is a security risk, we should sanitize the HTML
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: description }}
         css={styles.description}
@@ -60,7 +52,6 @@ export default function Form({
           Our data policy
         </Heading>
         <div
-          // TODO: This is a security risk, we should sanitize the HTML
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: privacyNotice }}
           css={styles.privacyNotice}

--- a/ws-nextjs-app/pages/[service]/send/[id]/Form/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/Form/index.tsx
@@ -9,13 +9,21 @@ import styles from './styles';
 import Submit from '../SubmitButton';
 import Loader from '../Loader';
 
-export default function Form({
-  fields,
-  privacyNotice,
-}: {
+type Props = {
+  title: string;
+  sectionTitle: string;
+  description: string;
   fields: Field[];
   privacyNotice: string;
-}) {
+};
+
+export default function Form({
+  title,
+  sectionTitle,
+  description,
+  fields,
+  privacyNotice,
+}: Props) {
   const { handleSubmit, submissionError, submitted } = useFormContext();
 
   const formFields = fields?.map(({ id, label, type, htmlType, textArea }) => (
@@ -31,6 +39,17 @@ export default function Form({
 
   return (
     <>
+      <Heading level={1} id="content" tabIndex={-1} css={styles.heading}>
+        {title}
+      </Heading>
+      <div
+        // TODO: This is a security risk, we should sanitize the HTML
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: description }}
+        css={styles.description}
+      />
+      <Heading level={2}>{sectionTitle}</Heading>
+
       <form onSubmit={handleSubmit} noValidate>
         {formFields}
 

--- a/ws-nextjs-app/pages/[service]/send/[id]/Form/styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/Form/styles.ts
@@ -1,3 +1,4 @@
+import pixelsToRem from '#app/utilities/pixelsToRem';
 import { Theme, css } from '@emotion/react';
 
 export default {
@@ -9,7 +10,25 @@ export default {
       padding: '1rem',
       margin: '1rem 0',
     }),
+  heading: () =>
+    css({
+      '&:focus': {
+        outline: 'none',
+      },
+    }),
+  description: ({ palette, spacings, fontVariants, fontSizes, mq }: Theme) =>
+    css({
+      borderBottom: `${pixelsToRem(1)}rem solid ${palette.GREY_5}`,
+      marginBottom: `${spacings.DOUBLE}rem`,
 
+      ...fontVariants.sansRegular,
+      ...fontSizes.bodyCopy,
+
+      [mq.GROUP_2_MIN_WIDTH]: {
+        paddingBottom: `${spacings.FULL}rem`,
+        marginBottom: `${spacings.TRIPLE}rem`,
+      },
+    }),
   privacyNotice: ({ fontVariants, fontSizes }: Theme) =>
     css({
       ...fontVariants.sansRegular,

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormContext/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormContext/index.tsx
@@ -12,6 +12,7 @@ import { OK } from '#app/lib/statusCodes.const';
 import {
   Field,
   FieldData,
+  FormScreen,
   OnChangeHandler,
   OnChangeInputName,
   OnChangeInputValue,
@@ -26,8 +27,6 @@ type SubmissionError = {
   isRecoverable?: boolean;
 } | null;
 
-type Screen = 'form' | 'uploading' | 'success' | 'error';
-
 export type ContextProps = {
   formState: Record<OnChangeInputName, FieldData>;
   handleChange: OnChangeHandler;
@@ -36,7 +35,7 @@ export type ContextProps = {
   submitted: boolean;
   hasAttemptedSubmit: boolean;
   progress: string;
-  screen: Screen;
+  screen: FormScreen;
 };
 
 export const FormContext = createContext({} as ContextProps);
@@ -72,9 +71,10 @@ const validateFormState = (state: Record<OnChangeInputName, FieldData>) => {
 };
 
 export const FormContextProvider = ({
+  initialScreen = 'form',
   fields,
   children,
-}: PropsWithChildren<{ fields: Field[] }>) => {
+}: PropsWithChildren<{ initialScreen?: FormScreen; fields: Field[] }>) => {
   const {
     query: { id },
   } = useRouter();
@@ -84,7 +84,7 @@ export const FormContextProvider = ({
   const [progress, setProgress] = useState('0');
   // TODO: Remove lint disable once screen state switching is used
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [screen, _setScreen] = useState<Screen>('form');
+  const [screen, _setScreen] = useState<FormScreen>(initialScreen);
   const [submissionError, setSubmissionError] = useState<SubmissionError>(null);
   const [hasAttemptedSubmit, setAttemptedSubmit] = useState(false);
 

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormContext/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormContext/index.tsx
@@ -26,6 +26,8 @@ type SubmissionError = {
   isRecoverable?: boolean;
 } | null;
 
+type Screen = 'form' | 'uploading' | 'success' | 'error';
+
 export type ContextProps = {
   formState: Record<OnChangeInputName, FieldData>;
   handleChange: OnChangeHandler;
@@ -34,9 +36,10 @@ export type ContextProps = {
   submitted: boolean;
   hasAttemptedSubmit: boolean;
   progress: string;
+  screen: Screen;
 };
 
-const FormContext = createContext({} as ContextProps);
+export const FormContext = createContext({} as ContextProps);
 
 const getInitialFormState = (
   fields: Field[],
@@ -79,6 +82,9 @@ export const FormContextProvider = ({
   const [formState, setFormState] = useState(getInitialFormState(fields));
   const [submitted, setSubmitted] = useState(false);
   const [progress, setProgress] = useState('0');
+  // TODO: Remove lint disable once screen state switching is used
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [screen, _setScreen] = useState<Screen>('form');
   const [submissionError, setSubmissionError] = useState<SubmissionError>(null);
   const [hasAttemptedSubmit, setAttemptedSubmit] = useState(false);
 
@@ -179,6 +185,7 @@ export const FormContextProvider = ({
         submitted,
         progress,
         hasAttemptedSubmit,
+        screen,
       }}
     >
       {children}

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/Checkbox.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/Checkbox.tsx
@@ -13,7 +13,7 @@ export default ({
   label,
   hasAttemptedSubmit,
 }: InputProps) => {
-  const { isValid, value = false, required, wasInvalid } = inputState;
+  const { isValid, value = false, required, wasInvalid } = inputState ?? {};
 
   return (
     <div css={[styles.checkboxContainer]}>

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/EmailInput.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/EmailInput.tsx
@@ -13,7 +13,7 @@ export default ({
   label,
   hasAttemptedSubmit,
 }: InputProps) => {
-  const { isValid, value = '', required, wasInvalid } = inputState;
+  const { isValid, value = '', required, wasInvalid } = inputState ?? {};
   return (
     <>
       <Label id={id}>{label}</Label>

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/File.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/File.tsx
@@ -10,7 +10,7 @@ export default ({
   describedBy,
   label,
 }: InputProps) => {
-  const { isValid, required } = inputState;
+  const { isValid, required } = inputState ?? {};
   return (
     <>
       <Label id={id}>{label}</Label>

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/Telephone.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/Telephone.tsx
@@ -13,7 +13,7 @@ export default ({
   label,
   hasAttemptedSubmit,
 }: InputProps) => {
-  const { isValid, value = '', required, wasInvalid } = inputState;
+  const { isValid, value = '', required, wasInvalid } = inputState ?? {};
   return (
     <>
       <Label id={id}>{label}</Label>

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/TextArea.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/TextArea.tsx
@@ -13,7 +13,7 @@ export default ({
   label,
   hasAttemptedSubmit,
 }: InputProps) => {
-  const { isValid, value = '', required, wasInvalid } = inputState;
+  const { isValid, value = '', required, wasInvalid } = inputState ?? {};
 
   return (
     <>

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/TextInput.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/TextInput.tsx
@@ -13,7 +13,7 @@ export default ({
   label,
   hasAttemptedSubmit,
 }: InputProps) => {
-  const { isValid, value = '', required, wasInvalid } = inputState;
+  const { isValid, value = '', required, wasInvalid } = inputState ?? {};
 
   return (
     <>

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/index.tsx
@@ -28,31 +28,12 @@ export type FormComponentProps = {
   id: string;
   htmlType: HtmlType;
   label: string;
-  type?: string;
-  textArea?: boolean;
 };
 
-const FormField = ({
-  id,
-  type,
-  htmlType,
-  label,
-  textArea,
-}: FormComponentProps) => {
-  // TODO: Don't like this but needed atm since 'file' and 'textarea' aren't returned as 'htmlType' from the API
-  // should probably do this in back-end
-  let derivedHtmlType = htmlType;
+const FormField = ({ id, htmlType, label }: FormComponentProps) => {
   const { handleChange, formState, hasAttemptedSubmit } = useFormContext();
 
-  if (textArea) {
-    derivedHtmlType = 'textarea';
-  }
-
-  if (type === 'file') {
-    derivedHtmlType = 'file';
-  }
-
-  const Component = FormComponents[derivedHtmlType];
+  const Component = FormComponents[htmlType];
   const { isValid, messageCode } = formState[id];
   const ariaErrorDescribedById = `${id}-error`;
 

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/index.tsx
@@ -33,11 +33,11 @@ export type FormComponentProps = {
 const FormField = ({ id, htmlType, label }: FormComponentProps) => {
   const { handleChange, formState, hasAttemptedSubmit } = useFormContext();
 
-  const Component = FormComponents[htmlType];
-  const { isValid, messageCode } = formState[id];
-  const ariaErrorDescribedById = `${id}-error`;
-
+  const Component = FormComponents?.[htmlType];
   if (!Component) return null;
+
+  const { isValid, messageCode } = formState?.[id] ?? {};
+  const ariaErrorDescribedById = `${id}-error`;
 
   // As part of GEL guidelines, we should show the invalid message only after the initial submit.
   return (
@@ -47,7 +47,7 @@ const FormField = ({ id, htmlType, label }: FormComponentProps) => {
         id={id}
         name={id}
         handleChange={handleChange}
-        inputState={formState[id]}
+        inputState={formState?.[id]}
         describedBy={ariaErrorDescribedById}
         hasAttemptedSubmit={hasAttemptedSubmit}
       />

--- a/ws-nextjs-app/pages/[service]/send/[id]/UGCPageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/UGCPageLayout.tsx
@@ -9,7 +9,7 @@ import { FormContext, FormContextProvider } from './FormContext';
 import Form from './Form';
 import Uploading from './Uploading';
 
-const UGCPageLayout = ({ pageData }: PageProps) => {
+const UGCPageLayout = ({ initialScreen = 'form', pageData }: PageProps) => {
   const { lang } = useContext(ServiceContext);
   const { title, description, sections, privacyNotice } = pageData;
 
@@ -29,7 +29,7 @@ const UGCPageLayout = ({ pageData }: PageProps) => {
       <div css={styles.grid}>
         <div css={styles.primaryColumn}>
           <main css={styles.mainContent}>
-            <FormContextProvider fields={fields}>
+            <FormContextProvider initialScreen={initialScreen} fields={fields}>
               <FormContext.Consumer>
                 {({ screen }) => {
                   switch (screen) {

--- a/ws-nextjs-app/pages/[service]/send/[id]/UGCPageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/UGCPageLayout.tsx
@@ -1,13 +1,13 @@
 /** @jsx jsx */
 import React, { useContext } from 'react';
 import { jsx } from '@emotion/react';
-import Heading from '#app/components/Heading';
 import Metadata from '#app/components/Metadata';
 import { ServiceContext } from '#app/contexts/ServiceContext';
 import styles from './styles';
 import { PageProps } from './types';
-import { FormContextProvider } from './FormContext';
+import { FormContext, FormContextProvider } from './FormContext';
 import Form from './Form';
+import Uploading from './Uploading';
 
 const UGCPageLayout = ({ pageData }: PageProps) => {
   const { lang } = useContext(ServiceContext);
@@ -29,24 +29,27 @@ const UGCPageLayout = ({ pageData }: PageProps) => {
         <div css={styles.grid}>
           <div css={styles.primaryColumn}>
             <main css={styles.mainContent}>
-              <Heading
-                level={1}
-                id="content"
-                tabIndex={-1}
-                css={styles.heading}
-              >
-                {title}
-              </Heading>
-              <div
-                // TODO: This is a security risk, we should sanitize the HTML
-                // eslint-disable-next-line react/no-danger
-                dangerouslySetInnerHTML={{ __html: description }}
-                css={styles.description}
-              />
-
-              <Heading level={2}>{sectionTitle}</Heading>
               <FormContextProvider fields={fields}>
-                <Form fields={fields} privacyNotice={privacyNotice.default} />
+                <FormContext.Consumer>
+                  {({ screen }) => {
+                    switch (screen) {
+                      case 'form':
+                        return (
+                          <Form
+                            title={title}
+                            description={description}
+                            sectionTitle={sectionTitle}
+                            privacyNotice={privacyNotice?.default}
+                            fields={fields}
+                          />
+                        );
+                      case 'uploading':
+                        return <Uploading />;
+                      default:
+                        return null;
+                    }
+                  }}
+                </FormContext.Consumer>
               </FormContextProvider>
             </main>
           </div>

--- a/ws-nextjs-app/pages/[service]/send/[id]/UGCPageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/UGCPageLayout.tsx
@@ -45,8 +45,11 @@ const UGCPageLayout = ({ pageData }: PageProps) => {
                       );
                     case 'uploading':
                       return <Uploading />;
+                    case 'success':
+                      return <div>Success</div>;
+                    case 'error':
                     default:
-                      return null;
+                      return <div>Error</div>;
                   }
                 }}
               </FormContext.Consumer>

--- a/ws-nextjs-app/pages/[service]/send/[id]/UGCPageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/UGCPageLayout.tsx
@@ -25,34 +25,33 @@ const UGCPageLayout = ({ pageData }: PageProps) => {
         openGraphType="website"
         hasAmpPage={false}
       />
-      <div css={styles.background}>
-        <div css={styles.grid}>
-          <div css={styles.primaryColumn}>
-            <main css={styles.mainContent}>
-              <FormContextProvider fields={fields}>
-                <FormContext.Consumer>
-                  {({ screen }) => {
-                    switch (screen) {
-                      case 'form':
-                        return (
-                          <Form
-                            title={title}
-                            description={description}
-                            sectionTitle={sectionTitle}
-                            privacyNotice={privacyNotice?.default}
-                            fields={fields}
-                          />
-                        );
-                      case 'uploading':
-                        return <Uploading />;
-                      default:
-                        return null;
-                    }
-                  }}
-                </FormContext.Consumer>
-              </FormContextProvider>
-            </main>
-          </div>
+      <div css={styles.background} />
+      <div css={styles.grid}>
+        <div css={styles.primaryColumn}>
+          <main css={styles.mainContent}>
+            <FormContextProvider fields={fields}>
+              <FormContext.Consumer>
+                {({ screen }) => {
+                  switch (screen) {
+                    case 'form':
+                      return (
+                        <Form
+                          title={title}
+                          description={description}
+                          sectionTitle={sectionTitle}
+                          privacyNotice={privacyNotice?.default}
+                          fields={fields}
+                        />
+                      );
+                    case 'uploading':
+                      return <Uploading />;
+                    default:
+                      return null;
+                  }
+                }}
+              </FormContext.Consumer>
+            </FormContextProvider>
+          </main>
         </div>
       </div>
     </>

--- a/ws-nextjs-app/pages/[service]/send/[id]/Uploading/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/Uploading/index.tsx
@@ -4,7 +4,7 @@ import Heading from '#app/components/Heading';
 import Paragraph from '#app/components/Paragraph';
 import styles from './styles';
 
-export default function Uploading() {
+const Uploading = () => {
   return (
     <>
       <Heading level={1} id="content" tabIndex={-1} css={styles.heading}>
@@ -13,4 +13,6 @@ export default function Uploading() {
       <Paragraph>Please wait until it is finished.</Paragraph>
     </>
   );
-}
+};
+
+export default Uploading;

--- a/ws-nextjs-app/pages/[service]/send/[id]/Uploading/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/Uploading/index.tsx
@@ -10,7 +10,7 @@ export default function Uploading() {
       <Heading level={1} id="content" tabIndex={-1} css={styles.heading}>
         Uploading
       </Heading>
-      <Paragraph>Please wait while we upload your files.</Paragraph>
+      <Paragraph>Please wait until it is finished.</Paragraph>
     </>
   );
 }

--- a/ws-nextjs-app/pages/[service]/send/[id]/Uploading/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/Uploading/index.tsx
@@ -1,0 +1,16 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/react';
+import Heading from '#app/components/Heading';
+import Paragraph from '#app/components/Paragraph';
+import styles from './styles';
+
+export default function Uploading() {
+  return (
+    <>
+      <Heading level={1} id="content" tabIndex={-1} css={styles.heading}>
+        Uploading
+      </Heading>
+      <Paragraph>Please wait while we upload your files.</Paragraph>
+    </>
+  );
+}

--- a/ws-nextjs-app/pages/[service]/send/[id]/Uploading/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/Uploading/index.tsx
@@ -4,7 +4,7 @@ import Heading from '#app/components/Heading';
 import Paragraph from '#app/components/Paragraph';
 import styles from './styles';
 
-const Uploading = () => {
+export default function Uploading() {
   return (
     <>
       <Heading level={1} id="content" tabIndex={-1} css={styles.heading}>
@@ -13,6 +13,4 @@ const Uploading = () => {
       <Paragraph>Please wait until it is finished.</Paragraph>
     </>
   );
-};
-
-export default Uploading;
+}

--- a/ws-nextjs-app/pages/[service]/send/[id]/Uploading/styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/Uploading/styles.ts
@@ -1,0 +1,11 @@
+import { Theme, css } from '@emotion/react';
+
+export default {
+  heading: ({ spacings }: Theme) =>
+    css({
+      marginBottom: `${spacings.FULL}rem`,
+      '&:focus': {
+        outline: 'none',
+      },
+    }),
+};

--- a/ws-nextjs-app/pages/[service]/send/[id]/send.stories.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/send.stories.tsx
@@ -4,7 +4,7 @@ import { NextRouter } from 'next/router';
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
 import mundoFormFixture from '#data/mundo/send/test2qq3x8vt.json';
 import UGCPage from './UGCPageLayout';
-import { PageProps } from './types';
+import { FormScreen, PageProps } from './types';
 
 const NextRouterWrapper = ({ children }: PropsWithChildren) => (
   <RouterContext.Provider
@@ -14,14 +14,21 @@ const NextRouterWrapper = ({ children }: PropsWithChildren) => (
   </RouterContext.Provider>
 );
 
-const Component = () => (
+const Component = ({
+  initialScreen = 'form',
+}: {
+  initialScreen: FormScreen;
+}) => (
   <NextRouterWrapper>
     <PageLayoutWrapper
       // @ts-expect-error partial data required for storybook
       pageData={mundoFormFixture}
       status={200}
     >
-      <UGCPage pageData={mundoFormFixture as PageProps['pageData']} />
+      <UGCPage
+        initialScreen={initialScreen}
+        pageData={mundoFormFixture as PageProps['pageData']}
+      />
     </PageLayoutWrapper>
   </NextRouterWrapper>
 );
@@ -31,4 +38,5 @@ export default {
   Component,
 };
 
-export const Example = Component;
+export const Form = () => <Component initialScreen="form" />;
+export const Uploading = () => <Component initialScreen="uploading" />;

--- a/ws-nextjs-app/pages/[service]/send/[id]/styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/styles.ts
@@ -2,13 +2,22 @@ import { Theme, css } from '@emotion/react';
 import pixelsToRem from '../../../../../src/app/utilities/pixelsToRem';
 
 export default {
-  background: () =>
+  background: ({ mq }: Theme) =>
     css({
-      background:
-        'linear-gradient(200deg, #A20219 0%, #180109 54%, #180109 90%)',
+      display: 'none',
+
+      [mq.GROUP_3_MIN_WIDTH]: {
+        display: 'block',
+        position: 'absolute',
+        inset: 0,
+        background:
+          'linear-gradient(200deg, #A20219 0%, #180109 54%, #180109 90%)',
+      },
     }),
   grid: ({ mq, gridWidths, spacings }: Theme) =>
     css({
+      position: 'relative',
+
       [mq.GROUP_3_MIN_WIDTH]: {
         maxWidth: `${pixelsToRem(gridWidths[1008])}rem`,
         margin: '0 auto',

--- a/ws-nextjs-app/pages/[service]/send/[id]/styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/styles.ts
@@ -37,23 +37,4 @@ export default {
         width: '35rem',
       },
     }),
-  heading: () =>
-    css({
-      '&:focus': {
-        outline: 'none',
-      },
-    }),
-  description: ({ palette, spacings, fontVariants, fontSizes, mq }: Theme) =>
-    css({
-      borderBottom: `${pixelsToRem(1)}rem solid ${palette.GREY_5}`,
-      marginBottom: `${spacings.DOUBLE}rem`,
-
-      ...fontVariants.sansRegular,
-      ...fontSizes.bodyCopy,
-
-      [mq.GROUP_2_MIN_WIDTH]: {
-        paddingBottom: `${spacings.FULL}rem`,
-        marginBottom: `${spacings.TRIPLE}rem`,
-      },
-    }),
 };

--- a/ws-nextjs-app/pages/[service]/send/[id]/types.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/types.ts
@@ -90,7 +90,10 @@ export type FieldData = {
   wasInvalid: boolean;
 };
 
+export type FormScreen = 'form' | 'uploading' | 'success' | 'error';
+
 export type PageProps = {
+  initialScreen?: FormScreen;
   pageData: {
     title: string;
     description: string;


### PR DESCRIPTION
Part of https://jira.dev.bbc.co.uk/browse/WSTEAM1-1029

Overall changes
======
- Adds 'Uploading' screen to UGC Form
- Adds initial screen switching switch/case to allow state updates to change the displayed screen
- Small change to background gradient to allow it to fill the entire screen regardless of form height
- Moves Form header and description elements down into the `<Form />` component and out of the root
- Adds Storybook stories for the 2 current screens

Code changes
======
- Adds `<Uploading />` screen component
- Exposes `FormContext.Consumer` to get access to the context at the root of the page to allow screen switching
- Removes the `derivedHtmlType` logic as this is now determined in the BFF
- Adds `initialScreen` prop for the root page to determine which screen to show initially. More so for Storybook benefits

Testing
======
1. Visit https://wsteam1-1029-form-uploading-screen--5d28eb3fe163f6002046d6fa.chromatic.com/?path=/story/pages-ugc-page--uploading
2. Confirm the layout meets UX and a11y requirements

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
