### PR TITLE
Afrique nav paris 2024 update

### DIFF
--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -330,6 +330,10 @@ export const service: DefaultServiceConfig = {
         url: '/afrique',
       },
       {
+        title: 'JO 2024',
+        url: '/afrique/topics/cgrjz0yz4n9t',
+      },
+      {
         title: 'Afrique',
         url: '/afrique/topics/cvqxn2k7kv7t',
       },
@@ -340,10 +344,6 @@ export const service: DefaultServiceConfig = {
       {
         title: 'Santé',
         url: '/afrique/topics/c06gq9jxz3rt',
-      },
-      {
-        title: 'JO 2024',
-        url: '/afrique/topics/cgrjz0yz4n9t',
       },
       {
         title: 'Science et technologie',

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
@@ -216,29 +216,29 @@ exports[`AMP Feature Index page Header Navigation link should match text and url
 
 exports[`AMP Feature Index page Header Navigation link should match text and url 2`] = `
 {
+  "text": "JO 2024",
+  "url": "/afrique/topics/cgrjz0yz4n9t",
+}
+`;
+
+exports[`AMP Feature Index page Header Navigation link should match text and url 3`] = `
+{
   "text": "Afrique",
   "url": "/afrique/topics/cvqxn2k7kv7t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 3`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 4`] = `
 {
   "text": "Monde",
   "url": "/afrique/topics/cvqxn21vx11t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 4`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
 {
   "text": "Santé",
   "url": "/afrique/topics/c06gq9jxz3rt",
-}
-`;
-
-exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
-{
-  "text": "JO 2024",
-  "url": "/afrique/topics/cgrjz0yz4n9t",
 }
 `;
 

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
@@ -75,29 +75,29 @@ exports[`Canonical Feature Index page Header Navigation link should match text a
 
 exports[`Canonical Feature Index page Header Navigation link should match text and url 2`] = `
 {
+  "text": "JO 2024",
+  "url": "/afrique/topics/cgrjz0yz4n9t",
+}
+`;
+
+exports[`Canonical Feature Index page Header Navigation link should match text and url 3`] = `
+{
   "text": "Afrique",
   "url": "/afrique/topics/cvqxn2k7kv7t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 3`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 4`] = `
 {
   "text": "Monde",
   "url": "/afrique/topics/cvqxn21vx11t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
 {
   "text": "Santé",
   "url": "/afrique/topics/c06gq9jxz3rt",
-}
-`;
-
-exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
-{
-  "text": "JO 2024",
-  "url": "/afrique/topics/cgrjz0yz4n9t",
 }
 `;
 


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
Shifts Paris 2024 topic link in the navgation bar of Afrique to second position


Code changes
======

- Edited Navigation section of src/app/lib/config/services/afrique.ts to move Paris 2024 topic link to second postion
- Updated snapshots

Testing
======
1. Open Afrique's front page, the second link in the nav should be JO 2024 and open the Paris 2024 topic

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
