### PR TITLE
WSTEAM1-1025 UGC Form a11y fixes

### DIFF
--- a/ws-nextjs-app/pages/[service]/send/[id]/Form/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/Form/index.tsx
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import React from 'react';
 import { jsx } from '@emotion/react';
-import Heading from '#app/components/Heading';
 import { useFormContext } from '../FormContext';
 import { Field } from '../types';
 import FormField from '../FormField';

--- a/ws-nextjs-app/pages/[service]/send/[id]/Form/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/Form/index.tsx
@@ -17,7 +17,7 @@ export default function Form({
   privacyNotice: string;
 }) {
   const { handleSubmit, submissionError, submitted } = useFormContext();
-
+  const translation = 'Our data policy';
   const formFields = fields?.map(({ id, label, type, htmlType, textArea }) => (
     <FormField
       key={id}
@@ -34,12 +34,11 @@ export default function Form({
       <form onSubmit={handleSubmit} noValidate>
         {formFields}
 
-        <Heading // TODO: need translations for this, it doesn't come through from the api
-          level={3}
+        <strong // TODO: need translations for this, it doesn't come through from the api
           css={styles.privacyHeading}
         >
-          Our data policy
-        </Heading>
+          {translation}
+        </strong>
         <div
           // TODO: This is a security risk, we should sanitize the HTML
           // eslint-disable-next-line react/no-danger

--- a/ws-nextjs-app/pages/[service]/send/[id]/Form/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/Form/index.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import React from 'react';
 import { jsx } from '@emotion/react';
+import Heading from '#app/components/Heading';
 import { useFormContext } from '../FormContext';
 import { Field } from '../types';
 import FormField from '../FormField';

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/Checkbox.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/Checkbox.tsx
@@ -30,7 +30,8 @@ export default ({
         })}
         {...(required && { 'aria-required': required })}
       />
-      <Label id={id} isCheckbox css={[styles.checkboxLabel]}>
+
+      <Label id={id} css={[styles.checkboxLabel]}>
         {label}
       </Label>
     </div>

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/Checkbox.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/Checkbox.tsx
@@ -30,7 +30,7 @@ export default ({
         })}
         {...(required && { 'aria-required': required })}
       />
-      <Label id={id} css={[styles.checkboxLabel]}>
+      <Label id={id} isCheckbox css={[styles.checkboxLabel]}>
         {label}
       </Label>
     </div>

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/EmailInput.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/EmailInput.tsx
@@ -17,19 +17,21 @@ export default ({
   return (
     <>
       <Label id={id}>{label}</Label>
-      <input
-        css={[styles.textField, styles.focusIndicator]}
-        id={id}
-        name={name}
-        type="email"
-        value={value as string}
-        onChange={e => handleChange(e.target.name, e.target.value)}
-        {...(hasAttemptedSubmit && {
-          ...(wasInvalid && { 'aria-invalid': !isValid }),
-          ...(required && { 'aria-required': required }),
-          ...(!isValid && { 'aria-describedby': describedBy }),
-        })}
-      />
+      <div>
+        <input
+          css={[styles.textField, styles.focusIndicator]}
+          id={id}
+          name={name}
+          type="email"
+          value={value as string}
+          onChange={e => handleChange(e.target.name, e.target.value)}
+          {...(hasAttemptedSubmit && {
+            ...(wasInvalid && { 'aria-invalid': !isValid }),
+            ...(required && { 'aria-required': required }),
+            ...(!isValid && { 'aria-describedby': describedBy }),
+          })}
+        />
+      </div>
     </>
   );
 };

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/FieldLabel.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/FieldLabel.tsx
@@ -9,32 +9,22 @@ export default ({
   id,
   children,
   className,
-  isCheckbox,
   withPTag,
 }: PropsWithChildren<{
   id: InputProps['id'];
   className?: string;
-  isCheckbox?: boolean;
   withPTag?: boolean;
-}>) => {
-  return isCheckbox ? (
-    <Text as="label" className={className} htmlFor={id} css={styles.fieldLabel}>
-      {children}
-    </Text>
-  ) : (
-    <div>
-      <Text
-        as="label"
-        className={className}
-        htmlFor={id}
-        css={({ spacings }: Theme) =>
-          withPTag
-            ? styles.fieldLabel
-            : [styles.fieldLabel, `marginBottom: ${spacings.FULL}rem`]
-        }
-      >
-        {children}
-      </Text>
-    </div>
-  );
-};
+}>) => (
+  <Text
+    as="label"
+    className={className}
+    htmlFor={id}
+    css={({ spacings }: Theme) =>
+      withPTag
+        ? styles.fieldLabel
+        : [styles.fieldLabel, `marginBottom: ${spacings.FULL}rem`]
+    }
+  >
+    {children}
+  </Text>
+);

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/FieldLabel.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/FieldLabel.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { PropsWithChildren } from 'react';
-import { jsx } from '@emotion/react';
+import { jsx, Theme } from '@emotion/react';
 import Text from '#app/components/Text';
 import { InputProps } from '../types';
 import styles from './styles';
@@ -10,10 +10,12 @@ export default ({
   children,
   className,
   isCheckbox,
+  withPTag,
 }: PropsWithChildren<{
   id: InputProps['id'];
   className?: string;
   isCheckbox?: boolean;
+  withPTag?: boolean;
 }>) => {
   return isCheckbox ? (
     <Text as="label" className={className} htmlFor={id} css={styles.fieldLabel}>
@@ -25,7 +27,11 @@ export default ({
         as="label"
         className={className}
         htmlFor={id}
-        css={styles.fieldLabel}
+        css={({ spacings }: Theme) =>
+          withPTag
+            ? styles.fieldLabel
+            : [styles.fieldLabel, `marginBottom: ${spacings.FULL}rem`]
+        }
       >
         {children}
       </Text>

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/FieldLabel.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/FieldLabel.tsx
@@ -9,8 +9,26 @@ export default ({
   id,
   children,
   className,
-}: PropsWithChildren<{ id: InputProps['id']; className?: string }>) => (
-  <Text as="label" className={className} htmlFor={id} css={styles.fieldLabel}>
-    {children}
-  </Text>
-);
+  isCheckbox,
+}: PropsWithChildren<{
+  id: InputProps['id'];
+  className?: string;
+  isCheckbox?: boolean;
+}>) => {
+  return isCheckbox ? (
+    <Text as="label" className={className} htmlFor={id} css={styles.fieldLabel}>
+      {children}
+    </Text>
+  ) : (
+    <div>
+      <Text
+        as="label"
+        className={className}
+        htmlFor={id}
+        css={styles.fieldLabel}
+      >
+        {children}
+      </Text>
+    </div>
+  );
+};

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/FieldLabel.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/FieldLabel.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { PropsWithChildren } from 'react';
-import { jsx, Theme } from '@emotion/react';
+import { jsx } from '@emotion/react';
 import Text from '#app/components/Text';
 import { InputProps } from '../types';
 import styles from './styles';
@@ -9,22 +9,11 @@ export default ({
   id,
   children,
   className,
-  withPTag,
 }: PropsWithChildren<{
   id: InputProps['id'];
   className?: string;
-  withPTag?: boolean;
 }>) => (
-  <Text
-    as="label"
-    className={className}
-    htmlFor={id}
-    css={({ spacings }: Theme) =>
-      withPTag
-        ? styles.fieldLabel
-        : [styles.fieldLabel, `marginBottom: ${spacings.FULL}rem`]
-    }
-  >
+  <Text as="label" className={className} htmlFor={id} css={styles.fieldLabel}>
     {children}
   </Text>
 );

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/File.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/File.tsx
@@ -14,18 +14,20 @@ export default ({
   return (
     <>
       <Label id={id}>{label}</Label>
-      <input
-        id={id}
-        name={name}
-        type="file"
-        onChange={e =>
-          e.target.files && handleChange(e.target.name, e.target.files)
-        }
-        multiple
-        aria-invalid={!isValid}
-        aria-required={required}
-        aria-describedby={describedBy}
-      />
+      <div>
+        <input
+          id={id}
+          name={name}
+          type="file"
+          onChange={e =>
+            e.target.files && handleChange(e.target.name, e.target.files)
+          }
+          multiple
+          aria-invalid={!isValid}
+          aria-required={required}
+          aria-describedby={describedBy}
+        />
+      </div>
     </>
   );
 };

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/Telephone.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/Telephone.tsx
@@ -17,19 +17,21 @@ export default ({
   return (
     <>
       <Label id={id}>{label}</Label>
-      <input
-        id={id}
-        css={[styles.textField, styles.focusIndicator]}
-        name={name}
-        type="tel"
-        value={value as string}
-        onChange={e => handleChange(e.target.name, e.target.value)}
-        {...(hasAttemptedSubmit && {
-          ...(wasInvalid && { 'aria-invalid': !isValid }),
-          ...(required && { 'aria-required': required }),
-          ...(!isValid && { 'aria-describedby': describedBy }),
-        })}
-      />
+      <div>
+        <input
+          id={id}
+          css={[styles.textField, styles.focusIndicator]}
+          name={name}
+          type="tel"
+          value={value as string}
+          onChange={e => handleChange(e.target.name, e.target.value)}
+          {...(hasAttemptedSubmit && {
+            ...(wasInvalid && { 'aria-invalid': !isValid }),
+            ...(required && { 'aria-required': required }),
+            ...(!isValid && { 'aria-describedby': describedBy }),
+          })}
+        />
+      </div>
     </>
   );
 };

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/TextArea.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/TextArea.tsx
@@ -1,5 +1,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react';
+import Paragraph from '#app/components/Paragraph';
+import pixelsToRem from '#app/utilities/pixelsToRem';
 import { InputProps } from '../types';
 import Label from './FieldLabel';
 import styles from './styles';
@@ -15,10 +17,19 @@ export default ({
 }: InputProps) => {
   const { isValid, value = '', required, wasInvalid } = inputState;
   const translation = 'Maximum 500 Words';
+
   return (
     <>
-      <Label id={id}>{label}</Label>
-      <p css={styles.textAreaLabel}>{translation}</p>
+      <Label id={id} withPTag>
+        {label}
+      </Label>
+      <Paragraph
+        css={() => `margin: ${pixelsToRem(6)}rem 0`}
+        fontVariant="sansRegular"
+        size="brevier"
+      >
+        {translation}
+      </Paragraph>
       <textarea
         id={id}
         css={[styles.textField, styles.textArea, styles.focusIndicator]}

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/TextArea.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/TextArea.tsx
@@ -20,11 +20,9 @@ export default ({
 
   return (
     <>
-      <Label id={id} withPTag>
-        {label}
-      </Label>
+      <Label id={id}>{label}</Label>
       <Paragraph
-        css={() => `margin: ${pixelsToRem(6)}rem 0`}
+        css={{ marginBottom: `${pixelsToRem(6)}rem` }}
         fontVariant="sansRegular"
         size="brevier"
       >

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/TextArea.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/TextArea.tsx
@@ -15,7 +15,6 @@ export default ({
   label,
   hasAttemptedSubmit,
 }: InputProps) => {
-
   const { isValid, value = '', required, wasInvalid } = inputState ?? {};
   const translation = 'Maximum 500 Words';
 

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/TextArea.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/TextArea.tsx
@@ -14,10 +14,11 @@ export default ({
   hasAttemptedSubmit,
 }: InputProps) => {
   const { isValid, value = '', required, wasInvalid } = inputState;
-
+  const translation = 'Maximum 500 Words';
   return (
     <>
       <Label id={id}>{label}</Label>
+      <p css={styles.textAreaLabel}>{translation}</p>
       <textarea
         id={id}
         css={[styles.textField, styles.textArea, styles.focusIndicator]}

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/TextInput.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/TextInput.tsx
@@ -18,19 +18,21 @@ export default ({
   return (
     <>
       <Label id={id}>{label}</Label>
-      <input
-        css={[styles.textField, styles.focusIndicator]}
-        id={id}
-        name={name}
-        type="text"
-        value={value as string}
-        onChange={e => handleChange(e.target.name, e.target.value)}
-        {...(hasAttemptedSubmit && {
-          ...(wasInvalid && { 'aria-invalid': !isValid }),
-          ...(required && { 'aria-required': required }),
-          ...(!isValid && { 'aria-describedby': describedBy }),
-        })}
-      />
+      <div>
+        <input
+          css={[styles.textField, styles.focusIndicator]}
+          id={id}
+          name={name}
+          type="text"
+          value={value as string}
+          onChange={e => handleChange(e.target.name, e.target.value)}
+          {...(hasAttemptedSubmit && {
+            ...(wasInvalid && { 'aria-invalid': !isValid }),
+            ...(required && { 'aria-required': required }),
+            ...(!isValid && { 'aria-describedby': describedBy }),
+          })}
+        />
+      </div>
     </>
   );
 };

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/__snapshots__/index.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/__snapshots__/index.test.tsx.snap
@@ -77,6 +77,7 @@ exports[`FormField should render a checkbox input with an associated label 1`] =
   font-style: normal;
   font-weight: 400;
   display: inline-block;
+  marginBottom: 0.5rem;
   -webkit-flex: auto;
   -ms-flex: auto;
   flex: auto;
@@ -203,21 +204,21 @@ exports[`FormField should render a tel input with an associated label 1`] = `
   <div
     class="emotion-0"
   >
+    <label
+      class="emotion-1"
+      for="testTelID"
+    >
+      This is a text field
+    </label>
     <div>
-      <label
-        class="emotion-1"
-        for="testTelID"
-      >
-        This is a text field
-      </label>
+      <input
+        class="emotion-2"
+        id="testTelID"
+        name="testTelID"
+        type="tel"
+        value=""
+      />
     </div>
-    <input
-      class="emotion-2"
-      id="testTelID"
-      name="testTelID"
-      type="tel"
-      value=""
-    />
   </div>
 </div>
 `;
@@ -302,21 +303,21 @@ exports[`FormField should render a text input with an associated label 1`] = `
   <div
     class="emotion-0"
   >
+    <label
+      class="emotion-1"
+      for="testTextID"
+    >
+      This is a text field
+    </label>
     <div>
-      <label
-        class="emotion-1"
-        for="testTextID"
-      >
-        This is a text field
-      </label>
+      <input
+        class="emotion-2"
+        id="testTextID"
+        name="testTextID"
+        type="text"
+        value=""
+      />
     </div>
-    <input
-      class="emotion-2"
-      id="testTextID"
-      name="testTextID"
-      type="text"
-      value=""
-    />
   </div>
 </div>
 `;
@@ -426,14 +427,12 @@ exports[`FormField should render a textarea input with an associated label 1`] =
   <div
     class="emotion-0"
   >
-    <div>
-      <label
-        class="emotion-1"
-        for="testTextAreaID"
-      >
-        This is a text field
-      </label>
-    </div>
+    <label
+      class="emotion-1"
+      for="testTextAreaID"
+    >
+      This is a text field
+    </label>
     <p
       class="emotion-2"
     >
@@ -529,21 +528,21 @@ exports[`FormField should render an email input with an associated label 1`] = `
   <div
     class="emotion-0"
   >
+    <label
+      class="emotion-1"
+      for="testEmailID"
+    >
+      This is a text field
+    </label>
     <div>
-      <label
-        class="emotion-1"
-        for="testEmailID"
-      >
-        This is a text field
-      </label>
+      <input
+        class="emotion-2"
+        id="testEmailID"
+        name="testEmailID"
+        type="email"
+        value=""
+      />
     </div>
-    <input
-      class="emotion-2"
-      id="testEmailID"
-      name="testEmailID"
-      type="email"
-      value=""
-    />
   </div>
 </div>
 `;

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/__snapshots__/index.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/__snapshots__/index.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`FormField should render a checkbox input with an associated label 1`] =
   font-style: normal;
   font-weight: 400;
   display: inline-block;
-  marginBottom: 0.5rem;
+  margin-bottom: 0.375rem;
   -webkit-flex: auto;
   -ms-flex: auto;
   flex: auto;
@@ -150,7 +150,7 @@ exports[`FormField should render a tel input with an associated label 1`] = `
   font-style: normal;
   font-weight: 400;
   display: inline-block;
-  marginBottom: 0.5rem;
+  margin-bottom: 0.375rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -249,7 +249,7 @@ exports[`FormField should render a text input with an associated label 1`] = `
   font-style: normal;
   font-weight: 400;
   display: inline-block;
-  marginBottom: 0.5rem;
+  margin-bottom: 0.375rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -348,6 +348,7 @@ exports[`FormField should render a textarea input with an associated label 1`] =
   font-style: normal;
   font-weight: 400;
   display: inline-block;
+  margin-bottom: 0.375rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -372,7 +373,7 @@ exports[`FormField should render a textarea input with an associated label 1`] =
   font-style: normal;
   font-weight: 400;
   margin: 0;
-  margin: 0.375rem 0;
+  margin-bottom: 0.375rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -474,7 +475,7 @@ exports[`FormField should render an email input with an associated label 1`] = `
   font-style: normal;
   font-weight: 400;
   display: inline-block;
-  marginBottom: 0.5rem;
+  margin-bottom: 0.375rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/__snapshots__/index.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/__snapshots__/index.test.tsx.snap
@@ -5,10 +5,6 @@ exports[`FormField should render a checkbox input with an associated label 1`] =
   margin-top: 1rem;
 }
 
-.emotion-0:nth-child(n+2) {
-  margin-top: 2rem;
-}
-
 .emotion-0:nth-child(5) {
   border-bottom: 0.0625rem solid #8A8C8E;
   padding-bottom: 1rem;
@@ -22,6 +18,10 @@ exports[`FormField should render a checkbox input with an associated label 1`] =
   }
 }
 
+.emotion-0:nth-of-type(5) label {
+  margin-bottom: 0;
+}
+
 .emotion-1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -31,6 +31,7 @@ exports[`FormField should render a checkbox input with an associated label 1`] =
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  padding-bottom: 1rem;
 }
 
 .emotion-2 {
@@ -41,8 +42,8 @@ exports[`FormField should render a checkbox input with an associated label 1`] =
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  width: 30px;
-  height: 30px;
+  width: 1.875rem;
+  height: 1.875rem;
   cursor: pointer;
   box-sizing: border-box;
   border: solid 0.0625rem #141414;
@@ -132,10 +133,6 @@ exports[`FormField should render a tel input with an associated label 1`] = `
   margin-top: 1rem;
 }
 
-.emotion-0:nth-child(n+2) {
-  margin-top: 2rem;
-}
-
 .emotion-0:nth-child(5) {
   border-bottom: 0.0625rem solid #8A8C8E;
   padding-bottom: 1rem;
@@ -147,6 +144,10 @@ exports[`FormField should render a tel input with an associated label 1`] = `
     padding-bottom: 1.5rem;
     margin-bottom: 1.5rem;
   }
+}
+
+.emotion-0:nth-of-type(5) label {
+  margin-bottom: 0;
 }
 
 .emotion-1 {
@@ -176,6 +177,7 @@ exports[`FormField should render a tel input with an associated label 1`] = `
 
 .emotion-2 {
   border: solid 0.0625rem #141414;
+  outline: solid 0.0625rem transparent;
   width: 100%;
   min-height: 2.75rem;
   padding: 0.5rem;
@@ -210,12 +212,14 @@ exports[`FormField should render a tel input with an associated label 1`] = `
   <div
     class="emotion-0"
   >
-    <label
-      class="emotion-1"
-      for="testTelID"
-    >
-      This is a text field
-    </label>
+    <div>
+      <label
+        class="emotion-1"
+        for="testTelID"
+      >
+        This is a text field
+      </label>
+    </div>
     <input
       class="emotion-2"
       id="testTelID"
@@ -232,10 +236,6 @@ exports[`FormField should render a text input with an associated label 1`] = `
   margin-top: 1rem;
 }
 
-.emotion-0:nth-child(n+2) {
-  margin-top: 2rem;
-}
-
 .emotion-0:nth-child(5) {
   border-bottom: 0.0625rem solid #8A8C8E;
   padding-bottom: 1rem;
@@ -247,6 +247,10 @@ exports[`FormField should render a text input with an associated label 1`] = `
     padding-bottom: 1.5rem;
     margin-bottom: 1.5rem;
   }
+}
+
+.emotion-0:nth-of-type(5) label {
+  margin-bottom: 0;
 }
 
 .emotion-1 {
@@ -276,6 +280,7 @@ exports[`FormField should render a text input with an associated label 1`] = `
 
 .emotion-2 {
   border: solid 0.0625rem #141414;
+  outline: solid 0.0625rem transparent;
   width: 100%;
   min-height: 2.75rem;
   padding: 0.5rem;
@@ -310,12 +315,14 @@ exports[`FormField should render a text input with an associated label 1`] = `
   <div
     class="emotion-0"
   >
-    <label
-      class="emotion-1"
-      for="testTextID"
-    >
-      This is a text field
-    </label>
+    <div>
+      <label
+        class="emotion-1"
+        for="testTextID"
+      >
+        This is a text field
+      </label>
+    </div>
     <input
       class="emotion-2"
       id="testTextID"
@@ -332,10 +339,6 @@ exports[`FormField should render a textarea input with an associated label 1`] =
   margin-top: 1rem;
 }
 
-.emotion-0:nth-child(n+2) {
-  margin-top: 2rem;
-}
-
 .emotion-0:nth-child(5) {
   border-bottom: 0.0625rem solid #8A8C8E;
   padding-bottom: 1rem;
@@ -347,6 +350,10 @@ exports[`FormField should render a textarea input with an associated label 1`] =
     padding-bottom: 1.5rem;
     margin-bottom: 1.5rem;
   }
+}
+
+.emotion-0:nth-of-type(5) label {
+  margin-bottom: 0;
 }
 
 .emotion-1 {
@@ -375,7 +382,31 @@ exports[`FormField should render a textarea input with an associated label 1`] =
 }
 
 .emotion-2 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  margin: 0.375rem 0;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-2 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+.emotion-3 {
   border: solid 0.0625rem #141414;
+  outline: solid 0.0625rem transparent;
   width: 100%;
   min-height: 2.75rem;
   padding: 0.5rem;
@@ -388,20 +419,20 @@ exports[`FormField should render a textarea input with an associated label 1`] =
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-2 {
+  .emotion-3 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-2 {
+  .emotion-3 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-2:focus {
+.emotion-3:focus {
   outline: 0.1875rem solid #FFFFFF;
   box-shadow: 0 0 0 0.1875rem #000000;
   outline-offset: 0.1875rem;
@@ -411,14 +442,21 @@ exports[`FormField should render a textarea input with an associated label 1`] =
   <div
     class="emotion-0"
   >
-    <label
-      class="emotion-1"
-      for="testTextAreaID"
-    >
-      This is a text field
-    </label>
-    <textarea
+    <div>
+      <label
+        class="emotion-1"
+        for="testTextAreaID"
+      >
+        This is a text field
+      </label>
+    </div>
+    <p
       class="emotion-2"
+    >
+      Maximum 500 Words
+    </p>
+    <textarea
+      class="emotion-3"
       id="testTextAreaID"
       name="testTextAreaID"
       rows="4"
@@ -432,10 +470,6 @@ exports[`FormField should render an email input with an associated label 1`] = `
   margin-top: 1rem;
 }
 
-.emotion-0:nth-child(n+2) {
-  margin-top: 2rem;
-}
-
 .emotion-0:nth-child(5) {
   border-bottom: 0.0625rem solid #8A8C8E;
   padding-bottom: 1rem;
@@ -447,6 +481,10 @@ exports[`FormField should render an email input with an associated label 1`] = `
     padding-bottom: 1.5rem;
     margin-bottom: 1.5rem;
   }
+}
+
+.emotion-0:nth-of-type(5) label {
+  margin-bottom: 0;
 }
 
 .emotion-1 {
@@ -476,6 +514,7 @@ exports[`FormField should render an email input with an associated label 1`] = `
 
 .emotion-2 {
   border: solid 0.0625rem #141414;
+  outline: solid 0.0625rem transparent;
   width: 100%;
   min-height: 2.75rem;
   padding: 0.5rem;
@@ -510,12 +549,14 @@ exports[`FormField should render an email input with an associated label 1`] = `
   <div
     class="emotion-0"
   >
-    <label
-      class="emotion-1"
-      for="testEmailID"
-    >
-      This is a text field
-    </label>
+    <div>
+      <label
+        class="emotion-1"
+        for="testEmailID"
+      >
+        This is a text field
+      </label>
+    </div>
     <input
       class="emotion-2"
       id="testEmailID"

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/__snapshots__/index.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/__snapshots__/index.test.tsx.snap
@@ -18,10 +18,6 @@ exports[`FormField should render a checkbox input with an associated label 1`] =
   }
 }
 
-.emotion-0:nth-of-type(5) label {
-  margin-bottom: 0;
-}
-
 .emotion-1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -81,7 +77,6 @@ exports[`FormField should render a checkbox input with an associated label 1`] =
   font-style: normal;
   font-weight: 400;
   display: inline-block;
-  margin-bottom: 0.5rem;
   -webkit-flex: auto;
   -ms-flex: auto;
   flex: auto;
@@ -146,10 +141,6 @@ exports[`FormField should render a tel input with an associated label 1`] = `
   }
 }
 
-.emotion-0:nth-of-type(5) label {
-  margin-bottom: 0;
-}
-
 .emotion-1 {
   color: #141414;
   font-size: 0.9375rem;
@@ -158,7 +149,7 @@ exports[`FormField should render a tel input with an associated label 1`] = `
   font-style: normal;
   font-weight: 400;
   display: inline-block;
-  margin-bottom: 0.5rem;
+  marginBottom: 0.5rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -249,10 +240,6 @@ exports[`FormField should render a text input with an associated label 1`] = `
   }
 }
 
-.emotion-0:nth-of-type(5) label {
-  margin-bottom: 0;
-}
-
 .emotion-1 {
   color: #141414;
   font-size: 0.9375rem;
@@ -261,7 +248,7 @@ exports[`FormField should render a text input with an associated label 1`] = `
   font-style: normal;
   font-weight: 400;
   display: inline-block;
-  margin-bottom: 0.5rem;
+  marginBottom: 0.5rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -352,10 +339,6 @@ exports[`FormField should render a textarea input with an associated label 1`] =
   }
 }
 
-.emotion-0:nth-of-type(5) label {
-  margin-bottom: 0;
-}
-
 .emotion-1 {
   color: #141414;
   font-size: 0.9375rem;
@@ -364,7 +347,6 @@ exports[`FormField should render a textarea input with an associated label 1`] =
   font-style: normal;
   font-weight: 400;
   display: inline-block;
-  margin-bottom: 0.5rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -382,11 +364,13 @@ exports[`FormField should render a textarea input with an associated label 1`] =
 }
 
 .emotion-2 {
+  color: #141414;
   font-size: 0.875rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-style: normal;
   font-weight: 400;
+  margin: 0;
   margin: 0.375rem 0;
 }
 
@@ -483,10 +467,6 @@ exports[`FormField should render an email input with an associated label 1`] = `
   }
 }
 
-.emotion-0:nth-of-type(5) label {
-  margin-bottom: 0;
-}
-
 .emotion-1 {
   color: #141414;
   font-size: 0.9375rem;
@@ -495,7 +475,7 @@ exports[`FormField should render an email input with an associated label 1`] = `
   font-style: normal;
   font-weight: 400;
   display: inline-block;
-  margin-bottom: 0.5rem;
+  marginBottom: 0.5rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/styles.ts
@@ -19,14 +19,10 @@ export default {
           marginBottom: `${spacings.TRIPLE}rem`,
         },
       },
-      '&:nth-of-type(5) label': {
-        marginBottom: '0',
-      },
     }),
-  fieldLabel: ({ spacings }: Theme) =>
+  fieldLabel: () =>
     css({
       display: 'inline-block',
-      marginBottom: `${spacings.FULL}rem`,
     }),
   focusIndicator: ({ palette }: Theme) =>
     css({
@@ -56,12 +52,6 @@ export default {
     css({
       resize: 'none',
     }),
-  textAreaLabel: ({ fontSizes, fontVariants }: Theme) =>
-    css({
-      ...fontSizes.brevier,
-      ...fontVariants.sansRegular,
-      margin: ` ${pixelsToRem(6)}rem 0`,
-    }),
   checkboxLabel: ({ spacings }: Theme) =>
     css({
       flex: 'auto',
@@ -73,8 +63,8 @@ export default {
       display: 'inline-block',
       flex: 'initial',
       flexShrink: 0,
-      width: '1.875rem',
-      height: '1.875rem',
+      width: `${pixelsToRem(30)}rem`,
+      height: `${pixelsToRem(30)}rem`,
       cursor: 'pointer',
       boxSizing: 'border-box',
       border: `solid 0.0625rem ${palette.GREY_10}`,

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/styles.ts
@@ -7,12 +7,7 @@ const CHECK_IMG = `data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.
 export default {
   formField: ({ spacings, palette, mq }: Theme) =>
     css({
-      '&:nth-child(n+2)': {
-        marginTop: `${spacings.QUADRUPLE}rem`,
-      },
-
       marginTop: `${spacings.DOUBLE}rem`,
-
       '&:nth-child(5)': {
         borderBottom: `${pixelsToRem(1)}rem solid ${palette.GREY_5}`,
         paddingBottom: `${spacings.DOUBLE}rem`,
@@ -23,6 +18,9 @@ export default {
           paddingBottom: `${spacings.TRIPLE}rem`,
           marginBottom: `${spacings.TRIPLE}rem`,
         },
+      },
+      '&:nth-of-type(5) label': {
+        marginBottom: '0',
       },
     }),
   fieldLabel: ({ spacings }: Theme) =>
@@ -41,21 +39,28 @@ export default {
   textField: ({ spacings, fontVariants, fontSizes, palette }: Theme) =>
     css({
       border: `solid 0.0625rem ${palette.GREY_10}`,
+      outline: 'solid 0.0625rem transparent',
       width: '100%',
       minHeight: `2.75rem`,
       padding: `${spacings.FULL}rem`,
       ...fontVariants.sansRegular,
       ...fontSizes.pica,
     }),
-  checkboxContainer: () =>
+  checkboxContainer: ({ spacings }: Theme) =>
     css({
       display: 'flex',
       flexWrap: 'nowrap',
+      paddingBottom: `${spacings.DOUBLE}rem`,
     }),
-
   textArea: () =>
     css({
       resize: 'none',
+    }),
+  textAreaLabel: ({ fontSizes, fontVariants }: Theme) =>
+    css({
+      ...fontSizes.brevier,
+      ...fontVariants.sansRegular,
+      margin: ` ${pixelsToRem(6)}rem 0`,
     }),
   checkboxLabel: ({ spacings }: Theme) =>
     css({
@@ -68,8 +73,8 @@ export default {
       display: 'inline-block',
       flex: 'initial',
       flexShrink: 0,
-      width: '30px',
-      height: '30px',
+      width: '1.875rem',
+      height: '1.875rem',
       cursor: 'pointer',
       boxSizing: 'border-box',
       border: `solid 0.0625rem ${palette.GREY_10}`,

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/styles.ts
@@ -23,6 +23,7 @@ export default {
   fieldLabel: () =>
     css({
       display: 'inline-block',
+      marginBottom: `${pixelsToRem(6)}rem`,
     }),
   focusIndicator: ({ palette }: Theme) =>
     css({

--- a/ws-nextjs-app/pages/[service]/send/[id]/SubmitButton/__snapshots__/index.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/send/[id]/SubmitButton/__snapshots__/index.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`SubmitButton should render a submit button with an associated label 1`]
   font-size: 0.9375rem;
   line-height: 1.25rem;
   border: none;
+  outline: solid 0.0625rem transparent;
   padding: 0.75rem 0;
   margin-bottom: 1rem;
   cursor: pointer;

--- a/ws-nextjs-app/pages/[service]/send/[id]/SubmitButton/styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/SubmitButton/styles.ts
@@ -9,6 +9,7 @@ export default {
       ...fontVariants.sansBold,
       ...fontSizes.bodyCopy,
       border: 'none',
+      outline: 'solid 0.0625rem transparent',
       padding: `${spacings.FULL + spacings.HALF}rem 0`,
       marginBottom: `${spacings.DOUBLE}rem`,
       cursor: 'pointer',


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-1025](https://jira.dev.bbc.co.uk/browse/WSTEAM1-1025)

Overall changes
======
Fixes a11y issues

Code changes
======

- [x] ‘Our data policy’ should be a strong element not h3 
- [x] Added ‘Maximum 500 words’ text above comments text area
- [x] Add a wrapping div element around each input (except checkbox) to improve the layout when there's no CSS
- [x] Use relative values for checkbox size so it resizes when you change the font size
- [x] Add transparent outline on input fields and button so they're clearer when viewing with colours changed in FireFox / Windows High contrast mode

- Also fixed the padding between each form field in line with the styles

Testing
======
1. Visit http://localhost.bbc.com:7081/mundo/send/u50853489?renderer_env=live or the storybook link and check all the above has been fixed
2. Check it looks correct against the [designs](https://www.figma.com/design/hbI3T5RehCO1EUsb1p9aI3/Uploader-update---MVP---Handoff-file?node-id=2003-4392&t=6XFcxSxA1VCzWqsK-0)

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
