### PR TITLE
Test removing Next.js dir from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: 'npm'
-    directories:
-      - '/'
+    directory: '/'
     schedule:
       interval: 'daily'
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,6 @@ updates:
   - package-ecosystem: 'npm'
     directories:
       - '/'
-      - '/ws-nextjs-app'
     schedule:
       interval: 'daily'
     ignore:


### PR DESCRIPTION
Attempt to stop `/ws-nextjs-app` specific PRs getting generated as they seem to be handled properly in other PRs: 

E.g. https://github.com/bbc/simorgh/pull/11892 is already handled in https://github.com/bbc/simorgh/pull/11891

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
