### PR TITLE
Uploader: Make page title translations consistent

### DIFF
--- a/ws-nextjs-app/pages/[service]/send/[id]/ErrorScreen/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/ErrorScreen/index.tsx
@@ -20,8 +20,8 @@ export default function ErrorScreen({ title }: Props) {
   const ref = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {
-    document.title = `Error: ${title}`;
-  }, [title]);
+    document.title = `${errorHeading}: ${title}`;
+  }, [title, errorHeading]);
 
   useEffect(() => {
     ref.current?.focus();

--- a/ws-nextjs-app/pages/[service]/send/[id]/UploadingScreen/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/UploadingScreen/index.tsx
@@ -18,8 +18,8 @@ export default function UploadingScreen({ title }: Props) {
   } = useContext(ServiceContext);
 
   useEffect(() => {
-    document.title = `Uploading: ${title}`;
-  }, [title]);
+    document.title = `${uploadingHeading}: ${title}`;
+  }, [title, uploadingHeading]);
 
   const ref = useRef<HTMLHeadingElement>(null);
   useEffect(() => {


### PR DESCRIPTION
Resolves JIRA N/A

Overall changes
======
Uses translations on page title on Error Screen and Uploading Screen (as we do for Sucess Screen)

Code changes
======
Uses translations on page title on Error Screen and Uploading Screen

Testing
======
Pull down PR and visit http://localhost.bbc.com:7081/mundo/send/u50853489?renderer_env=live
Go through stages and see page title in the browser tab.

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
