### PR TITLE
Fix UGC success 'tick' SVG for RTL languages

### DIFF
--- a/ws-nextjs-app/pages/[service]/send/[id]/SuccessMessage/index.styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/SuccessMessage/index.styles.ts
@@ -21,7 +21,7 @@ export default {
     }),
   tickIcon: ({ spacings, mq, palette }: Theme) =>
     css({
-      marginRight: `${spacings.FULL}rem`,
+      marginInlineEnd: `${spacings.FULL}rem`,
       fill: palette.SUCCESS_CORE,
       [mq.HIGH_CONTRAST]: {
         path: {

--- a/ws-nextjs-app/pages/[service]/send/[id]/send.stories.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/send.stories.tsx
@@ -36,6 +36,9 @@ const Component = ({
 export default {
   title: 'Pages/UGC Page',
   Component,
+  parameters: {
+    layout: 'fullscreen',
+  },
 };
 
 export const Form = () => (
@@ -47,7 +50,7 @@ export const UploaderForm = () => (
 export const Uploading = () => (
   <Component initialScreen="uploading" fixtureData={mundoFormFixture} />
 );
-  
+
 export const Success = () => (
   <Component initialScreen="success" fixtureData={mundoFormFixture} />
 );


### PR DESCRIPTION
Overall changes
======
- Uses `marginInlineEnd` instead of `marginRight` to ensure the spacing between the 'tick' SVG and the header text is the same on RTL languages

Code changes
======
- Updates CSS for spacing between 'tick' SVG and header text on the UGC success screen
- Adds `layout: 'fullscreen'` for UGC page Storybook stories to remove the padding around the preview


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
