### PR TITLE
Add Quota reform topic to Bengali nav and remove Euro 2024

### DIFF
--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -324,6 +324,10 @@ export const service: DefaultServiceConfig = {
         url: '/bengali',
       },
       {
+        title: 'কোটা আন্দোলন',
+        url: '/bengali/topics/cz47p4p81qdt',
+      },
+      {
         title: 'রাজনীতি',
         url: '/bengali/topics/cqywj91rkg6t',
       },

--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -111,10 +111,6 @@ export const service: SerbianConfig = {
         url: '/serbian/lat',
       },
       {
-        title: 'Euro 2024',
-        url: '/serbian/lat/topics/cl442rlk0mjt',
-      },
-      {
         title: 'Ukrajina',
         url: '/serbian/lat/topics/c5wzvzzz5vrt',
       },
@@ -498,10 +494,6 @@ export const service: SerbianConfig = {
       {
         title: 'Почетна страна',
         url: '/serbian/cyr',
-      },
-      {
-        title: 'Еуро 2024',
-        url: '/serbian/cyr/topics/cz998753m4qt',
       },
       {
         title: 'Украјина',

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -321,10 +321,6 @@ export const service: DefaultServiceConfig = {
         url: '/turkce/topics/ckdxn2xk95gt',
       },
       {
-        title: 'Euro 2024',
-        url: '/turkce/topics/cd11gkz9yvxt',
-      },
-      {
         title: 'Rusya-Ukrayna Savaşı',
         url: '/turkce/topics/cy0ryl4pvx6t',
       },

--- a/src/app/lib/config/services/ukrainian.ts
+++ b/src/app/lib/config/services/ukrainian.ts
@@ -347,10 +347,6 @@ const baseServiceConfig = {
       title: 'Подкасти',
       url: '/ukrainian/podcasts/p09jsy3h',
     },
-    {
-      title: 'Євро – 2024',
-      url: '/ukrainian/topics/ckvv0w1kqnzt',
-    },
   ],
 };
 

--- a/src/integration/pages/frontPage/serbian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/frontPage/serbian/__snapshots__/amp.test.js.snap
@@ -216,47 +216,40 @@ exports[`AMP Front Page Header Navigation link should match text and url 1`] = `
 
 exports[`AMP Front Page Header Navigation link should match text and url 2`] = `
 {
-  "text": "Euro 2024",
-  "url": "/serbian/lat/topics/cl442rlk0mjt",
-}
-`;
-
-exports[`AMP Front Page Header Navigation link should match text and url 3`] = `
-{
   "text": "Ukrajina",
   "url": "/serbian/lat/topics/c5wzvzzz5vrt",
 }
 `;
 
-exports[`AMP Front Page Header Navigation link should match text and url 4`] = `
+exports[`AMP Front Page Header Navigation link should match text and url 3`] = `
 {
   "text": "Srbija",
   "url": "/serbian/lat/topics/cr50vdy9q6wt",
 }
 `;
 
-exports[`AMP Front Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Front Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Balkan",
   "url": "/serbian/lat/topics/c06g87137jgt",
 }
 `;
 
-exports[`AMP Front Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Front Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Svet",
   "url": "/serbian/lat/topics/c2lej05e1eqt",
 }
 `;
 
-exports[`AMP Front Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Front Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Video",
   "url": "/serbian/lat/topics/c44vyp5g049t",
 }
 `;
 
-exports[`AMP Front Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Front Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Najpopularnije",
   "url": "/serbian/lat/popular/read",

--- a/src/integration/pages/frontPage/serbian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/frontPage/serbian/__snapshots__/canonical.test.js.snap
@@ -75,47 +75,40 @@ exports[`Canonical Front Page Header Navigation link should match text and url 1
 
 exports[`Canonical Front Page Header Navigation link should match text and url 2`] = `
 {
-  "text": "Euro 2024",
-  "url": "/serbian/lat/topics/cl442rlk0mjt",
-}
-`;
-
-exports[`Canonical Front Page Header Navigation link should match text and url 3`] = `
-{
   "text": "Ukrajina",
   "url": "/serbian/lat/topics/c5wzvzzz5vrt",
 }
 `;
 
-exports[`Canonical Front Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Front Page Header Navigation link should match text and url 3`] = `
 {
   "text": "Srbija",
   "url": "/serbian/lat/topics/cr50vdy9q6wt",
 }
 `;
 
-exports[`Canonical Front Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Front Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Balkan",
   "url": "/serbian/lat/topics/c06g87137jgt",
 }
 `;
 
-exports[`Canonical Front Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Front Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Svet",
   "url": "/serbian/lat/topics/c2lej05e1eqt",
 }
 `;
 
-exports[`Canonical Front Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Front Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Video",
   "url": "/serbian/lat/topics/c44vyp5g049t",
 }
 `;
 
-exports[`Canonical Front Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Front Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Najpopularnije",
   "url": "/serbian/lat/popular/read",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds Quota reform topic links to the navgation bar of Bengali
- Removed Euro 2024 BBC Serbian, Turkce and Ukrainian


Code changes
======
- Edited Navigation section of src/app/lib/config/services/bengali.ts to add Quota reform topic link in second position
- Edited Navigation section of src/app/lib/config/services/serbian.ts to remove Euro 2024
- Edited Navigation section of src/app/lib/config/services/turkce.ts to remove Euro 2024
- Edited Navigation section of src/app/lib/config/services/ukrainian.ts to remove Euro 2024
- updated snapshots


Testing
======
1. Open Bengali's front page, second link in the nav should be কোটা আন্দোলন and open /bengali/topics/cz47p4p81qdt
2. Open Serbian's front page, Euro 2024 should not longer appear in second position of the nav bar
3. Open Turkce's front page, Euro 2024 should not longer appear in third position of the nav bar
4. Open Ukrainian's front page, Євро – 2024 should not longer appear in the nav bar's last position 


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
