### PR TITLE
Testing to see if skip installs will stop renovate from timing out

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": ["config:recommended", ":pinDependencies"],
   "enabledManagers": ["npm"],
+  "skipInstalls": true,
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
Overall changes
======
According to the renovate logs, the builds are timing out when trying to run `yarn install --mode=skip-builds`

Here's the renovate code:
https://github.com/renovatebot/renovate/blob/4914b6c26c18fd13b4ca79417be49e4e9af03061/lib/modules/manager/npm/post-update/yarn.ts#L185-L188

If we set skipInstalls to true, then perhaps it might not time out? Worth a try.

Code changes
======

Set skipInstalls = true to see if this stops the renovate jobs from timing out?

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
