### PR TITLE
Update Brasil nav to add link to US elections

### DIFF
--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -415,6 +415,10 @@ export const service: DefaultServiceConfig = {
         url: '/portuguese/topics/cz74k717pw5t',
       },
       {
+        title: 'Eleições EUA',
+        url: '/portuguese/topics/c30gn378n6kt',
+      },
+      {
         title: 'Internacional',
         url: '/portuguese/topics/cmdm4ynm24kt',
       },

--- a/src/integration/pages/podcastPage/portugueseBrand/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/podcastPage/portugueseBrand/__snapshots__/amp.test.js.snap
@@ -216,47 +216,54 @@ exports[`AMP Podcast Page Header Navigation link should match text and url 2`] =
 
 exports[`AMP Podcast Page Header Navigation link should match text and url 3`] = `
 {
+  "text": "Eleições EUA",
+  "url": "/portuguese/topics/c30gn378n6kt",
+}
+`;
+
+exports[`AMP Podcast Page Header Navigation link should match text and url 4`] = `
+{
   "text": "Internacional",
   "url": "/portuguese/topics/cmdm4ynm24kt",
 }
 `;
 
-exports[`AMP Podcast Page Header Navigation link should match text and url 4`] = `
+exports[`AMP Podcast Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Economia",
   "url": "/portuguese/topics/cvjp2jr0k9rt",
 }
 `;
 
-exports[`AMP Podcast Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Podcast Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Saúde",
   "url": "/portuguese/topics/c340q430z4vt",
 }
 `;
 
-exports[`AMP Podcast Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Podcast Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Ciência",
   "url": "/portuguese/topics/cr50y580rjxt",
 }
 `;
 
-exports[`AMP Podcast Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Podcast Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Tecnologia",
   "url": "/portuguese/topics/c404v027pd4t",
 }
 `;
 
-exports[`AMP Podcast Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Podcast Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Vídeos",
   "url": "/portuguese/topics/c9y2j35dn2zt",
 }
 `;
 
-exports[`AMP Podcast Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Podcast Page Header Navigation link should match text and url 10`] = `
 {
   "text": "BBC Lê",
   "url": "/portuguese/topics/cxndrr1qgllt",

--- a/src/integration/pages/podcastPage/portugueseBrand/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/podcastPage/portugueseBrand/__snapshots__/canonical.test.js.snap
@@ -82,47 +82,54 @@ exports[`Canonical Podcast Page Header Navigation link should match text and url
 
 exports[`Canonical Podcast Page Header Navigation link should match text and url 3`] = `
 {
+  "text": "Eleições EUA",
+  "url": "/portuguese/topics/c30gn378n6kt",
+}
+`;
+
+exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
+{
   "text": "Internacional",
   "url": "/portuguese/topics/cmdm4ynm24kt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Economia",
   "url": "/portuguese/topics/cvjp2jr0k9rt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Saúde",
   "url": "/portuguese/topics/c340q430z4vt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Ciência",
   "url": "/portuguese/topics/cr50y580rjxt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Tecnologia",
   "url": "/portuguese/topics/c404v027pd4t",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Vídeos",
   "url": "/portuguese/topics/c9y2j35dn2zt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 10`] = `
 {
   "text": "BBC Lê",
   "url": "/portuguese/topics/cxndrr1qgllt",

--- a/src/integration/pages/podcastPage/portugueseEpisode/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/podcastPage/portugueseEpisode/__snapshots__/amp.test.js.snap
@@ -216,47 +216,54 @@ exports[`AMP Podcast Page Header Navigation link should match text and url 2`] =
 
 exports[`AMP Podcast Page Header Navigation link should match text and url 3`] = `
 {
+  "text": "Eleições EUA",
+  "url": "/portuguese/topics/c30gn378n6kt",
+}
+`;
+
+exports[`AMP Podcast Page Header Navigation link should match text and url 4`] = `
+{
   "text": "Internacional",
   "url": "/portuguese/topics/cmdm4ynm24kt",
 }
 `;
 
-exports[`AMP Podcast Page Header Navigation link should match text and url 4`] = `
+exports[`AMP Podcast Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Economia",
   "url": "/portuguese/topics/cvjp2jr0k9rt",
 }
 `;
 
-exports[`AMP Podcast Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Podcast Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Saúde",
   "url": "/portuguese/topics/c340q430z4vt",
 }
 `;
 
-exports[`AMP Podcast Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Podcast Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Ciência",
   "url": "/portuguese/topics/cr50y580rjxt",
 }
 `;
 
-exports[`AMP Podcast Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Podcast Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Tecnologia",
   "url": "/portuguese/topics/c404v027pd4t",
 }
 `;
 
-exports[`AMP Podcast Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Podcast Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Vídeos",
   "url": "/portuguese/topics/c9y2j35dn2zt",
 }
 `;
 
-exports[`AMP Podcast Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Podcast Page Header Navigation link should match text and url 10`] = `
 {
   "text": "BBC Lê",
   "url": "/portuguese/topics/cxndrr1qgllt",

--- a/src/integration/pages/podcastPage/portugueseEpisode/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/podcastPage/portugueseEpisode/__snapshots__/canonical.test.js.snap
@@ -82,47 +82,54 @@ exports[`Canonical Podcast Page Header Navigation link should match text and url
 
 exports[`Canonical Podcast Page Header Navigation link should match text and url 3`] = `
 {
+  "text": "Eleições EUA",
+  "url": "/portuguese/topics/c30gn378n6kt",
+}
+`;
+
+exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
+{
   "text": "Internacional",
   "url": "/portuguese/topics/cmdm4ynm24kt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Economia",
   "url": "/portuguese/topics/cvjp2jr0k9rt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Saúde",
   "url": "/portuguese/topics/c340q430z4vt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Ciência",
   "url": "/portuguese/topics/cr50y580rjxt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Tecnologia",
   "url": "/portuguese/topics/c404v027pd4t",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Vídeos",
   "url": "/portuguese/topics/c9y2j35dn2zt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 10`] = `
 {
   "text": "BBC Lê",
   "url": "/portuguese/topics/cxndrr1qgllt",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds US election topic link to the navgation bar of BBC Brasil 

Code changes
======

- Edited Navigation section of src/app/lib/config/services/portuguese.ts to add election topic link in third position
- Updated snapshots

Testing
======
1. Open Brasil front page, third link in the nav should be Eleições EUA and open the election topic

<img width="576" alt="brasil_nav_udpate" src="https://github.com/user-attachments/assets/eb0d8606-7a6c-4e88-8ec1-e03f0bcdd367">


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
