### PR TITLE
Add Paris 2024 link to Afrique, Japanese and Turkce nav bars

### DIFF
--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -342,8 +342,8 @@ export const service: DefaultServiceConfig = {
         url: '/afrique/topics/c06gq9jxz3rt',
       },
       {
-        title: 'Bien-être',
-        url: '/afrique/topics/c0vmyy90q8zt',
+        title: 'JO 2024',
+        url: '/afrique/topics/cgrjz0yz4n9t',
       },
       {
         title: 'Science et technologie',

--- a/src/app/lib/config/services/japanese.ts
+++ b/src/app/lib/config/services/japanese.ts
@@ -303,6 +303,10 @@ export const service: DefaultServiceConfig = {
         url: '/japanese',
       },
       {
+        title: 'パリ五輪',
+        url: '/japanese/topics/c136egn3g6rt',
+      },
+      {
         title: 'ガザ',
         url: '/japanese/topics/cw5wn2e9rpnt',
       },
@@ -331,7 +335,7 @@ export const service: DefaultServiceConfig = {
         url: '/japanese/topics/cdr56kqdr70t',
       },
       {
-        title: '解説・読み物',
+        title: '読み物',
         url: '/japanese/topics/c2xj7ep5812t',
       },
       {
@@ -339,7 +343,7 @@ export const service: DefaultServiceConfig = {
         url: '/japanese/topics/c132079wln0t',
       },
       {
-        title: 'ワールドニュースTV',
+        title: 'ニュースTV',
         url: 'https://www.bbcworldnews-japan.com/',
       },
     ],

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -321,6 +321,10 @@ export const service: DefaultServiceConfig = {
         url: '/turkce/topics/ckdxn2xk95gt',
       },
       {
+        title: '2024 Paris Olimpiyatları',
+        url: '/turkce/topics/cjrrzp9q7gwt',
+      },
+      {
         title: 'Rusya-Ukrayna Savaşı',
         url: '/turkce/topics/cy0ryl4pvx6t',
       },

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
@@ -237,8 +237,8 @@ exports[`AMP Feature Index page Header Navigation link should match text and url
 
 exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
 {
-  "text": "Bien-être",
-  "url": "/afrique/topics/c0vmyy90q8zt",
+  "text": "JO 2024",
+  "url": "/afrique/topics/cgrjz0yz4n9t",
 }
 `;
 

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
@@ -96,8 +96,8 @@ exports[`Canonical Feature Index page Header Navigation link should match text a
 
 exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
 {
-  "text": "Bien-être",
-  "url": "/afrique/topics/c0vmyy90q8zt",
+  "text": "JO 2024",
+  "url": "/afrique/topics/cgrjz0yz4n9t",
 }
 `;
 


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds Paris 2024 topic links to the navgation bars of Afrique, Japanese and Turkish 

Code changes
======

- Edited Navigation section of src/app/lib/config/services/afrique.ts to replace fifth link with Paris 2024 topic
- Edited Navigation section of src/app/lib/config/services/japanese.ts to add Paris 2024 topic link, shortened link text of Features (10th link) and BBC TV (12th) links to avoid having the long bar split in two lines 
- Edited Navigation section of src/app/lib/config/services/turkce.ts to add Paris 2024 topic link in third postion
- Updated snapshots 
Testing
======
1. Open Afrique's front page, the fifth link in the nav should be JO 2024  and open the Paris 2024 topic
2. Open Japanese front page, the second link in the nav should be パリ五輪  and open the Paris 2024 topic
3. Open the Turkce front page, the third link in the nav should be 2024 Paris Olimpiyatları and open the Paris 2024 topic


<img width="977" alt="afrique_nav" src="https://github.com/user-attachments/assets/7671b9ce-745e-4ae9-b0e5-fe8b6adb02d2">
<img width="1079" alt="japanese-nav" src="https://github.com/user-attachments/assets/99362354-aaf1-491c-aab7-84fee59525b9">
<img width="912" alt="turkce_nav" src="https://github.com/user-attachments/assets/57637ba4-32b3-4a5c-97be-3b1d8a8553e7">



Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
