### PR TITLE
Updated Gujarati and Tamil navvigation

### DIFF
--- a/src/app/lib/config/services/gujarati.ts
+++ b/src/app/lib/config/services/gujarati.ts
@@ -332,6 +332,10 @@ export const service: DefaultServiceConfig = {
         url: '/gujarati/topics/c83plvezd90t',
       },
       {
+        title: 'હવામાન સમાચાર',
+        url: '/gujarati/topics/cv2gk3nze31t',
+      },
+      {
         title: 'સ્પોર્ટ્સ',
         url: '/gujarati/topics/c404vn5qxq9t',
       },

--- a/src/app/lib/config/services/tamil.ts
+++ b/src/app/lib/config/services/tamil.ts
@@ -338,10 +338,6 @@ export const service: DefaultServiceConfig = {
         url: '/tamil',
       },
       {
-        title: 'டி20 உலகக் கோப்பை',
-        url: '/tamil/topics/c1nqez19x01t',
-      },
-      {
         title: 'உலகம்',
         url: '/tamil/topics/c40379e2n2zt',
       },


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Added Weather news topic link to Gujarati's navigation bar
- Removed T20 Worlcup topic link from BBC Tamil nav bar

Code changes
======

- Edited Navigation section of src/app/lib/config/services/gujarati.ts to add Weather news topic link in fifth position
- Edited Navigation section of src/app/lib/config/services/tamil.ts to remove T20 topic link from second position


Testing
======
1. Open Gujarati's front page, fitfh link in the nav should be હવામાન સમાચાર and open /gujarati/topics/cv2gk3nze31t
2. Open Tamil' front page, டி20 உலகக் கோப்பை (/tamil/topics/c1nqez19x01t) should no longer be the second link in the nav 

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
