### PR TITLE
WSTEAM1: Extends onBlur handleFocusOut to checkbox

### DIFF
--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/Checkbox.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/Checkbox.tsx
@@ -9,6 +9,7 @@ export default ({
   id,
   name,
   handleChange,
+  handleFocusOut,
   inputState,
   label,
   hasAttemptedSubmit,
@@ -38,6 +39,7 @@ export default ({
           type="checkbox"
           checked={value as boolean}
           onChange={e => handleChange(e.target.name, e.target.checked)}
+          onBlur={e => handleFocusOut(e.target.name)}
           {...(!hasAttemptedSubmit && { 'aria-invalid': 'false' })}
           {...(hasAttemptedSubmit && {
             ...(wasInvalid && { 'aria-invalid': !isValid }),


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Fixes issue with required checkbox on form when error message does not disappear after error is resolved.

Code changes
======
Extends onBlur handleFocusOut behaviour to checkbox.

Testing
======
1. Visit form with required checkbox, e.g. http://localhost.bbc.com:7081/somali/send/u130092370?renderer_env=test
2. Press submit to see validation errors
3. Fix checkbox validation error
4. See error message disappear.

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
