### PR TITLE
Disable `useRouteMatch` on Next.js app

### DIFF
--- a/src/app/components/Header/ScriptLink/index.tsx
+++ b/src/app/components/Header/ScriptLink/index.tsx
@@ -62,11 +62,13 @@ const ScriptLink = ({ scriptSwitchId = '' }) => {
   const { isNextJs } = useContext(RequestContext);
   const { enabled: scriptLinkEnabled } = useToggle('scriptLink');
   const { enabled: variantCookieEnabled } = useToggle('variantCookie');
-  const { path, params }: UseRouteMatcher = useRouteMatch();
 
   // TODO: Next.JS doesn't support `react-router-dom` hooks, so we need to
   // revisit this to support both Express and Next.JS in the future.
   if (!scriptLinkEnabled || isNextJs) return null;
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { path, params }: UseRouteMatcher = useRouteMatch();
 
   const { text, variant } = scriptLink || {};
 


### PR DESCRIPTION
- Prevents usage of this hook as the Next.js app does not support `react-router-dom`

Testing
======
1. Visit http://localhost:7081/serbian/send/u39697902?renderer_env=live
2. Confirm it renders correctly
3. Visit http://localhost:7081/ukchina/send/u39697902?renderer_env=live
4. Confirm it renders correctly

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
