### PR TITLE
Fix types for `aresMedia` in MediaLoader

### DIFF
--- a/src/app/components/MediaLoader/configs/aresMedia.ts
+++ b/src/app/components/MediaLoader/configs/aresMedia.ts
@@ -30,45 +30,42 @@ export default ({
     'aresMedia',
   );
 
-  const aresMediaMetadataBlock: AresMediaMetadataBlock = filterForBlockType(
-    aresMediaBlock?.model?.blocks,
-    'aresMediaMetadata',
-  );
+  const { model: aresMediaMetadata }: AresMediaMetadataBlock =
+    filterForBlockType(aresMediaBlock?.model?.blocks, 'aresMediaMetadata') ??
+    {};
 
   const aresMediaImageBlock: OptimoImageBlock = filterForBlockType(
     aresMediaBlock?.model?.blocks,
     'image',
   );
 
-  const rawImageBlock: OptimoRawImageBlock = filterForBlockType(
-    aresMediaImageBlock?.model?.blocks,
-    'rawImage',
-  );
+  const { model: rawImage }: OptimoRawImageBlock =
+    filterForBlockType(aresMediaImageBlock?.model?.blocks, 'rawImage') ?? {};
 
-  const { originCode = '', locator = '' } = rawImageBlock?.model ?? {};
+  const { originCode = '', locator = '' } = rawImage ?? {};
 
-  const { webcastVersions = [] } = aresMediaMetadataBlock?.model ?? {};
+  const { webcastVersions = [] } = aresMediaMetadata ?? {};
 
   const hasWebcastItems = webcastVersions.length > 0;
 
   const versionParameter = hasWebcastItems ? 'webcastVersions' : 'versions';
 
-  const versionsBlock = aresMediaMetadataBlock?.model?.[versionParameter]?.[0];
+  const versionsBlock = aresMediaMetadata?.[versionParameter]?.[0];
 
   const versionID = versionsBlock?.versionId ?? '';
 
-  const format = aresMediaMetadataBlock?.model?.format;
+  const format = aresMediaMetadata?.format;
 
   const rawDuration = versionsBlock?.duration ?? 0;
 
-  const title = aresMediaMetadataBlock?.model?.title ?? '';
+  const title = aresMediaMetadata?.title ?? '';
 
   const captionBlock = getCaptionBlock(blocks, pageType);
 
   const caption =
     captionBlock?.model?.blocks?.[0]?.model?.blocks?.[0]?.model?.text;
 
-  const kind = aresMediaMetadataBlock?.model?.smpKind ?? 'programme';
+  const kind = aresMediaMetadata?.smpKind ?? 'programme';
 
   const guidanceMessage = versionsBlock?.warnings?.short;
 
@@ -78,7 +75,7 @@ export default ({
     duration: rawDuration,
   });
 
-  const embeddingAllowed = aresMediaMetadataBlock?.model?.embedding ?? false;
+  const embeddingAllowed = aresMediaMetadata?.embedding ?? false;
 
   const holdingImageURL = buildIChefURL({
     originCode,

--- a/src/app/components/MediaLoader/configs/aresMedia.ts
+++ b/src/app/components/MediaLoader/configs/aresMedia.ts
@@ -53,13 +53,13 @@ export default ({
 
   const versionParameter = hasWebcastItems ? 'webcastVersions' : 'versions';
 
-  const versionID =
-    aresMediaMetadataBlock?.model?.[versionParameter]?.[0]?.versionId ?? '';
+  const versionsBlock = aresMediaMetadataBlock?.model?.[versionParameter]?.[0];
+
+  const versionID = versionsBlock?.versionId ?? '';
 
   const format = aresMediaMetadataBlock?.model?.format;
 
-  const rawDuration =
-    aresMediaMetadataBlock?.model?.[versionParameter]?.[0]?.duration ?? 0;
+  const rawDuration = versionsBlock?.duration ?? 0;
 
   const title = aresMediaMetadataBlock?.model?.title ?? '';
 
@@ -70,8 +70,7 @@ export default ({
 
   const kind = aresMediaMetadataBlock?.model?.smpKind ?? 'programme';
 
-  const guidanceMessage =
-    aresMediaMetadataBlock?.model?.[versionParameter]?.[0]?.warnings?.short;
+  const guidanceMessage = versionsBlock?.warnings?.short;
 
   const showAds = shouldDisplayAds({
     adsEnabled,
@@ -94,8 +93,7 @@ export default ({
     title,
     type: format || 'video',
     duration: rawDuration,
-    durationISO8601:
-      aresMediaMetadataBlock?.model?.[versionParameter]?.[0]?.durationISO8601,
+    durationISO8601: versionsBlock?.durationISO8601,
     guidanceMessage,
     holdingImageURL,
     translations,

--- a/src/app/components/MediaLoader/configs/aresMedia.ts
+++ b/src/app/components/MediaLoader/configs/aresMedia.ts
@@ -1,7 +1,12 @@
 import buildIChefURL from '#lib/utilities/ichefURL';
 import filterForBlockType from '#lib/utilities/blockHandlers';
 import {
+  OptimoImageBlock,
+  OptimoRawImageBlock,
+} from '#app/models/types/optimo';
+import {
   AresMediaBlock,
+  AresMediaMetadataBlock,
   ConfigBuilderProps,
   ConfigBuilderReturnProps,
   PlaylistItem,
@@ -25,39 +30,48 @@ export default ({
     'aresMedia',
   );
 
-  const { webcastVersions = [] } =
-    aresMediaBlock?.model?.blocks?.[0]?.model ?? [];
+  const aresMediaMetadataBlock: AresMediaMetadataBlock = filterForBlockType(
+    aresMediaBlock?.model?.blocks,
+    'aresMediaMetadata',
+  );
+
+  const aresMediaImageBlock: OptimoImageBlock = filterForBlockType(
+    aresMediaBlock?.model?.blocks,
+    'image',
+  );
+
+  const rawImageBlock: OptimoRawImageBlock = filterForBlockType(
+    aresMediaImageBlock?.model?.blocks,
+    'rawImage',
+  );
+
+  const { originCode = '', locator = '' } = rawImageBlock?.model ?? {};
+
+  const { webcastVersions = [] } = aresMediaMetadataBlock?.model ?? {};
 
   const hasWebcastItems = webcastVersions.length > 0;
 
   const versionParameter = hasWebcastItems ? 'webcastVersions' : 'versions';
 
-  const { originCode, locator } =
-    aresMediaBlock?.model?.blocks?.[1]?.model?.blocks?.[0]?.model ?? {};
-
   const versionID =
-    aresMediaBlock?.model?.blocks?.[0]?.model?.[versionParameter]?.[0]
-      ?.versionId;
+    aresMediaMetadataBlock?.model?.[versionParameter]?.[0]?.versionId ?? '';
 
-  const format = aresMediaBlock?.model?.blocks?.[0]?.model?.format;
+  const format = aresMediaMetadataBlock?.model?.format;
 
   const rawDuration =
-    aresMediaBlock?.model?.blocks?.[0]?.model?.[versionParameter]?.[0]
-      ?.duration;
+    aresMediaMetadataBlock?.model?.[versionParameter]?.[0]?.duration ?? 0;
 
-  const title = aresMediaBlock?.model?.blocks?.[0]?.model?.title;
+  const title = aresMediaMetadataBlock?.model?.title ?? '';
 
   const captionBlock = getCaptionBlock(blocks, pageType);
 
   const caption =
     captionBlock?.model?.blocks?.[0]?.model?.blocks?.[0]?.model?.text;
 
-  const kind =
-    aresMediaBlock?.model?.blocks?.[0]?.model?.smpKind || 'programme';
+  const kind = aresMediaMetadataBlock?.model?.smpKind ?? 'programme';
 
   const guidanceMessage =
-    aresMediaBlock?.model?.blocks?.[0]?.model?.[versionParameter]?.[0]?.warnings
-      ?.short;
+    aresMediaMetadataBlock?.model?.[versionParameter]?.[0]?.warnings?.short;
 
   const showAds = shouldDisplayAds({
     adsEnabled,
@@ -65,8 +79,7 @@ export default ({
     duration: rawDuration,
   });
 
-  const embeddingAllowed =
-    aresMediaBlock?.model?.blocks?.[0]?.model?.embedding ?? false;
+  const embeddingAllowed = aresMediaMetadataBlock?.model?.embedding ?? false;
 
   const holdingImageURL = buildIChefURL({
     originCode,
@@ -82,8 +95,7 @@ export default ({
     type: format || 'video',
     duration: rawDuration,
     durationISO8601:
-      aresMediaBlock?.model?.blocks?.[0]?.model?.[versionParameter]?.[0]
-        ?.durationISO8601,
+      aresMediaMetadataBlock?.model?.[versionParameter]?.[0]?.durationISO8601,
     guidanceMessage,
     holdingImageURL,
     translations,

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -1,5 +1,5 @@
 import { PageTypes, Services } from '#app/models/types/global';
-import { OptimoBlock } from '#app/models/types/optimo';
+import { OptimoImageBlock } from '#app/models/types/optimo';
 import { Translations } from '#app/models/types/translations';
 
 export type PlayerConfig = {
@@ -125,11 +125,18 @@ export type CaptionBlock = {
 export type AresMediaBlock = {
   type: 'aresMedia';
   model: {
+    blocks: [AresMediaMetadataBlock | OptimoImageBlock];
+  };
+};
+
+export type AresMediaMetadataBlock = {
+  type: 'aresMediaMetadata';
+  model: {
+    live?: boolean;
     locator: string;
     originCode: string;
     text: string;
     title: string;
-    blocks: AresMediaBlock[];
     imageUrl: string;
     format: 'audio' | 'video';
     embedding: boolean;
@@ -170,74 +177,7 @@ export type ClipMediaBlock = {
   };
 };
 
-export type SyndicationAresMediaBlock = {
-  type: 'aresMedia';
-  model: {
-    blocks: (
-      | {
-          type: 'aresMediaMetadata';
-          model: {
-            type: 'aresMediaMetadata';
-            blockId?: string;
-            model: {
-              id: string;
-              subType: 'clip' | 'episode';
-              format?: 'audio_video' | 'video' | 'audio';
-              title: string;
-              synopses: {
-                short?: string;
-                medium?: string;
-                long?: string;
-              };
-              imageUrl: string;
-              imageCopyright?: string;
-              embedding: boolean;
-              advertising: boolean;
-              versions: {
-                versionId: string;
-                types: string[];
-                duration: number;
-                durationISO8601: string;
-                warnings: {
-                  short?: string;
-                  medium?: string;
-                  long?: string;
-                };
-                availableTerritories: {
-                  uk: boolean;
-                  nonUk: boolean;
-                };
-                availableUntil?: number;
-                availableFrom?: number;
-              }[];
-              syndication: {
-                destinations: string[];
-              };
-              smpKind?: 'radioProgramme' | 'programme';
-            };
-          };
-        }
-      | {
-          type: 'image';
-          model: {
-            blocks: OptimoBlock[];
-          };
-        }
-      | {
-          type: 'captionText';
-          model: {
-            caption: string;
-          };
-        }
-    )[];
-  };
-};
-
-export type MediaBlock =
-  | AresMediaBlock
-  | ClipMediaBlock
-  | CaptionBlock
-  | SyndicationAresMediaBlock;
+export type MediaBlock = AresMediaBlock | ClipMediaBlock | CaptionBlock;
 
 export type BuildConfigProps = {
   blocks: MediaBlock[];

--- a/src/app/models/types/optimo.ts
+++ b/src/app/models/types/optimo.ts
@@ -10,6 +10,21 @@ export type OptimoBlock = {
   blockGroupIndex?: number;
 };
 
+export type OptimoRawImageBlock = {
+  type: 'rawImage';
+  model: {
+    locator: string;
+    originCode: string;
+  };
+};
+
+export type OptimoImageBlock = {
+  type: 'image';
+  model: {
+    blocks: [OptimoRawImageBlock];
+  };
+};
+
 export type ArticleMetadata = {
   passport: {
     language: string;


### PR DESCRIPTION
Overall changes
======
- We were accessing `aresMedia` as if it were `aresMediaMetadata`, which wasn't really correct, so this makes the typing more accurately match the data model
- This helps simplify the property accessing of the nested `aresMediaMetadata` block

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
