### PR TITLE
Remove Welsh service transform logic

### DIFF
--- a/src/app/routes/cpsAsset/getInitialData/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/index.js
@@ -86,29 +86,14 @@ const transformJson = async (json, pathname, toggles) => {
   }
 };
 
-const getDerivedServiceAndPath = (service, pathname) => {
-  switch (service) {
-    case 'cymrufyw':
-      return {
-        service: 'newyddion',
-        path: pathname.replace('cymrufyw', 'newyddion'),
-      };
-    default:
-      return { service, path: pathname };
-  }
-};
-
 export default async ({ path: pathname, service, variant, toggles, isAmp }) => {
   try {
-    const { service: derivedService, path: derivedPath } =
-      getDerivedServiceAndPath(service, pathname);
-
     const {
       status,
       pageData: { secondaryColumn, recommendations, ...article } = {},
     } = await getArticleInitialData({
-      path: derivedPath,
-      service: derivedService,
+      path: pathname,
+      service,
       variant,
       pageType: 'article',
       isAmp,


### PR DESCRIPTION
Overall changes
======
- Removes service and path name transforms for Welsh language from fetch, instead offloading this work to the BFF https://github.com/bbc/fabl-modules/pull/7494

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
