### PR TITLE
Updates to Indian and Ukranian navigation bars

### DIFF
--- a/src/app/lib/config/services/gujarati.ts
+++ b/src/app/lib/config/services/gujarati.ts
@@ -325,10 +325,6 @@ export const service: DefaultServiceConfig = {
         url: '/gujarati',
       },
       {
-        title: 'લોકસભા ચૂંટણી 2024',
-        url: '/gujarati/topics/cg843q7vgq3t',
-      },
-      {
         title: 'ગુજરાત',
         url: '/gujarati/topics/cz74kjn4j5wt',
       },

--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -364,10 +364,6 @@ export const service: DefaultServiceConfig = {
         url: '/hindi',
       },
       {
-        title: 'लोकसभा चुनाव 2024',
-        url: '/hindi/topics/cm5m26q8qxpt',
-      },
-      {
         title: 'भारत',
         url: '/hindi/topics/ckdxnkz7607t',
       },

--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -338,10 +338,6 @@ export const service: DefaultServiceConfig = {
         url: '/marathi',
       },
       {
-        title: 'लोकसभा निवडणूक 2024',
-        url: '/marathi/topics/c1wmk63rjkvt',
-      },
-      {
         title: 'महाराष्ट्र',
         url: '/marathi/topics/c5qvpxvv7y3t',
       },

--- a/src/app/lib/config/services/punjabi.ts
+++ b/src/app/lib/config/services/punjabi.ts
@@ -279,10 +279,6 @@ export const service: DefaultServiceConfig = {
         url: '/punjabi',
       },
       {
-        title: 'ਲੋਕ ਸਭਾ ਚੋਣਾਂ 2024',
-        url: '/punjabi/topics/cz4xp0dw200t',
-      },
-      {
         title: 'ਵੀਡੀਓ',
         url: '/punjabi/topics/cx12qmz6jm4t',
       },

--- a/src/app/lib/config/services/tamil.ts
+++ b/src/app/lib/config/services/tamil.ts
@@ -343,8 +343,8 @@ export const service: DefaultServiceConfig = {
         url: '/tamil',
       },
       {
-        title: 'மக்களவைத் தேர்தல் 2024',
-        url: '/tamil/topics/cpw2q7jk0kwt',
+        title: 'டி20 உலகக் கோப்பை',
+        url: '/tamil/topics/c1nqez19x01t',
       },
       {
         title: 'உலகம்',

--- a/src/app/lib/config/services/telugu.ts
+++ b/src/app/lib/config/services/telugu.ts
@@ -329,10 +329,6 @@ export const service: DefaultServiceConfig = {
         url: '/telugu',
       },
       {
-        title: 'ఆంధ్ర ప్రదేశ్ అసెంబ్లీ ఎన్నికలు 2024',
-        url: '/telugu/topics/c442kv3851yt',
-      },
-      {
         title: 'వీడియో',
         url: '/telugu/topics/cl29j0e3e2dt',
       },

--- a/src/app/lib/config/services/ukrainian.ts
+++ b/src/app/lib/config/services/ukrainian.ts
@@ -351,6 +351,10 @@ const baseServiceConfig = {
       title: 'Подкасти',
       url: '/ukrainian/podcasts/p09jsy3h',
     },
+    {
+      title: 'Євро – 2024',
+      url: '/ukrainian/topics/ckvv0w1kqnzt',
+    },
   ],
 };
 

--- a/src/integration/pages/homePage/hindi/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/homePage/hindi/__snapshots__/amp.test.js.snap
@@ -207,61 +207,54 @@ exports[`AMP Home Page Header Navigation link should match text and url 1`] = `
 
 exports[`AMP Home Page Header Navigation link should match text and url 2`] = `
 {
-  "text": "लोकसभा चुनाव 2024",
-  "url": "/hindi/topics/cm5m26q8qxpt",
-}
-`;
-
-exports[`AMP Home Page Header Navigation link should match text and url 3`] = `
-{
   "text": "भारत",
   "url": "/hindi/topics/ckdxnkz7607t",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 4`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 3`] = `
 {
   "text": "विदेश",
   "url": "/hindi/topics/c9wpm0en87xt",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 4`] = `
 {
   "text": "मनोरंजन",
   "url": "/hindi/topics/c06gq3n0pp7t",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 5`] = `
 {
   "text": "खेल",
   "url": "/hindi/topics/cwr9j8g1kj9t",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 6`] = `
 {
   "text": "विज्ञान-टेक्नॉलॉजी",
   "url": "/hindi/topics/c2lej0594knt",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 7`] = `
 {
   "text": "सोशल",
   "url": "/hindi/topics/c2e4q0z9qznt",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 8`] = `
 {
   "text": "वीडियो",
   "url": "/hindi/topics/cw9kv0kpxydt",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 9`] = `
 {
   "text": "पॉडकास्ट",
   "url": "/hindi/institutional-61824775",

--- a/src/integration/pages/homePage/hindi/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/hindi/__snapshots__/canonical.test.js.snap
@@ -75,61 +75,54 @@ exports[`Canonical Home Page Header Navigation link should match text and url 1`
 
 exports[`Canonical Home Page Header Navigation link should match text and url 2`] = `
 {
-  "text": "लोकसभा चुनाव 2024",
-  "url": "/hindi/topics/cm5m26q8qxpt",
-}
-`;
-
-exports[`Canonical Home Page Header Navigation link should match text and url 3`] = `
-{
   "text": "भारत",
   "url": "/hindi/topics/ckdxnkz7607t",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 3`] = `
 {
   "text": "विदेश",
   "url": "/hindi/topics/c9wpm0en87xt",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 4`] = `
 {
   "text": "मनोरंजन",
   "url": "/hindi/topics/c06gq3n0pp7t",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 5`] = `
 {
   "text": "खेल",
   "url": "/hindi/topics/cwr9j8g1kj9t",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 6`] = `
 {
   "text": "विज्ञान-टेक्नॉलॉजी",
   "url": "/hindi/topics/c2lej0594knt",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 7`] = `
 {
   "text": "सोशल",
   "url": "/hindi/topics/c2e4q0z9qznt",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 8`] = `
 {
   "text": "वीडियो",
   "url": "/hindi/topics/cw9kv0kpxydt",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 9`] = `
 {
   "text": "पॉडकास्ट",
   "url": "/hindi/institutional-61824775",


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
- Remove election topic links to the navgation bar of Gujarati, Hindi, Marathi, Punjanbi and Telugu
- Replaced election topic with T20 WC on Tamil's nav bar
- Added Euro 2024 to Ukrainian's navbar 
- 
======

- Edited Navigation section of src/app/lib/config/services/gujarati.ts to remove election topic
- Edited Navigation section of src/app/lib/config/services/hindi.ts to remove election topic
- Edited Navigation section of src/app/lib/config/services/marathi.ts to remove election topic
- Edited Navigation section of src/app/lib/config/services/punjabi.ts to remove election topic
- Edited Navigation section of src/app/lib/config/services/tamil.ts to replace election topic link with T20 WC topic
- Edited Navigation section of src/app/lib/config/services/telugu.ts to remove election topic
- Edited Navigation section of src/app/lib/config/services/ukrainian.ts to add Euro 2024 at the end
- Updated snapshots

Testing
======
1. Open the Gujarati, Hindi, Marathi, Punjabi and Telugu front page there should be no election topic link in second position
2. Open the Tamil front page the second link in the nav should open /tamil/topics/c1nqez19x01t
3. Open the Ukrainian front page the last link in the nav should open /ukrainian/topics/ckvv0w1kqnzt

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
