### PR TITLE
WSTEAM1-1060 - Uploader inline links reduced width focus indicator

### DIFF
--- a/ws-nextjs-app/pages/[service]/send/[id]/SuccessMessage/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/SuccessMessage/index.tsx
@@ -82,12 +82,22 @@ const SuccessMessage = () => {
         <Paragraph>{retentionPolicy}</Paragraph>
         <Paragraph>
           {emailGuidelineClauses?.[0]}
-          <a href={`mailto:${DEFAULT_EMAIL}`}>{DEFAULT_EMAIL}</a>
+          <a
+            href={`mailto:${DEFAULT_EMAIL}`}
+            className="focusIndicatorReducedWidth"
+          >
+            {DEFAULT_EMAIL}
+          </a>
           {emailGuidelineClauses?.[1]} {removalGuidelineText}
         </Paragraph>
         <Paragraph>
           {privacyClauses?.[0]}
-          <a href={privacyPolicyLinkHref}>{privacyPolicyLinkText}</a>
+          <a
+            href={privacyPolicyLinkHref}
+            className="focusIndicatorReducedWidth"
+          >
+            {privacyPolicyLinkText}
+          </a>
           {privacyClauses?.[1]}
         </Paragraph>
       </div>


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAM1-1060

Overall changes
======
- Adds `focusIndicatorReducedWidth` CSS class to Uploader success screen inline links

Testing
======
1. Visit the Storybook link for the Success screen: https://wsteam1-1060-uploader-inlinelinks-red--5d28eb3fe163f6002046d6fa.chromatic.com/?path=/story/pages-ugc-page--success 
2. Focus on the inline links
3. Confirm it is using the thinner/reduced width border focus styling

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
