### PR TITLE
Update Japanese nav to add US election

### DIFF
--- a/src/app/lib/config/services/japanese.ts
+++ b/src/app/lib/config/services/japanese.ts
@@ -315,6 +315,10 @@ export const service: DefaultServiceConfig = {
         url: '/japanese/topics/c50vpymk750t',
       },
       {
+        title: '米大統領選',
+        url: '/japanese/topics/c5qx4zgm86et',
+      },
+      {
         title: '気候変動',
         url: '/japanese/topics/c2dwqjr27zjt',
       },


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds US election topic links to the navgation bar BBC Japanese


Code changes
======

- Edited Navigation section of src/app/lib/config/services/japanese.ts to add election topic link in fourth position

Testing
======
1. Open the Japanese front page, fourth link in the nav should be 米大統領選 and open the election topic (https://www.bbc.com/japanese/topics/c5qx4zgm86et)

![image](https://github.com/user-attachments/assets/bf6b143d-3bf8-45fa-bafc-38ee1771c174)


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
