### PR TITLE
WSTEAM1: Gets Success Screen translations from page data

### DIFF
--- a/ws-nextjs-app/pages/[service]/send/[id]/SuccessScreen/index.stories.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/SuccessScreen/index.stories.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import SuccessScreen from '.';
 
-const Component = () => <SuccessScreen title="Form title" />;
+const Component = () => (
+  <SuccessScreen
+    title="Form title"
+    replyEmailAddress="test@bbc.co.uk"
+    retentionPeriod="270"
+  />
+);
 
 export default {
   title: 'Components/FormScreens/SuccessScreen',

--- a/ws-nextjs-app/pages/[service]/send/[id]/SuccessScreen/index.test.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/SuccessScreen/index.test.tsx
@@ -12,6 +12,8 @@ jest.mock('next/router', () => ({
 }));
 
 const MOCK_TITLE = 'Test Title';
+const MOCK_EMAIL = 'test@bbc.co.uk';
+const MOCK_RETENTION_PERIOD = '270';
 
 describe('SuccessScreen', () => {
   beforeEach(() => {
@@ -20,7 +22,13 @@ describe('SuccessScreen', () => {
 
   it('Should have a h1', async () => {
     const { container } = await act(() => {
-      return render(<SuccessScreen title={MOCK_TITLE} />);
+      return render(
+        <SuccessScreen
+          title={MOCK_TITLE}
+          replyEmailAddress={MOCK_EMAIL}
+          retentionPeriod={MOCK_RETENTION_PERIOD}
+        />,
+      );
     });
     const h1 = container.querySelector('h1');
 
@@ -38,7 +46,11 @@ describe('SuccessScreen', () => {
     const { container } = await act(() => {
       return render(
         <FormContext.FormContextProvider fields={[]}>
-          <SuccessScreen title={MOCK_TITLE} />
+          <SuccessScreen
+            title={MOCK_TITLE}
+            replyEmailAddress={MOCK_EMAIL}
+            retentionPeriod={MOCK_RETENTION_PERIOD}
+          />
         </FormContext.FormContextProvider>,
       );
     });
@@ -48,21 +60,33 @@ describe('SuccessScreen', () => {
 
   it('Should have a retention policy', async () => {
     const { container } = await act(() => {
-      return render(<SuccessScreen title={MOCK_TITLE} />);
+      return render(
+        <SuccessScreen
+          title={MOCK_TITLE}
+          replyEmailAddress={MOCK_EMAIL}
+          retentionPeriod={MOCK_RETENTION_PERIOD}
+        />,
+      );
     });
 
     expect(container.innerHTML).toContain(
-      `We'll keep your submission for up to`,
+      `We'll keep your submission for up to 270 days – and if we don't use it we'll then delete it and any other information you sent us.`,
     );
   });
 
   it('Should provide an email for removal services', async () => {
     const { container } = await act(() => {
-      return render(<SuccessScreen title={MOCK_TITLE} />);
+      return render(
+        <SuccessScreen
+          title={MOCK_TITLE}
+          replyEmailAddress={MOCK_EMAIL}
+          retentionPeriod={MOCK_RETENTION_PERIOD}
+        />,
+      );
     });
 
     const emailAnchor = container.querySelector(
-      'a[href="mailto:CannotFindEmail@bbc.co.uk"]',
+      'a[href="mailto:test@bbc.co.uk"]',
     );
 
     expect(emailAnchor).toBeInTheDocument();
@@ -70,7 +94,13 @@ describe('SuccessScreen', () => {
 
   it('Should have a privacy policy link', async () => {
     const { container } = await act(() => {
-      return render(<SuccessScreen title={MOCK_TITLE} />);
+      return render(
+        <SuccessScreen
+          title={MOCK_TITLE}
+          replyEmailAddress={MOCK_EMAIL}
+          retentionPeriod={MOCK_RETENTION_PERIOD}
+        />,
+      );
     });
 
     const policyAnchor = container.querySelector(

--- a/ws-nextjs-app/pages/[service]/send/[id]/SuccessScreen/index.test.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/SuccessScreen/index.test.tsx
@@ -58,7 +58,7 @@ describe('SuccessScreen', () => {
     expect(container.innerHTML).toContain(`TestSubmissionID`);
   });
 
-  it('Should have a retention policy', async () => {
+  it('Should have a retention policy if a retention period is provided', async () => {
     const { container } = await act(() => {
       return render(
         <SuccessScreen
@@ -74,7 +74,23 @@ describe('SuccessScreen', () => {
     );
   });
 
-  it('Should provide an email for removal services', async () => {
+  it('Should not have a retention policy if retention period is not provided', async () => {
+    const { container } = await act(() => {
+      return render(
+        <SuccessScreen
+          title={MOCK_TITLE}
+          replyEmailAddress={MOCK_EMAIL}
+          retentionPeriod=""
+        />,
+      );
+    });
+
+    expect(container.innerHTML).not.toContain(
+      `We'll keep your submission for up to 270 days – and if we don't use it we'll then delete it and any other information you sent us.`,
+    );
+  });
+
+  it('Should have an clause for removal services if reply email address is provided', async () => {
     const { container } = await act(() => {
       return render(
         <SuccessScreen
@@ -88,8 +104,34 @@ describe('SuccessScreen', () => {
     const emailAnchor = container.querySelector(
       'a[href="mailto:test@bbc.co.uk"]',
     );
+    const emailGuidelineClauseStart = `If you change your mind and don't want us to use it, just email us at`;
+    const emailGuidelineClauseEnd = `Don't forget the reference number. If you submitted something for a programme or online, we won't be able to remove it once we use it.`;
 
     expect(emailAnchor).toBeInTheDocument();
+    expect(container.innerHTML).toContain(emailGuidelineClauseStart);
+    expect(container.innerHTML).toContain(emailGuidelineClauseEnd);
+  });
+
+  it('Should not have clause for removal services if reply email addres is not provided', async () => {
+    const { container } = await act(() => {
+      return render(
+        <SuccessScreen
+          title={MOCK_TITLE}
+          replyEmailAddress=""
+          retentionPeriod={MOCK_RETENTION_PERIOD}
+        />,
+      );
+    });
+
+    const emailAnchor = container.querySelector(
+      'a[href="mailto:test@bbc.co.uk"]',
+    );
+    const emailGuidelineClauseStart = `If you change your mind and don't want us to use it, just email us at`;
+    const emailGuidelineClauseEnd = `Don't forget the reference number. If you submitted something for a programme or online, we won't be able to remove it once we use it.`;
+
+    expect(emailAnchor).not.toBeInTheDocument();
+    expect(container.innerHTML).not.toContain(emailGuidelineClauseStart);
+    expect(container.innerHTML).not.toContain(emailGuidelineClauseEnd);
   });
 
   it('Should have a privacy policy link', async () => {

--- a/ws-nextjs-app/pages/[service]/send/[id]/SuccessScreen/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/SuccessScreen/index.tsx
@@ -10,14 +10,17 @@ import TickSvg from './svgs';
 import { useFormContext } from '../FormContext';
 import fallbackTranslations from '../fallbackTranslations';
 
-const DEFAULT_RETENTION_POLICY_DAY = '270';
-const DEFAULT_EMAIL = 'CannotFindEmail@bbc.co.uk';
-
 type Props = {
   title: string;
+  replyEmailAddress: string;
+  retentionPeriod: string;
 };
 
-const SuccessScreen = ({ title }: Props) => {
+const SuccessScreen = ({
+  title,
+  replyEmailAddress,
+  retentionPeriod,
+}: Props) => {
   const {
     translations: {
       ugc: {
@@ -49,7 +52,7 @@ const SuccessScreen = ({ title }: Props) => {
 
   const retentionPolicy = retentionPeriodDays?.replace(
     '{{days}}',
-    DEFAULT_RETENTION_POLICY_DAY,
+    retentionPeriod,
   );
 
   const privacyClauses = privacyInfoHtml?.split('{{privacyInfoLink}}');
@@ -87,10 +90,10 @@ const SuccessScreen = ({ title }: Props) => {
         <Paragraph>
           {emailGuidelineClauses?.[0]}
           <a
-            href={`mailto:${DEFAULT_EMAIL}`}
+            href={`mailto:${replyEmailAddress}`}
             className="focusIndicatorReducedWidth"
           >
-            {DEFAULT_EMAIL}
+            {replyEmailAddress}
           </a>
           {emailGuidelineClauses?.[1]} {removalGuidelineText}
         </Paragraph>

--- a/ws-nextjs-app/pages/[service]/send/[id]/SuccessScreen/index.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/SuccessScreen/index.tsx
@@ -86,17 +86,19 @@ const SuccessScreen = ({
           </Text>
           <Paragraph>{submissionID}</Paragraph>
         </div>
-        <Paragraph>{retentionPolicy}</Paragraph>
-        <Paragraph>
-          {emailGuidelineClauses?.[0]}
-          <a
-            href={`mailto:${replyEmailAddress}`}
-            className="focusIndicatorReducedWidth"
-          >
-            {replyEmailAddress}
-          </a>
-          {emailGuidelineClauses?.[1]} {removalGuidelineText}
-        </Paragraph>
+        {retentionPeriod && <Paragraph>{retentionPolicy}</Paragraph>}
+        {replyEmailAddress && (
+          <Paragraph>
+            {replyEmailAddress && emailGuidelineClauses?.[0]}
+            <a
+              href={`mailto:${replyEmailAddress}`}
+              className="focusIndicatorReducedWidth"
+            >
+              {replyEmailAddress}
+            </a>
+            {emailGuidelineClauses?.[1]} {removalGuidelineText}
+          </Paragraph>
+        )}
         <Paragraph>
           {privacyClauses?.[0]}
           <a

--- a/ws-nextjs-app/pages/[service]/send/[id]/UGCPageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/UGCPageLayout.tsx
@@ -33,6 +33,7 @@ const UGCPageLayout = ({ initialScreen = 'form', pageData }: PageProps) => {
     privacyNotice,
     campaignStatus,
     closingTime,
+    settings,
   } = pageData;
 
   const { fields } = sections?.[0] ?? {};
@@ -81,7 +82,13 @@ const UGCPageLayout = ({ initialScreen = 'form', pageData }: PageProps) => {
                         case 'uploading':
                           return <UploadingScreen title={title} />;
                         case 'success':
-                          return <SuccessScreen title={title} />;
+                          return (
+                            <SuccessScreen
+                              title={title}
+                              replyEmailAddress={settings.replyEmailAddress}
+                              retentionPeriod={settings.retentionPeriodDays}
+                            />
+                          );
                         case 'error':
                         default:
                           return <ErrorScreen title={title} />;

--- a/ws-nextjs-app/pages/[service]/send/[id]/types.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/types.ts
@@ -115,6 +115,10 @@ export type PageProps = {
   pageData: {
     title: string;
     description: string;
+    settings: {
+      replyEmailAddress: string;
+      retentionPeriodDays: string;
+    };
     sections: Section[];
     privacyNotice: {
       default: string;


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Gets replyEmailAddress and retentionPeriod from UGC config to use on the form Success Screen.

Code changes
======
- Extracts settings from UGC config page data
- Passes values for settings.replyEmailAddress and settings.retentionPeriodDays through to Success screen to be used as values
- Makes sections of success screen conditional on these values being present.
- Extends/Updates unit tests and story file.

(Note this only supports forms that use retentionPeriod (a number of days). We noticed a current Competition using retentionExpiryDate (a set date). I've confirmed with editorial we are not yet supporting Compeitions.

Testing
======
Test on Storybook (Tested as part of development)
1. Visit Success screen component storybook 'Components/FormScreens/SuccessScreen'
2. See replyEmailAddress and retentionPeriod values displayed.
3. Option to pull down locally and change/replace the values with empty string to check they change

Check on live (once merged)
1. Visit an asset (will need to be one that you can reach the success screen of)
2. Check UGC config file
3. Cofirm replyEmailAddress and retentionPeriod in UGC config file are the same as those used on Success screen

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
