### PR TITLE
Remove `/ws/` syndication references

### DIFF
--- a/src/app/routes/utils/constructPageFetchUrl/index.ts
+++ b/src/app/routes/utils/constructPageFetchUrl/index.ts
@@ -231,7 +231,9 @@ const constructPageFetchUrl = ({
         const host = `http://${process.env.HOSTNAME || 'localhost'}`;
         const port = process.env.PORT ? `:${process.env.PORT}` : '';
 
-        if (parsedRoute.isSyndicationRoute) {
+        if (parsedRoute.isWsRoute) {
+          // handle /ws/av-embeds route
+        } else {
           fetchUrl = Url(
             `${host}${port}/api/local/${parsedRoute.service}/av-embeds/${parsedRoute.variant ? `${parsedRoute?.variant}/` : ''}${parsedRoute.assetId}${parsedRoute.mediaId ? `/${parsedRoute.mediaDelimiter}/${parsedRoute.mediaId}` : ''}`,
           );

--- a/src/app/routes/utils/parseAvRoute/index.ts
+++ b/src/app/routes/utils/parseAvRoute/index.ts
@@ -164,8 +164,7 @@ export default function parseAvRoute(resolvedUrl: string) {
 
   const query = resolvedUrlWithoutQuery.split(/[/.]/).filter(Boolean);
 
-  // Assumes /ws/ routes are purely for Simorgh AMP pages
-  const isSyndicationRoute = !query.includes('ws');
+  const isWsRoute = query.includes('ws');
 
   const service = extractService(query);
   const variant = extractVariant(query);
@@ -177,7 +176,7 @@ export default function parseAvRoute(resolvedUrl: string) {
   const amp = extractAmp(query);
 
   return {
-    isSyndicationRoute,
+    isWsRoute,
     service,
     variant,
     platform,

--- a/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.test.ts
+++ b/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.test.ts
@@ -17,7 +17,7 @@ describe('Handle AV Route', () => {
     jest.clearAllMocks();
   });
 
-  it('should set the cache control header correctly for a Syndication route', async () => {
+  it('should set the cache control header correctly for a non-WS route', async () => {
     mockGetServerSidePropsContext.resolvedUrl = '/news/av-embeds/123';
 
     await handleAvRoute(mockGetServerSidePropsContext);
@@ -28,7 +28,7 @@ describe('Handle AV Route', () => {
     );
   });
 
-  it('should set the cache control header correctly for a non-Syndication route', async () => {
+  it('should set the cache control header correctly for a WS route', async () => {
     mockGetServerSidePropsContext.resolvedUrl = '/ws/av-embeds/123';
 
     await handleAvRoute(mockGetServerSidePropsContext);

--- a/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.ts
+++ b/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.ts
@@ -20,15 +20,15 @@ export default async (context: GetServerSidePropsContext) => {
 
   const parsedRoute = parseAvRoute(resolvedUrl);
 
-  if (parsedRoute.isSyndicationRoute) {
+  if (parsedRoute.isWsRoute) {
     context.res.setHeader(
       'Cache-Control',
-      'private, stale-if-error=90, stale-while-revalidate=30, max-age=0, must-revalidate',
+      'public, stale-if-error=90, stale-while-revalidate=30, max-age=30',
     );
   } else {
     context.res.setHeader(
       'Cache-Control',
-      'public, stale-if-error=90, stale-while-revalidate=30, max-age=30',
+      'private, stale-if-error=90, stale-while-revalidate=30, max-age=0, must-revalidate',
     );
   }
 


### PR DESCRIPTION
Overall changes
======
- Removes references to `syndication` when checking the requested route, as `/ws/av-embeds` can be used for both syndication and AMP purposes

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
