### PR TITLE
WSTEAM1-1157 - Next.js app ATI analytics object fix

### DIFF
--- a/src/app/components/ATIAnalytics/types.ts
+++ b/src/app/components/ATIAnalytics/types.ts
@@ -27,6 +27,7 @@ export interface PageData {
       producer?: string;
     };
     atiAnalytics?: {
+      pageIdentifier?: string;
       producerId?: string;
       chapter?: string;
     };

--- a/src/app/components/ATIAnalytics/types.ts
+++ b/src/app/components/ATIAnalytics/types.ts
@@ -15,6 +15,23 @@ export interface AMPAnalyticsData {
   triggers: { trackPageview: { on: string; request: string } };
 }
 
+export interface ATIData {
+  campaigns?: { campaignId?: string; campaignName?: string }[] | null;
+  categoryName?: string | null;
+  contentId?: string | null;
+  contentType?: string;
+  language?: string | null;
+  ldpThingIds?: string | null;
+  ldpThingLabels?: string | null;
+  nationsProducer?: string | null;
+  pageIdentifier?: string;
+  pageTitle?: string | null;
+  producerId?: string | null;
+  producerName?: string | null;
+  timePublished?: string | null;
+  timeUpdated?: string | null;
+}
+
 export interface PageData {
   metadata?: {
     analyticsLabels?: {
@@ -59,23 +76,6 @@ export interface PageData {
   lastRecordTimeStamp?: string;
   contentType?: string;
   title?: string;
-}
-
-export interface ATIData {
-  campaigns?: { campaignId?: string; campaignName?: string }[] | null;
-  categoryName?: string | null;
-  contentId?: string | null;
-  contentType?: string;
-  language?: string | null;
-  ldpThingIds?: string | null;
-  ldpThingLabels?: string | null;
-  nationsProducer?: string | null;
-  pageIdentifier?: string;
-  pageTitle?: string | null;
-  producerId?: string | null;
-  producerName?: string | null;
-  timePublished?: string | null;
-  timeUpdated?: string | null;
 }
 
 export interface ATIDataWithContexts {

--- a/src/app/components/ATIAnalytics/types.ts
+++ b/src/app/components/ATIAnalytics/types.ts
@@ -26,11 +26,7 @@ export interface PageData {
       pageTitle?: string;
       producer?: string;
     };
-    atiAnalytics?: {
-      pageIdentifier?: string;
-      producerId?: string;
-      chapter?: string;
-    };
+    atiAnalytics?: ATIData;
     locators?: { optimoUrn?: string; curie?: string };
     passport?: {
       category?: { categoryId?: string; categoryName?: string };

--- a/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
@@ -52,7 +52,7 @@ type ComponentProps = {
     promoImage: LivePromoImage | null;
     startDateTime?: string;
     endDateTime?: string;
-    atiAnalytics: ATIData;
+    metadata: { atiAnalytics: ATIData };
   };
 };
 
@@ -69,7 +69,7 @@ const LivePage = ({ pageData }: ComponentProps) => {
     isLive,
     summaryPoints: { content: keyPoints },
     liveTextStream,
-    atiAnalytics,
+    metadata: { atiAnalytics = undefined } = {},
     headerImage,
     promoImage,
   } = pageData;

--- a/ws-nextjs-app/pages/[service]/live/[id]/live.stories.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/live.stories.tsx
@@ -13,6 +13,7 @@ const mockPageData = {
   someResponse: {
     block: 'Its a block',
   },
+  metadata: { atiAnalytics: {} },
 };
 
 const Component = () => (

--- a/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
@@ -38,6 +38,7 @@ const mockPageData = {
     altText: 'Man',
     copyright: 'BBC',
   },
+  metadata: { atiAnalytics: {} },
 };
 
 const mockPageDataWithPosts = {
@@ -49,6 +50,7 @@ const mockPageDataWithPosts = {
     content: postFixture,
     contributors: 'Not a random dude',
   },
+  metadata: { atiAnalytics: {} },
 };
 
 const mockPageDataWithoutKeyPoints = {
@@ -64,6 +66,7 @@ const mockPageDataWithoutKeyPoints = {
     content: postFixture,
     contributors: 'Not a random dude',
   },
+  metadata: { atiAnalytics: {} },
 };
 
 const mockPageDataWithMetadata = ({

--- a/ws-nextjs-app/pages/_app.page.tsx
+++ b/ws-nextjs-app/pages/_app.page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { AppProps } from 'next/app';
+import { ATIData } from '#app/components/ATIAnalytics/types';
 import { ToggleContextProvider } from '../../src/app/contexts/ToggleContext';
 import { ServiceContextProvider } from '../../src/app/contexts/ServiceContext';
 import { RequestContextProvider } from '../../src/app/contexts/RequestContext';
@@ -27,7 +28,7 @@ interface Props extends AppProps {
     pageData: {
       metadata: {
         type: PageTypes;
-        atiAnalytics?: { pageIdentifier?: string };
+        atiAnalytics?: ATIData;
       };
     };
     pageLang?: string;

--- a/ws-nextjs-app/pages/_app.page.tsx
+++ b/ws-nextjs-app/pages/_app.page.tsx
@@ -27,7 +27,7 @@ interface Props extends AppProps {
     pageData: {
       metadata: {
         type: PageTypes;
-        atiAnalytics?: { pageIdentifier: string };
+        atiAnalytics?: { pageIdentifier?: string };
       };
     };
     pageLang?: string;
@@ -67,7 +67,7 @@ export default function App({ Component, pageProps }: Props) {
     isUK,
   } = pageProps;
 
-  const { metadata: { atiAnalytics } = {} } = pageData;
+  const { metadata: { atiAnalytics = {} } = {} } = pageData ?? {};
 
   return (
     <ToggleContextProvider toggles={toggles}>

--- a/ws-nextjs-app/pages/_app.page.tsx
+++ b/ws-nextjs-app/pages/_app.page.tsx
@@ -68,7 +68,7 @@ export default function App({ Component, pageProps }: Props) {
     isUK,
   } = pageProps;
 
-  const { metadata: { atiAnalytics = {} } = {} } = pageData ?? {};
+  const { metadata: { atiAnalytics = undefined } = {} } = pageData ?? {};
 
   return (
     <ToggleContextProvider toggles={toggles}>

--- a/ws-nextjs-app/pages/_app.page.tsx
+++ b/ws-nextjs-app/pages/_app.page.tsx
@@ -27,8 +27,8 @@ interface Props extends AppProps {
     pageData: {
       metadata: {
         type: PageTypes;
+        atiAnalytics?: { pageIdentifier: string };
       };
-      atiAnalytics?: { pageIdentifier: string };
     };
     pageLang?: string;
     pageType: PageTypes;
@@ -67,6 +67,8 @@ export default function App({ Component, pageProps }: Props) {
     isUK,
   } = pageProps;
 
+  const { metadata: { atiAnalytics } = {} } = pageData;
+
   return (
     <ToggleContextProvider toggles={toggles}>
       <ServiceContextProvider
@@ -91,9 +93,9 @@ export default function App({ Component, pageProps }: Props) {
           mvtExperiments={mvtExperiments}
           isNextJs={isNextJs}
           isUK={isUK ?? false}
-          counterName={pageData?.atiAnalytics?.pageIdentifier ?? null}
+          counterName={atiAnalytics?.pageIdentifier ?? null}
         >
-          <EventTrackingContextProvider data={pageData}>
+          <EventTrackingContextProvider atiData={atiAnalytics} data={pageData}>
             <UserContextProvider>
               <PageWrapper pageData={pageData} status={status}>
                 {status === 200 ? (


### PR DESCRIPTION
Part of https://jira.dev.bbc.co.uk/browse/WSTEAM1-1157

Overall changes
======
- Extracts ATI analytics from the new `metadata.atiAnalytics` object if available
- This will enable backwards compatiblity whilst the BFF changes are made to return analytics values in the new `metadata.atiAnalytics` structure, falling back to using the values from the root `pageData` object if not: https://github.com/bbc/simorgh/blob/76620a8856e726ddf5839d7916266c1ac8079c46/src/app/components/ATIAnalytics/params/index.ts#L152

Testing
======
- Run this branch locally
- Open a Live page, e.g. http://localhost:7081/burmese/live/cx8jgp1zxylt?renderer_env=live
- Check the Chrome dev tools, under the 'Fetch/XHR' tab
- Confirm that ATI beacons continue to send as before


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
