### PR TITLE
Remove `table` component E2E checks

### DIFF
--- a/cypress/e2e/pages/storyPage/testsForAMPOnly.js
+++ b/cypress/e2e/pages/storyPage/testsForAMPOnly.js
@@ -7,50 +7,6 @@ export const testsThatAlwaysRunForAMPOnly = ({
   variant,
 }) => {
   describe(`Running testsToAlwaysRunForAMPOnly for ${service} ${pageType}`, () => {
-    it('Table displays expected number of rows and columns', () => {
-      if (service === 'sport') {
-        cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-          const tableBlock = body.content.blocks.find(
-            block => block.type === 'table',
-          );
-          if (tableBlock) {
-            const numberOfRows = tableBlock.rows.length;
-            cy.get('table')
-              .find('tr')
-              .then(row => {
-                expect(row.length).to.equal(numberOfRows);
-                cy.log(
-                  `Number of rows in json = ${numberOfRows}. Number of rows displayed on page = ${row.length}`,
-                );
-                const numberOfColumns = tableBlock.width;
-                cy.get('table')
-                  .find('tr')
-                  .eq(0)
-                  .find('th')
-                  .then(th => {
-                    expect(th.length).to.equal(numberOfColumns);
-                    cy.log(
-                      `Number of columns in json = ${numberOfColumns}. Number of columns displayed on page = ${th.length}`,
-                    );
-                  });
-              });
-          }
-        });
-      }
-    });
-    it('Table has a heading', () => {
-      if (service === 'sport') {
-        cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-          const tableBlock = body.content.blocks.find(
-            block => block.type === 'table',
-          );
-          if (tableBlock) {
-            cy.get('table').find('thead');
-          }
-        });
-      }
-    });
-
     /* Most Read Component
      * These cypress tests are needed as unit tests cannot be run on the jsdom.
      *

--- a/cypress/e2e/pages/storyPage/testsForAMPOnly.js
+++ b/cypress/e2e/pages/storyPage/testsForAMPOnly.js
@@ -7,18 +7,6 @@ export const testsThatAlwaysRunForAMPOnly = ({
   variant,
 }) => {
   describe(`Running testsToAlwaysRunForAMPOnly for ${service} ${pageType}`, () => {
-    it('If there is a table in the json, display it on the page', () => {
-      if (service === 'sport') {
-        cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-          const tableBlock = body.content.blocks.find(
-            block => block.type === 'table',
-          );
-          if (tableBlock) {
-            cy.get('table');
-          }
-        });
-      }
-    });
     it('Table displays expected number of rows and columns', () => {
       if (service === 'sport') {
         cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {


### PR DESCRIPTION
Overall changes
======
- Removes the `table` component E2E check as we no longer support this block type in CAF rendered assets.

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
