### PR TITLE
Stop amp cookie banner tests running on tv pages

### DIFF
--- a/cypress/e2e/specialFeatures/cookieBanner/index.cy.js
+++ b/cypress/e2e/specialFeatures/cookieBanner/index.cy.js
@@ -57,11 +57,13 @@ Object.keys(config)
     paths
       .map(path => `${path}.amp`)
       .forEach(path => {
-        describeForEuOnly(`${path} - AMP Cookie Banner`, () => {
-          beforeEach(() => {
-            visitPage(path, pageType);
+        if (!path.includes('tv')) {
+          describeForEuOnly(`${path} - AMP Cookie Banner`, () => {
+            beforeEach(() => {
+              visitPage(path, pageType);
+            });
+            runAmpTests({ service, variant, pageType, path });
           });
-          runAmpTests({ service, variant, pageType, path });
-        });
+        }
       });
   });


### PR DESCRIPTION

The page type is only known from the paths, as the URLs are in specialFeatures > cookieBanner and there is no pageType section within this. We can add to the path substring exclusion in each test removal PR until we have only the pageType left that we want to stay with amp, and then instead of exclusion we can switch it to inclusion of e.g article

Overall changes
======
_A very high-level summary of easily-reproducible changes that can be understood by non-devs, and why these changes where made._

Code changes
======

- _A bullet point list of key code changes that have been made._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
