### PR TITLE
UGC Form a11y fix - specify text colour for privacyHeading

### DIFF
--- a/ws-nextjs-app/pages/[service]/send/[id]/Form/styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/Form/styles.ts
@@ -40,8 +40,9 @@ export default {
       a: getInlineLinkStyles(palette),
     }),
 
-  privacyHeading: ({ fontVariants, fontSizes }: Theme) =>
+  privacyHeading: ({ fontVariants, fontSizes, palette }: Theme) =>
     css({
+      color: palette.BLACK,
       ...fontVariants.sansBold,
       ...fontSizes.brevier,
     }),


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Specifies text colour for privacy heading to resolve this bug :
"When I change colours in Firefox and view the page with these colours, when I then go back to the colour settings and select 'Never' and view the page again, I can still see the privacy heading showing the colours I selected (even though I am not viewing in this mode now)."

![Screenshot 2024-05-21 at 16 53 23](https://github.com/bbc/simorgh/assets/71819756/26057791-3ff3-4f17-8186-1ab8db7b32eb)


Code changes
======

- _A bullet point list of key code changes that have been made._

Testing
======
1. Visit http://localhost.bbc.com:7081/mundo/send/u50853489?renderer_env=live or the storybook link on firefox, change colour preferences and observe the "Our data policy" text reflecting the changes, change the colours back to default and observe the text reflecting this.

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
