### PR TITLE
Remove Paris 2024 link from Afrique, Japanese, Serbian and Turkce nav bars

### DIFF
--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -334,10 +334,6 @@ export const service: DefaultServiceConfig = {
         url: '/afrique',
       },
       {
-        title: 'JO 2024',
-        url: '/afrique/topics/cgrjz0yz4n9t',
-      },
-      {
         title: 'Afrique',
         url: '/afrique/topics/cvqxn2k7kv7t',
       },

--- a/src/app/lib/config/services/japanese.ts
+++ b/src/app/lib/config/services/japanese.ts
@@ -307,10 +307,6 @@ export const service: DefaultServiceConfig = {
         url: '/japanese',
       },
       {
-        title: 'パリ五輪',
-        url: '/japanese/topics/c136egn3g6rt',
-      },
-      {
         title: 'ガザ',
         url: '/japanese/topics/cw5wn2e9rpnt',
       },

--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -111,10 +111,6 @@ export const service: SerbianConfig = {
         url: '/serbian/lat',
       },
       {
-        title: 'Pariz 2024',
-        url: '/serbian/lat/topics/cv223zl2wp7t',
-      },
-      {
         title: 'Ukrajina',
         url: '/serbian/lat/topics/c5wzvzzz5vrt',
       },
@@ -506,10 +502,6 @@ export const service: SerbianConfig = {
       {
         title: 'Почетна страна',
         url: '/serbian/cyr',
-      },
-      {
-        title: 'Париз 2024',
-        url: '/serbian/cyr/topics/cw556217lept',
       },
       {
         title: 'Украјина',

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -325,10 +325,6 @@ export const service: DefaultServiceConfig = {
         url: '/turkce/topics/ckdxn2xk95gt',
       },
       {
-        title: '2024 Paris Olimpiyatları',
-        url: '/turkce/topics/cjrrzp9q7gwt',
-      },
-      {
         title: 'Rusya-Ukrayna Savaşı',
         url: '/turkce/topics/cy0ryl4pvx6t',
       },

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
@@ -216,68 +216,61 @@ exports[`AMP Feature Index page Header Navigation link should match text and url
 
 exports[`AMP Feature Index page Header Navigation link should match text and url 2`] = `
 {
-  "text": "JO 2024",
-  "url": "/afrique/topics/cgrjz0yz4n9t",
-}
-`;
-
-exports[`AMP Feature Index page Header Navigation link should match text and url 3`] = `
-{
   "text": "Afrique",
   "url": "/afrique/topics/cvqxn2k7kv7t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 4`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 3`] = `
 {
   "text": "Monde",
   "url": "/afrique/topics/cvqxn21vx11t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 4`] = `
 {
   "text": "Santé",
   "url": "/afrique/topics/c06gq9jxz3rt",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 6`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
 {
   "text": "Science et technologie",
   "url": "/afrique/topics/crezq2zk0q4t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 7`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 6`] = `
 {
   "text": "Economie",
   "url": "/afrique/topics/cnq687nr9v1t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 8`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 7`] = `
 {
   "text": "Culture",
   "url": "/afrique/topics/cnq687nrrw8t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 9`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 8`] = `
 {
   "text": "Vidéos",
   "url": "/afrique/topics/cz4vn9gyd6rt",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 10`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 9`] = `
 {
   "text": "Nos émissions",
   "url": "/afrique/topics/c88nzggm8gxt",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 11`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 10`] = `
 {
   "text": "Ecoutez en direct",
   "url": "/afrique/bbc_afrique_radio/liveradio",

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
@@ -75,68 +75,61 @@ exports[`Canonical Feature Index page Header Navigation link should match text a
 
 exports[`Canonical Feature Index page Header Navigation link should match text and url 2`] = `
 {
-  "text": "JO 2024",
-  "url": "/afrique/topics/cgrjz0yz4n9t",
-}
-`;
-
-exports[`Canonical Feature Index page Header Navigation link should match text and url 3`] = `
-{
   "text": "Afrique",
   "url": "/afrique/topics/cvqxn2k7kv7t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 3`] = `
 {
   "text": "Monde",
   "url": "/afrique/topics/cvqxn21vx11t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 4`] = `
 {
   "text": "Santé",
   "url": "/afrique/topics/c06gq9jxz3rt",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
 {
   "text": "Science et technologie",
   "url": "/afrique/topics/crezq2zk0q4t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 6`] = `
 {
   "text": "Economie",
   "url": "/afrique/topics/cnq687nr9v1t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 7`] = `
 {
   "text": "Culture",
   "url": "/afrique/topics/cnq687nrrw8t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 8`] = `
 {
   "text": "Vidéos",
   "url": "/afrique/topics/cz4vn9gyd6rt",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 9`] = `
 {
   "text": "Nos émissions",
   "url": "/afrique/topics/c88nzggm8gxt",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 10`] = `
 {
   "text": "Ecoutez en direct",
   "url": "/afrique/bbc_afrique_radio/liveradio",

--- a/src/integration/pages/frontPage/serbian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/frontPage/serbian/__snapshots__/amp.test.js.snap
@@ -216,47 +216,40 @@ exports[`AMP Front Page Header Navigation link should match text and url 1`] = `
 
 exports[`AMP Front Page Header Navigation link should match text and url 2`] = `
 {
-  "text": "Pariz 2024",
-  "url": "/serbian/lat/topics/cv223zl2wp7t",
-}
-`;
-
-exports[`AMP Front Page Header Navigation link should match text and url 3`] = `
-{
   "text": "Ukrajina",
   "url": "/serbian/lat/topics/c5wzvzzz5vrt",
 }
 `;
 
-exports[`AMP Front Page Header Navigation link should match text and url 4`] = `
+exports[`AMP Front Page Header Navigation link should match text and url 3`] = `
 {
   "text": "Srbija",
   "url": "/serbian/lat/topics/cr50vdy9q6wt",
 }
 `;
 
-exports[`AMP Front Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Front Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Balkan",
   "url": "/serbian/lat/topics/c06g87137jgt",
 }
 `;
 
-exports[`AMP Front Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Front Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Svet",
   "url": "/serbian/lat/topics/c2lej05e1eqt",
 }
 `;
 
-exports[`AMP Front Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Front Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Video",
   "url": "/serbian/lat/topics/c44vyp5g049t",
 }
 `;
 
-exports[`AMP Front Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Front Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Najpopularnije",
   "url": "/serbian/lat/popular/read",

--- a/src/integration/pages/frontPage/serbian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/frontPage/serbian/__snapshots__/canonical.test.js.snap
@@ -75,47 +75,40 @@ exports[`Canonical Front Page Header Navigation link should match text and url 1
 
 exports[`Canonical Front Page Header Navigation link should match text and url 2`] = `
 {
-  "text": "Pariz 2024",
-  "url": "/serbian/lat/topics/cv223zl2wp7t",
-}
-`;
-
-exports[`Canonical Front Page Header Navigation link should match text and url 3`] = `
-{
   "text": "Ukrajina",
   "url": "/serbian/lat/topics/c5wzvzzz5vrt",
 }
 `;
 
-exports[`Canonical Front Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Front Page Header Navigation link should match text and url 3`] = `
 {
   "text": "Srbija",
   "url": "/serbian/lat/topics/cr50vdy9q6wt",
 }
 `;
 
-exports[`Canonical Front Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Front Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Balkan",
   "url": "/serbian/lat/topics/c06g87137jgt",
 }
 `;
 
-exports[`Canonical Front Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Front Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Svet",
   "url": "/serbian/lat/topics/c2lej05e1eqt",
 }
 `;
 
-exports[`Canonical Front Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Front Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Video",
   "url": "/serbian/lat/topics/c44vyp5g049t",
 }
 `;
 
-exports[`Canonical Front Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Front Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Najpopularnije",
   "url": "/serbian/lat/popular/read",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Removes Paris 2024 topic links from the navigation bars of Afrique, Japanese, Serbian and Turkish 

Code changes
======

- Edited Navigation section of src/app/lib/config/services/afrique.ts to remove Paris 2024 link
- Edited Navigation section of src/app/lib/config/services/japanese.ts to remove Paris 2024 link
- Edited Navigation section of src/app/lib/config/services/serbian.ts to remove Paris 2024 link
- Edited Navigation section of src/app/lib/config/services/turkce.ts to remove Paris 2024 link
- Updated snapshots 

Testing
======
1. Open Afrique's front page, there shouldn't be a link to Paris 2024 in second position in the nav bar 
2. Open the Japanese front page, there shouldn't be a link to Paris 2024 in second position in the nav bar 
3. Open Serbian Latin and Cyrillic front pages, there shouldn't be a link to Paris 2024 in second position in the nav bar 
4. Open the Turkce front page, there shouldn't be a linkt to Paris 2024 in third position in the nav bar 

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
