### PR TITLE
Add YouTube link to Brasil podcast and update Russian byline

### DIFF
--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -172,7 +172,7 @@ export const mainTranslations = {
     listItemImage: 'Добавить фото',
     published: 'Опубликовано',
     reportingFrom: 'Место сообщения',
-    role: 'Должность',
+    role: 'Место работы',
   },
   media: {
     noJs: 'Для просмотра этого контента вам надо включить JavaScript или использовать другой браузер',

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/portuguese.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/portuguese.js
@@ -12,6 +12,12 @@ const externalLinks = {
           'https://podcasts.apple.com/br/podcast/que-hist%C3%B3ria/id1492686435',
         linkType: 'apple',
       },
+      {
+        linkText: 'YouTube',
+        linkUrl:
+          'https://www.youtube.com/playlist?list=PLCX5XjxKTpTmh19ipbvr6OACmBWczOLJO',
+        linkType: 'youtube',
+      },
     ],
     p09qw1cn: [
       {


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Added Youtube link to Brasil's p07r3r3t podcast 
- Update role string in BBC Russian byline


Code changes
======
- Added Youtube link to src>app>routes.onDemandAudio>tempData>podcastExternalLinks>portuguese.js
- Edited role in Byline  section of src/app/lib/config/services/russian.ts


Testing
======
1. Open localhost:7080/portuguese/podcasts/p07r3r3t?renderer_env=live third link in External links should be YouTube and point to https://www.youtube.com/playlist?list=PLCX5XjxKTpTmh19ipbvr6OACmBWczOLJO 


<img width="787" alt="braisl_podcast" src="https://github.com/user-attachments/assets/d6cd4cfa-c540-4f70-b48e-dfdb77aa604a">


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
