### PR TITLE
WSTEAM1-1020 - Adds default styling for P and A elements on the Uploader form

### DIFF
--- a/src/app/components/InlineLink/index.styles.ts
+++ b/src/app/components/InlineLink/index.styles.ts
@@ -2,21 +2,20 @@ import { css, Theme } from '@emotion/react';
 
 import pixelsToRem from '../../utilities/pixelsToRem';
 
-const styles = {
-  self: ({ palette }: Theme) =>
-    css({
-      color: palette.EBON,
-      borderBottom: `${pixelsToRem(1)}rem solid ${palette.POSTBOX}`,
-      textDecoration: 'none',
-      '&:visited': {
-        color: palette.METAL,
-        borderBottom: `${pixelsToRem(1)}rem solid ${palette.METAL}`,
-      },
-      '&:focus, &:hover': {
-        borderBottom: `${pixelsToRem(2)}rem solid ${palette.POSTBOX}`,
-        color: palette.POSTBOX,
-      },
-    }),
-};
+export const getInlineLinkStyles = (palette: Theme['palette']) => ({
+  color: palette.EBON,
+  borderBottom: `${pixelsToRem(1)}rem solid ${palette.POSTBOX}`,
+  textDecoration: 'none',
+  '&:visited': {
+    color: palette.METAL,
+    borderBottom: `${pixelsToRem(1)}rem solid ${palette.METAL}`,
+  },
+  '&:focus, &:hover': {
+    borderBottom: `${pixelsToRem(2)}rem solid ${palette.POSTBOX}`,
+    color: palette.POSTBOX,
+  },
+});
 
-export default styles;
+export const styles = {
+  self: ({ palette }: Theme) => css(getInlineLinkStyles(palette)),
+};

--- a/src/app/components/InlineLink/index.tsx
+++ b/src/app/components/InlineLink/index.tsx
@@ -6,7 +6,7 @@ import Url from 'url-parse';
 
 import { FontVariant, GelFontSize } from '../../models/types/theming';
 import { ServiceContext } from '../../contexts/ServiceContext';
-import styles from './index.styles';
+import { styles } from './index.styles';
 
 interface Props extends HTMLAttributes<HTMLElement> {
   className?: string;

--- a/ws-nextjs-app/pages/[service]/send/[id]/Form/styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/Form/styles.ts
@@ -1,4 +1,5 @@
 import { Theme, css } from '@emotion/react';
+import { getInlineLinkStyles } from '#app/components/InlineLink/index.styles';
 
 export default {
   submissionError: () =>
@@ -10,11 +11,14 @@ export default {
       margin: '1rem 0',
     }),
 
-  privacyNotice: ({ fontVariants, fontSizes }: Theme) =>
+  privacyNotice: ({ palette, fontVariants, fontSizes }: Theme) =>
     css({
       ...fontVariants.sansRegular,
       ...fontSizes.brevier,
+      p: { color: palette.BLACK },
+      a: getInlineLinkStyles(palette),
     }),
+
   privacyHeading: ({ fontVariants, fontSizes }: Theme) =>
     css({
       ...fontVariants.sansBold,

--- a/ws-nextjs-app/pages/[service]/send/[id]/styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/styles.ts
@@ -1,4 +1,5 @@
 import { Theme, css } from '@emotion/react';
+import { getInlineLinkStyles } from '#app/components/InlineLink/index.styles';
 import pixelsToRem from '../../../../../src/app/utilities/pixelsToRem';
 
 export default {
@@ -55,5 +56,7 @@ export default {
         paddingBottom: `${spacings.FULL}rem`,
         marginBottom: `${spacings.TRIPLE}rem`,
       },
+      p: { color: palette.BLACK },
+      a: getInlineLinkStyles(palette),
     }),
 };


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-1020](https://jira.dev.bbc.co.uk/browse/WSTEAM1-1020)

Overall changes
======
Adds default styling for p and a elements on the uploader page to fix a bug with Firefox retaining adjusted colours when disabled

Code changes
======

- Refactors `InlineLink` component to export style object
- Creates styles for p and a tags on Uploader components

Testing
======
1. Cd into `ws-nextjs-app`
2. Run `yarn dev`
3. Visit http://localhost:7081/mundo/send/u50853472?renderer_env=live on Firfox
4. Change colour settings in preferences
5. See colour changes
6. Set colours back to `never`
7. Colours should revert back to default

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
