### PR TITLE
Add `cache-control` header to Next.js pages

### DIFF
--- a/src/app/lib/utilities/getToggles/withCache.js
+++ b/src/app/lib/utilities/getToggles/withCache.js
@@ -2,9 +2,12 @@ import Cache from 'lru-cache';
 import getToggles from '.';
 import { getEnvConfig } from '../getEnvConfig';
 
-const cacheMaxItems = parseInt(getEnvConfig().SIMORGH_CONFIG_CACHE_ITEMS, 10);
+const cacheMaxItems = parseInt(
+  getEnvConfig().SIMORGH_CONFIG_CACHE_ITEMS ?? 400,
+  10,
+);
 const cacheTTL = parseInt(
-  getEnvConfig().SIMORGH_CONFIG_CACHE_MAX_AGE_SECONDS,
+  getEnvConfig().SIMORGH_CONFIG_CACHE_MAX_AGE_SECONDS ?? 300,
   10,
 );
 const cache = new Cache({ max: cacheMaxItems, ttl: cacheTTL * 1000 });

--- a/ws-nextjs-app/pages/[service]/live/[id]/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/[[...variant]].page.tsx
@@ -92,6 +92,11 @@ const getPageData = async ({
 };
 
 export const getServerSideProps: GetServerSideProps = async context => {
+  context.res.setHeader(
+    'Cache-Control',
+    'public, stale-if-error=300, stale-while-revalidate=120, max-age=30',
+  );
+
   logResponseTime(
     {
       path: context.resolvedUrl,

--- a/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
@@ -8,7 +8,9 @@ import {
 } from '#app/components/react-testing-library-with-providers';
 import liveFixture from '#data/pidgin/livePage/c7p765ynk9qt.json';
 import postFixture from '#data/pidgin/posts/postFixture.json';
+import { GetServerSidePropsContext } from 'next';
 import Live from './LivePageLayout';
+import { getServerSideProps } from './[[...variant]].page';
 
 const mockPageData = {
   ...liveFixture.data,
@@ -99,6 +101,26 @@ const mockPageDataWithMetadata = ({
 };
 
 describe('Live Page', () => {
+  it('Should set Cache-Control header to correct values', async () => {
+    const context = {
+      query: {
+        service: 'pidgin',
+        id: 'c7p765ynk9qt',
+      },
+      req: { headers: {} },
+      res: {
+        setHeader: jest.fn(),
+        on: jest.fn(),
+      },
+    } as unknown as GetServerSidePropsContext;
+
+    await getServerSideProps(context);
+    expect(context.res.setHeader).toHaveBeenCalledWith(
+      'Cache-Control',
+      'public, stale-if-error=300, stale-while-revalidate=120, max-age=30',
+    );
+  });
+
   it.each`
     title             | seoTitle             | info                      | expected
     ${'I am a Title'} | ${'I am a seoTitle'} | ${'seoTitle'}             | ${'I am a seoTitle - BBC News Pidgin'}

--- a/ws-nextjs-app/pages/[service]/send/[id]/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/[[...variant]].page.tsx
@@ -9,6 +9,11 @@ import UGCPageLayout from './UGCPageLayout';
 const logger = nodeLogger(__filename);
 
 export const getServerSideProps: GetServerSideProps = async context => {
+  context.res.setHeader(
+    'Cache-Control',
+    'public, stale-if-error=300, stale-while-revalidate=120, max-age=30',
+  );
+
   const isLite = isLitePath(context.resolvedUrl);
 
   const {

--- a/ws-nextjs-app/pages/ws/languages.page.tsx
+++ b/ws-nextjs-app/pages/ws/languages.page.tsx
@@ -1,12 +1,17 @@
 import Head from 'next/head';
 import * as React from 'react';
-import { GetStaticProps } from 'next';
+import { GetServerSideProps } from 'next';
 import { STATIC_PAGE } from '#app/routes/utils/pageTypes';
 import ChartbeatAnalytics from '#app/components/ChartbeatAnalytics';
 import ATIAnalytics from '#app/components/ATIAnalytics';
 import MetadataContainer from '#app/components/Metadata';
 
-export const getStaticProps: GetStaticProps = () => {
+export const getServerSideProps: GetServerSideProps = async context => {
+  context.res.setHeader(
+    'Cache-Control',
+    'public, stale-if-error=300, stale-while-revalidate=120, max-age=30',
+  );
+
   return {
     props: {
       error: null,
@@ -15,11 +20,11 @@ export const getStaticProps: GetStaticProps = () => {
       page: null,
       pageData: {
         metadata: {
-            type: STATIC_PAGE,
+          type: STATIC_PAGE,
         },
       },
       pageType: STATIC_PAGE,
-      pathname: '/ws/languages',
+      pathname: context.resolvedUrl,
       service: 'ws',
       status: 200,
       timeOnServer: Date.now(), // TODO: check if needed?
@@ -31,11 +36,10 @@ const morphCSS1 = `@charset "CP850";@font-face{font-family:ReithSans;font-weight
 
 const morphCSS2 = `body{color:#404040;font-family:ReithSans,Arial,Helvetica,sans-serif}ol,ul{list-style:none}a:link{-webkit-tap-highlight-color:rgba(17,103,168,.3)}#core-navigation{display:none}.column-clearfix::after,.column-clearfix::before{content:"";display:block;height:0;overflow:hidden}.column-clearfix::after,.column-clearfix::before{clear:both}.units-list .unit+.unit{padding-top:9px}.units-list--separators .unit+.unit{padding-top:8px;border-top:1px solid #dcdcdc}.units-list--columning .unit+.unit{padding-top:0}.units-list .unit+.unit{padding-top:17px}#page{position:relative;z-index:10;background:#fff}.c-open{font-size:14px;padding-left:0;margin:0 auto;box-sizing:border-box;-webkit-box-sizing:border-box;-moz-box-sizing:border-box}.container{padding-bottom:42px}.container ul{margin:0;padding:0}.story-body__h1{font-family:ReithSerif,Arial,Helvetica,sans-serif;font-size:1.5rem;line-height:1.125;color:#1e1e1e;font-weight:700;margin:0;}.column--primary{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;padding-right:16px;padding-top:12px}.group__title{font-family:ReithSerif,Arial,Helvetica,sans-serif;font-size:24px;font-size:1.5rem;line-height:1;text-rendering:optimizeLegibility;letter-spacing:-.0425em;font-weight:700;margin-bottom:.5em}.group-title-component{margin-top:40px}.unit{clear:both;margin-bottom:8px}.container{padding-left:8px;padding-right:8px}.hide{display:none}.atlas-languages-page a{text-decoration:none;color:inherit}.atlas-languages-page a:focus,.atlas-languages-page a:hover{color:#1167a8}.language-switcher{padding:8px 0; margin:0;}@media (max-width:600px){.group-title-component{float:none}.group-title-component:nth-child(2){clear:both}}@media (min-width:480px){.container{padding-left:16px;padding-right:16px}.unit{margin-bottom:16px}}@media (min-width:600px){.group-title-component{float:left;width:50%}.group-title-component:nth-child(3),.group-title-component:nth-child(5),.group-title-component:nth-child(7){clear:both}.story-body__h1{font-size:2.25rem}.column--primary{padding-top:24px}}@media (min-width:976px){.container{margin:0 auto;max-width:1008px}.group-title-component{float:left;width:25%}.group-title-component:nth-child(3),.group-title-component:nth-child(5),.group-title-component:nth-child(7){clear:none}.story-body__h1{font-size:2rem}.column--primary{padding-top:20px;float:left;width:976px}}@media (min-width:1280px){.container{margin:0 auto;max-width:63.4rem; padding:0}}`;
 
-// @ts-ignore
-const languageToggle = e => {
+const languageToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
   e.stopPropagation();
   const elements = document.querySelectorAll('.panel, .toggle');
-  for (let i = 0; i < elements.length; ++i) {
+  for (let i = 0; i < elements.length; i += 1) {
     const classNames = elements[i].className.split(' ');
     const indexOfHide = classNames.indexOf('hide');
     if (indexOfHide !== -1) {
@@ -93,6 +97,7 @@ const pageLayout = () => {
                     className="switcher"
                     id="switcher"
                     onClick={languageToggle}
+                    type="button"
                   >
                     <span className="toggle">Switch list to English</span>
                     <span className="toggle hide">
@@ -114,7 +119,7 @@ const pageLayout = () => {
                       </li>
                       <li id="afrique" className="unit">
                         <a href="https://www.bbc.com/afrique">
-                          L'actualité en Français
+                          L&#39;actualité en Français
                         </a>
                       </li>
                       <li id="hausa" className="unit">

--- a/ws-nextjs-app/setupTests.ts
+++ b/ws-nextjs-app/setupTests.ts
@@ -1,4 +1,12 @@
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'node:util';
+import { ReadableStream } from 'node:stream/web';
+
+Object.defineProperties(globalThis, {
+  TextDecoder: { value: TextDecoder },
+  TextEncoder: { value: TextEncoder },
+  ReadableStream: { value: ReadableStream },
+});
 
 global.console = {
   ...console,


### PR DESCRIPTION
Overall changes
======
Sets the `cache-control` header on Next.js pages to ensure the CDN serves cached copies of the page to users where applicable.

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
