### PR TITLE
Renames HIGH_CONTRAST to FORCED_COLOURS

### DIFF
--- a/.storybook/StorybookComponents/ColorList/ColorCard/index.styles.tsx
+++ b/.storybook/StorybookComponents/ColorList/ColorCard/index.styles.tsx
@@ -10,21 +10,21 @@ const styles = {
 
   color:
     colorCode =>
-      ({ spacings, mq }: Theme) =>
-        css({
-          '::before': {
-            content: '""',
-            display: 'block',
-            height: '4rem',
-            margin: `-${spacings.FULL}rem`,
-            marginBottom: `${spacings.FULL}rem`,
+    ({ spacings, mq }: Theme) =>
+      css({
+        '::before': {
+          content: '""',
+          display: 'block',
+          height: '4rem',
+          margin: `-${spacings.FULL}rem`,
+          marginBottom: `${spacings.FULL}rem`,
+          background: colorCode,
+          [mq.FORCED_COLOURS]: {
             background: colorCode,
-            [mq.FORCED_COLOURS]: {
-              background: colorCode,
-              forcedColorAdjust: 'none',
-            },
+            forcedColorAdjust: 'none',
           },
-        }),
+        },
+      }),
 
   text: { display: 'block' },
 };

--- a/.storybook/StorybookComponents/ColorList/ColorCard/index.styles.tsx
+++ b/.storybook/StorybookComponents/ColorList/ColorCard/index.styles.tsx
@@ -10,21 +10,21 @@ const styles = {
 
   color:
     colorCode =>
-    ({ spacings, mq }: Theme) =>
-      css({
-        '::before': {
-          content: '""',
-          display: 'block',
-          height: '4rem',
-          margin: `-${spacings.FULL}rem`,
-          marginBottom: `${spacings.FULL}rem`,
-          background: colorCode,
-          [mq.HIGH_CONTRAST]: {
+      ({ spacings, mq }: Theme) =>
+        css({
+          '::before': {
+            content: '""',
+            display: 'block',
+            height: '4rem',
+            margin: `-${spacings.FULL}rem`,
+            marginBottom: `${spacings.FULL}rem`,
             background: colorCode,
-            forcedColorAdjust: 'none',
+            [mq.FORCED_COLOURS]: {
+              background: colorCode,
+              forcedColorAdjust: 'none',
+            },
           },
-        },
-      }),
+        }),
 
   text: { display: 'block' },
 };

--- a/docs/Coding-Standards/Migrating-Legacy-Components.mdx
+++ b/docs/Coding-Standards/Migrating-Legacy-Components.mdx
@@ -252,8 +252,8 @@ export default styles;
 | `@media (min-width: ${GEL_GROUP_1_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {` | `[mq.GROUP_1_AND_GROUP_2]: {` |
 | `@media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {` | `[mq.GROUP_3_ONLY]: {`        |
 | `@media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {` | `[mq.GROUP_4_ONLY]: {`        |
-| **High Contrast**                                                                                        |                               |
-| `@media screen and (forced-colors: active)`                                                              | `[mq.HIGH_CONTRAST]: {`       |
+| **Forced Colours/High Contrast**                                                                         |                               |
+| `@media screen and (forced-colors: active)`                                                              | `[mq.FORCED_COLOURS]: {`      |
 
 ### Migrating GEL Breakpoints (Spacing)
 

--- a/src/app/components/Billboard/index.styles.ts
+++ b/src/app/components/Billboard/index.styles.ts
@@ -27,7 +27,7 @@ export default {
       display: 'flex',
       flexDirection: 'column',
       position: 'relative',
-      [mq.HIGH_CONTRAST]: {
+      [mq.FORCED_COLOURS]: {
         border: `solid ${pixelsToRem(3)}rem transparent`,
       },
     }),
@@ -77,7 +77,7 @@ export default {
         width: `${spacings.TRIPLE + spacings.HALF}rem`,
         height: `${spacings.TRIPLE + spacings.HALF}rem`,
       },
-      [mq.HIGH_CONTRAST]: {
+      [mq.FORCED_COLOURS]: {
         color: 'canvasText',
       },
     }),

--- a/src/app/components/Byline/index.styles.tsx
+++ b/src/app/components/Byline/index.styles.tsx
@@ -37,7 +37,7 @@ export default {
       fill: 'currentcolor',
       width: `${spacings.FULL + spacings.HALF}rem`,
       height: `${spacings.FULL + spacings.HALF}rem`,
-      [mq.HIGH_CONTRAST]: { fill: 'linkText' },
+      [mq.FORCED_COLOURS]: { fill: 'linkText' },
     }),
 
   twitterChevron: ({ palette, spacings, mq }: Theme) =>
@@ -48,7 +48,7 @@ export default {
       fill: 'currentcolor',
       width: `${spacings.FULL}rem`,
       height: `${spacings.FULL}rem`,
-      [mq.HIGH_CONTRAST]: { fill: 'linkText' },
+      [mq.FORCED_COLOURS]: { fill: 'linkText' },
     }),
 
   link: ({ mq }: Theme) =>
@@ -61,7 +61,7 @@ export default {
           textDecoration: 'underline',
         },
       },
-      [mq.HIGH_CONTRAST]: {
+      [mq.FORCED_COLOURS]: {
         '&:visited': {
           svg: {
             fill: 'VisitedText',

--- a/src/app/components/Embeds/EmbedError/index.styles.tsx
+++ b/src/app/components/Embeds/EmbedError/index.styles.tsx
@@ -14,7 +14,7 @@ const styles = {
       [mq.GROUP_4_MIN_WIDTH]: {
         margin: `0 0 ${spacings.TRIPLE}rem`,
       },
-      [mq.HIGH_CONTRAST]: {
+      [mq.FORCED_COLOURS]: {
         border: `${pixelsToRem(3)}rem solid transparent`,
       },
     }),

--- a/src/app/components/Embeds/Uploader/index.styles.tsx
+++ b/src/app/components/Embeds/Uploader/index.styles.tsx
@@ -16,7 +16,7 @@ const styles = {
     css({
       backgroundColor: palette.WHITE,
       padding: `${spacings.DOUBLE}rem`,
-      [mq.HIGH_CONTRAST]: {
+      [mq.FORCED_COLOURS]: {
         border: '0.1875rem solid transparent',
       },
     }),

--- a/src/app/components/MessageBanner/index.styles.tsx
+++ b/src/app/components/MessageBanner/index.styles.tsx
@@ -17,7 +17,7 @@ const styles = {
         background:
           'linear-gradient(-120deg, #A20219 0%, #180109 54%, #180109 90%)',
       },
-      [mq.HIGH_CONTRAST]: {
+      [mq.FORCED_COLOURS]: {
         border: '0.1875rem solid transparent',
       },
     }),

--- a/src/app/components/Pagination/index.styles.ts
+++ b/src/app/components/Pagination/index.styles.ts
@@ -74,7 +74,7 @@ const styles = {
       textAlign: 'center',
       margin: '0 0.125rem',
       svg: {
-        [mq.HIGH_CONTRAST]: {
+        [mq.FORCED_COLOURS]: {
           fill: 'linkText',
         },
         fill: 'currentColor',
@@ -94,7 +94,7 @@ const styles = {
       margin: '0 0.125rem',
       color: palette.GREY_5,
       svg: {
-        [mq.HIGH_CONTRAST]: {
+        [mq.FORCED_COLOURS]: {
           fill: 'canvasText',
         },
         fill: 'currentColor',

--- a/src/app/components/ThemeProvider/mediaQueries.ts
+++ b/src/app/components/ThemeProvider/mediaQueries.ts
@@ -43,4 +43,4 @@ export const GROUP_4_ONLY = `@media (min-width: ${GROUP_4_MIN_WIDTH_BP}rem) and 
 
 export const GROUP_5_MIN_WIDTH = `@media (min-width: ${GROUP_5_MIN_WIDTH_BP}rem)`;
 
-export const HIGH_CONTRAST = `@media screen and (forced-colors: active)`;
+export const FORCED_COLOURS = `@media screen and (forced-colors: active)`;

--- a/src/app/components/ThemeProvider/withThemeProvider.tsx
+++ b/src/app/components/ThemeProvider/withThemeProvider.tsx
@@ -80,7 +80,7 @@ import {
   GROUP_4_MIN_WIDTH,
   GROUP_4_ONLY,
   GROUP_5_MIN_WIDTH,
-  HIGH_CONTRAST,
+  FORCED_COLOURS,
 } from './mediaQueries';
 import {
   HALF,
@@ -213,7 +213,7 @@ const withThemeProvider = ({
       GROUP_4_MIN_WIDTH,
       GROUP_4_ONLY,
       GROUP_5_MIN_WIDTH,
-      HIGH_CONTRAST,
+      FORCED_COLOURS,
     },
     palette: {
       ARCHIVE_BLUE,

--- a/src/app/legacy/containers/PodcastPromo/Inline.jsx
+++ b/src/app/legacy/containers/PodcastPromo/Inline.jsx
@@ -30,7 +30,7 @@ import SkipLinkWrapper from '#components/SkipLinkWrapper';
 import { mediaIcons } from '#psammead/psammead-assets/src/svgs';
 import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 import { RequestContext } from '#app/contexts/RequestContext';
-import { HIGH_CONTRAST } from '#app/components/ThemeProvider/mediaQueries';
+import { FORCED_COLOURS } from '#app/components/ThemeProvider/mediaQueries';
 import { ServiceContext } from '../../../contexts/ServiceContext';
 import PromoComponent from './components';
 import getPromo from './shared';
@@ -62,7 +62,7 @@ const ResponsivePodcastPromoWrapper = styled.div`
 
 const StyledPromoComponent = styled(PromoComponent)`
   padding: 0;
-  ${HIGH_CONTRAST} {
+  ${FORCED_COLOURS} {
     border: 0.1875rem solid transparent;
   }
 `;

--- a/src/app/models/types/theming.ts
+++ b/src/app/models/types/theming.ts
@@ -396,11 +396,11 @@ export type GelFontSize =
 
 type FontSize = {
   [x: string]:
-  | string
-  | {
-    fontSize: string;
-    lineHeight: string;
-  };
+    | string
+    | {
+        fontSize: string;
+        lineHeight: string;
+      };
   fontSize: string;
   lineHeight: string;
 };

--- a/src/app/models/types/theming.ts
+++ b/src/app/models/types/theming.ts
@@ -80,7 +80,7 @@ interface MediaQueries {
   GROUP_4_MIN_WIDTH: string;
   GROUP_4_ONLY: string;
   GROUP_5_MIN_WIDTH: string;
-  HIGH_CONTRAST: string;
+  FORCED_COLOURS: string;
 }
 
 interface Spacings {
@@ -396,11 +396,11 @@ export type GelFontSize =
 
 type FontSize = {
   [x: string]:
-    | string
-    | {
-        fontSize: string;
-        lineHeight: string;
-      };
+  | string
+  | {
+    fontSize: string;
+    lineHeight: string;
+  };
   fontSize: string;
   lineHeight: string;
 };

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.styles.ts
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/LiveLabelHeader/index.styles.ts
@@ -21,7 +21,7 @@ const styles = {
         width: `${spacings.TRIPLE + spacings.HALF}rem`,
         height: `${spacings.TRIPLE + spacings.HALF}rem`,
       },
-      [mq.HIGH_CONTRAST]: {
+      [mq.FORCED_COLOURS]: {
         color: 'canvasText',
       },
     }),

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -7,7 +7,7 @@ export default {
       display: 'flex',
       flexDirection: 'column',
       position: 'relative',
-      [mq.HIGH_CONTRAST]: {
+      [mq.FORCED_COLOURS]: {
         borderBottom: `solid ${pixelsToRem(1)}rem transparent`,
       },
     }),

--- a/ws-nextjs-app/pages/[service]/live/[id]/Post/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Post/styles.tsx
@@ -16,7 +16,7 @@ export default {
       borderTop: `solid ${pixelsToRem(2)}rem ${palette.BRAND_BACKGROUND}`,
       display: 'inline-block',
       width: '100%',
-      [mq.HIGH_CONTRAST]: {
+      [mq.FORCED_COLOURS]: {
         borderBottom: `solid ${pixelsToRem(3)}rem transparent`,
       },
     }),
@@ -65,7 +65,7 @@ export default {
       [mq.GROUP_4_MIN_WIDTH]: {
         margin: `0 0 ${spacings.DOUBLE}rem`,
       },
-      [mq.HIGH_CONTRAST]: {
+      [mq.FORCED_COLOURS]: {
         border: `solid ${pixelsToRem(3)}rem transparent`,
         borderTop: `solid ${pixelsToRem(1)}rem transparent`,
       },

--- a/ws-nextjs-app/pages/[service]/live/[id]/ShareButton/styles.ts
+++ b/ws-nextjs-app/pages/[service]/live/[id]/ShareButton/styles.ts
@@ -22,18 +22,18 @@ const styles = {
         backgroundColor: palette.BRAND_BACKGROUND,
         path: {
           fill: palette.WHITE,
-          [mq.HIGH_CONTRAST]: {
+          [mq.FORCED_COLOURS]: {
             fill: 'canvasText',
           },
         },
-        [mq.HIGH_CONTRAST]: {
+        [mq.FORCED_COLOURS]: {
           backgroundColor: 'canvas',
           color: 'canvasText',
           border: `${pixelsToRem(2)}rem solid canvasText`,
           textDecoration: 'underline',
         },
       },
-      [mq.HIGH_CONTRAST]: {
+      [mq.FORCED_COLOURS]: {
         color: 'canvasText',
         border: `${pixelsToRem(2)}rem solid canvasText`,
       },
@@ -43,7 +43,7 @@ const styles = {
         marginInlineEnd: `${spacings.FULL}rem`,
         path: {
           fill: palette.BLACK,
-          [mq.HIGH_CONTRAST]: {
+          [mq.FORCED_COLOURS]: {
             fill: 'canvasText',
           },
         },

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/File/styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/File/styles.ts
@@ -83,7 +83,7 @@ export default {
           svg: {
             color: palette.BLACK,
             fill: 'currentcolor',
-            [mq.HIGH_CONTRAST]: { stroke: palette.WHITE },
+            [mq.FORCED_COLOURS]: { stroke: palette.WHITE },
           },
         },
       },

--- a/ws-nextjs-app/pages/[service]/send/[id]/FormField/styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/FormField/styles.ts
@@ -108,7 +108,7 @@ export default {
         width: '100%',
         height: '100%',
       },
-      [mq.HIGH_CONTRAST]: {
+      [mq.FORCED_COLOURS]: {
         appearance: 'auto', // renders browser default checkbox
         '&:checked::after': {
           content: 'none',
@@ -129,7 +129,7 @@ export default {
       verticalAlign: 'middle',
       marginInlineEnd: '0.75rem',
       minWidth: '1.5rem',
-      [mq.HIGH_CONTRAST]: {
+      [mq.FORCED_COLOURS]: {
         path: {
           fill: 'currentColor',
         },

--- a/ws-nextjs-app/pages/[service]/send/[id]/SuccessScreen/index.styles.ts
+++ b/ws-nextjs-app/pages/[service]/send/[id]/SuccessScreen/index.styles.ts
@@ -23,7 +23,7 @@ export default {
     css({
       marginInlineEnd: `${spacings.FULL}rem`,
       fill: palette.SUCCESS_CORE,
-      [mq.HIGH_CONTRAST]: {
+      [mq.FORCED_COLOURS]: {
         path: {
           fill: 'currentColor',
         },


### PR DESCRIPTION
Resolves JIRA N/A

Overall changes
======
To avoid confusion this PR renames HIGH_CONTRAST to FORCED_COLOURS, as the `forced-colors` isn't just for high contrast mode, it's also used for user customised colours, like the settings used in firefox

Code changes
======

- Replaces instances of HIGH_CONTRAST with FORCED_COLOURS name

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
