### PR TITLE
WSTEAM1-1250: Update tests

### DIFF
--- a/ws-nextjs-app/cypress/e2e/avEmbed/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/avEmbed/index.cy.ts
@@ -1,13 +1,12 @@
 import pageVisit from './pageVisit';
 import runTestsForPage from '../../support/helpers/runTestsForPage';
 
-const VALID_ENV = ['test', 'local'];
-
 const testDetails = {
   pageType: 'avEmbed',
   testSuites: [
     {
       path: '/russian/av-embeds/media-38886884',
+      runforEnv: ['live'],
       id: 'media-38886884',
       service: 'russian',
       tests: [pageVisit],
@@ -16,7 +15,5 @@ const testDetails = {
 };
 
 describe('AVEmbed Page Spec', () => {
-  if (VALID_ENV.includes(Cypress.env('APP_ENV'))) {
-    runTestsForPage(testDetails);
-  }
+  runTestsForPage(testDetails);
 });

--- a/ws-nextjs-app/cypress/e2e/livePage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/livePage/index.cy.ts
@@ -3,14 +3,13 @@ import pageVisit from './pageVisit';
 import { testsThatAlwaysRunForAllPages } from '../testsForAllPages';
 import runTestsForPage from '../../support/helpers/runTestsForPage';
 
-const VALID_ENV = ['test', 'local'];
-
 const testDetails = {
   pageType: 'live',
   testSuites: [
     {
       path: '/pidgin/live/c7p765ynk9qt',
       id: 'c7p765ynk9qt',
+      runforEnv: ['test', 'local'],
       service: 'pidgin',
       tests: [testsThatAlwaysRunForAllPages, pageVisit, mediaPlayerTests],
     },
@@ -18,7 +17,5 @@ const testDetails = {
 };
 
 describe('Live Page Spec', () => {
-  if (VALID_ENV.includes(Cypress.env('APP_ENV'))) {
-    runTestsForPage(testDetails);
-  }
+  runTestsForPage(testDetails);
 });

--- a/ws-nextjs-app/cypress/e2e/send/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/send/index.cy.ts
@@ -2,14 +2,13 @@ import pageVisit from './pageVisit';
 import { testsThatAlwaysRunForAllPages } from '../testsForAllPages';
 import runTestsForPage from '../../support/helpers/runTestsForPage';
 
-const VALID_ENV = ['test', 'local'];
-
 const testDetails = {
   pageType: 'send',
   testSuites: [
     {
       path: '/somali/send/u130092370',
       id: 'u130092370',
+      runforEnv: ['test', 'local'],
       service: 'somali',
       tests: [testsThatAlwaysRunForAllPages, pageVisit],
     },
@@ -17,13 +16,12 @@ const testDetails = {
       path: '/mundo/send/u50853489',
       id: 'u50853489',
       service: 'mundo',
+      runforEnv: ['test', 'local'],
       tests: [testsThatAlwaysRunForAllPages, pageVisit],
     },
   ],
 };
 
 describe('Send Page Spec', () => {
-  if (VALID_ENV.includes(Cypress.env('APP_ENV'))) {
-    runTestsForPage(testDetails);
-  }
+  runTestsForPage(testDetails);
 });

--- a/ws-nextjs-app/cypress/support/helpers/runTestsForPage.ts
+++ b/ws-nextjs-app/cypress/support/helpers/runTestsForPage.ts
@@ -1,9 +1,12 @@
 export default ({ pageType, testSuites }) => {
   testSuites.forEach(testData => {
-    const { path, tests, ...params } = testData;
-    before(() => {
-      cy.visit(path);
-    });
-    tests.forEach(test => test({ path, pageType, ...params }));
+    const { path, tests, runforEnv, ...params } = testData;
+    const cypressEnv = Cypress.env('APP_ENV');
+    if (runforEnv.includes(cypressEnv)) {
+      before(() => {
+        cy.visit(path);
+      });
+      tests.forEach(test => test({ path, pageType, ...params }));
+    }
   });
 };


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-1250](https://jira.dev.bbc.co.uk/browse/WSTEAM1-1250)

Overall changes
======
Adds logic to only run tests respective to their environments. 

Code changes
======
- _Conditional logic in ws-next-js/cypress that limits live urls to only run on the live domain name._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
