### PR TITLE
Uploader Success Page: Add outline none to header

### DIFF
--- a/ws-nextjs-app/pages/[service]/send/[id]/SuccessMessage/index.styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/SuccessMessage/index.styles.ts
@@ -29,6 +29,12 @@ export default {
         },
       },
     }),
+  heading: () =>
+    css({
+      '&:focus': {
+        outline: 'none',
+      },
+    }),
   descriptionContainer: ({ spacings }: Theme) =>
     css({
       '& > p, & > div': {

--- a/ws-nextjs-app/pages/[service]/send/[id]/SuccessMessage/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/SuccessMessage/index.tsx
@@ -64,7 +64,13 @@ const SuccessMessage = () => {
         <TickSvg css={styles.tickIcon} />
         <div css={styles.messageTextContainer}>
           <div>
-            <Heading level={1} id="content" tabIndex={-1} size="trafalgar">
+            <Heading
+              level={1}
+              id="content"
+              tabIndex={-1}
+              size="trafalgar"
+              css={styles.heading}
+            >
               {confirmationStepTitle}
             </Heading>
             <Paragraph>{confirmationStepDescriptionHtml}</Paragraph>


### PR DESCRIPTION
Resolves JIRA N/A

Overall changes
======
Ensures outline does not appear around Heading on form Success page (to match default form page)

Code changes
======
Adds outline none styling to H1 on focus state.

Testing
======
[Open storybook UGC permalink ](https://a11y-fix-outline-none--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&id=pages-ugc-page--success&viewMode=story)
Use the Skip to content link in the brand
Ensure outline does not appear around heading

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
