### PR TITLE
Add default header extraction to Next.js routes

### DIFF
--- a/src/server/utilities/extractHeaders/index.test.ts
+++ b/src/server/utilities/extractHeaders/index.test.ts
@@ -6,7 +6,9 @@ describe('extractHeader', () => {
       'x-bbc-edge-isuk': 'yes',
     });
     expect(actual).toStrictEqual({
+      bbcOrigin: null,
       isUK: true,
+      showAdsBasedOnLocation: false,
       showCookieBannerBasedOnCountry: true,
     });
   });
@@ -16,7 +18,9 @@ describe('extractHeader', () => {
       'x-country': 'gb',
     });
     expect(actual).toStrictEqual({
+      bbcOrigin: null,
       isUK: true,
+      showAdsBasedOnLocation: false,
       showCookieBannerBasedOnCountry: true,
     });
   });
@@ -27,7 +31,9 @@ describe('extractHeader', () => {
       'x-bbc-edge-isuk': 'no',
     });
     expect(actual).toStrictEqual({
+      bbcOrigin: null,
       isUK: false,
+      showAdsBasedOnLocation: false,
       showCookieBannerBasedOnCountry: false,
     });
   });
@@ -38,7 +44,9 @@ describe('extractHeader', () => {
       'x-bbc-edge-isuk': 'yes',
     });
     expect(actual).toStrictEqual({
+      bbcOrigin: null,
       isUK: true,
+      showAdsBasedOnLocation: false,
       showCookieBannerBasedOnCountry: true,
     });
   });
@@ -48,8 +56,34 @@ describe('extractHeader', () => {
       'x-bbc-edge-country': 'za',
     });
     expect(actual).toStrictEqual({
+      bbcOrigin: null,
       isUK: null,
+      showAdsBasedOnLocation: false,
       showCookieBannerBasedOnCountry: false,
+    });
+  });
+
+  it(`sets showAdsBasedOnLocation to true when 'bbc-adverts' header is set to 'true'`, () => {
+    const actual = extractHeaders({
+      'bbc-adverts': 'true',
+    });
+    expect(actual).toStrictEqual({
+      bbcOrigin: null,
+      isUK: null,
+      showAdsBasedOnLocation: true,
+      showCookieBannerBasedOnCountry: true,
+    });
+  });
+
+  it(`sets bbcOrigin to 'news' when 'bbc-origin' is set to 'news'`, () => {
+    const actual = extractHeaders({
+      'bbc-origin': 'https://www.bbc.co.uk/news',
+    });
+    expect(actual).toStrictEqual({
+      bbcOrigin: 'https://www.bbc.co.uk/news',
+      isUK: null,
+      showAdsBasedOnLocation: false,
+      showCookieBannerBasedOnCountry: true,
     });
   });
 });

--- a/src/server/utilities/extractHeaders/index.test.ts
+++ b/src/server/utilities/extractHeaders/index.test.ts
@@ -75,7 +75,7 @@ describe('extractHeader', () => {
     });
   });
 
-  it(`sets bbcOrigin to 'news' when 'bbc-origin' is set to 'news'`, () => {
+  it(`sets bbcOrigin when 'bbc-origin' header is set`, () => {
     const actual = extractHeaders({
       'bbc-origin': 'https://www.bbc.co.uk/news',
     });

--- a/src/server/utilities/extractHeaders/index.ts
+++ b/src/server/utilities/extractHeaders/index.ts
@@ -24,7 +24,9 @@ const extractHeaders = (headers: IncomingHttpHeaders) => {
   }
 
   return {
+    bbcOrigin: headers['bbc-origin'] || null,
     isUK,
+    showAdsBasedOnLocation: headers['bbc-adverts'] === 'true' || false,
     showCookieBannerBasedOnCountry,
   };
 };

--- a/ws-nextjs-app/pages/[service]/[[...]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/[[...]].page.tsx
@@ -49,7 +49,6 @@ export const getServerSideProps: GetServerSideProps = async context => {
 
   return {
     props: {
-      bbcOrigin: reqHeaders['bbc-origin'] || null,
       isLite,
       isNextJs: true,
       service,

--- a/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.tsx
+++ b/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.tsx
@@ -58,7 +58,6 @@ export default async (context: GetServerSidePropsContext) => {
 
   return {
     props: {
-      bbcOrigin: reqHeaders['bbc-origin'] || null,
       isNextJs: true,
       isAvEmbeds: true,
       pageData: avEmbed
@@ -70,8 +69,8 @@ export default async (context: GetServerSidePropsContext) => {
         : null,
       pageType: AV_EMBEDS,
       service,
-      variant,
       status: pageStatus,
+      variant,
       ...extractHeaders(reqHeaders),
     },
   };

--- a/ws-nextjs-app/pages/[service]/downloads/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/downloads/[[...variant]].page.tsx
@@ -36,10 +36,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
     'public, stale-if-error=600, stale-while-revalidate=240, max-age=60',
   );
 
-  const {
-    service,
-    variant,
-  } = context.query as PageDataParams;
+  const { service, variant } = context.query as PageDataParams;
 
   const downloadData = await dataFetch(service);
 
@@ -47,7 +44,6 @@ export const getServerSideProps: GetServerSideProps = async context => {
 
   return {
     props: {
-      bbcOrigin: reqHeaders['bbc-origin'] || null,
       error: null,
       isAmp: false,
       isNextJs: true,
@@ -62,7 +58,6 @@ export const getServerSideProps: GetServerSideProps = async context => {
       pageType: DOWNLOADS_PAGE,
       pathname: `${service}/downloads`,
       service,
-      showAdsBasedOnLocation: false,
       status: 200,
       timeOnServer: Date.now(), // TODO: check if needed?
       variant: variant?.[0] || null,

--- a/ws-nextjs-app/pages/[service]/live/[id]/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/[[...variant]].page.tsx
@@ -130,7 +130,6 @@ export const getServerSideProps: GetServerSideProps = async context => {
 
     return {
       props: {
-        bbcOrigin: reqHeaders['bbc-origin'] || null,
         isApp,
         isLite,
         isNextJs: true,
@@ -166,7 +165,6 @@ export const getServerSideProps: GetServerSideProps = async context => {
   context.res.statusCode = data.status;
   return {
     props: {
-      bbcOrigin: reqHeaders['bbc-origin'] || null,
       error: data?.error || null,
       id,
       isApp,
@@ -186,7 +184,6 @@ export const getServerSideProps: GetServerSideProps = async context => {
       pageType: LIVE_PAGE,
       pathname: context.resolvedUrl,
       service,
-      showAdsBasedOnLocation: reqHeaders['bbc-adverts'] === 'true' || false,
       status: data.status,
       timeOnServer: Date.now(), // TODO: check if needed?
       toggles,

--- a/ws-nextjs-app/pages/[service]/send/[id]/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/[[...variant]].page.tsx
@@ -50,7 +50,6 @@ export const getServerSideProps: GetServerSideProps = async context => {
 
   return {
     props: {
-      bbcOrigin: reqHeaders['bbc-origin'] || null,
       error: data?.error || null,
       id,
       isApp,


### PR DESCRIPTION
Related to https://jira.dev.bbc.co.uk/browse/WSTEAM1-1229

Overall changes
======
- Extracts the `bbc-origin` and `bbc-header` headers by default for Next.js routes when the `extractHeaders` function is used

Code changes
======
- Refactors the `extractHeaders` function to also return the `bbc-origin` and `bbc-header` headers by default, so that they don't need explicitly extracted for every route

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
