### PR TITLE
`av-embeds` set `atiAnalytics` object

### DIFF
--- a/data/russian/av-embeds/features-49881797.json
+++ b/data/russian/av-embeds/features-49881797.json
@@ -2,6 +2,31 @@
   "data": {
     "avEmbed": {
       "metadata": {
+        "atiAnalytics": {
+          "campaigns": [
+            {
+              "campaignId": "5a988e3739461b000e9dabfa",
+              "campaignName": "WS - Give me perspective"
+            },
+            {
+              "campaignId": "5a988e4739461b000e9dabfc",
+              "campaignName": "WS - Update me"
+            }
+          ],
+          "categoryName": "News",
+          "contentId": "urn:bbc:cps:curie:asset:6ea0060d-2cb6-9b45-b4d9-08876ea24283",
+          "contentType": "article",
+          "language": "ru",
+          "ldpThingIds": null,
+          "ldpThingLabels": null,
+          "nationsProducer": null,
+          "pageIdentifier": "russian.features.story.49881797.page",
+          "pageTitle": "\"Невыносимые условия\". Как живут деревни возле новой полосы Шереметьево",
+          "timePublished": "2019-10-04T15:36:44.000Z",
+          "timeUpdated": "2019-10-04T15:36:44.000Z",
+          "producerName": "RUSSIAN",
+          "producerId": "75"
+        },
         "id": "urn:bbc:ares::asset:russian/features-49881797",
         "locators": {
           "assetUri": "/russian/features-49881797",
@@ -85,10 +110,6 @@
           "aresMediaMetadata"
         ],
         "includeComments": false,
-        "atiAnalytics": {
-          "producerName": "RUSSIAN",
-          "producerId": "75"
-        },
         "readTime": 4,
         "siteUri": "/russian",
         "allowAdvertising": true,

--- a/data/russian/av-embeds/features-49881797/pid/p07q3wwl.json
+++ b/data/russian/av-embeds/features-49881797/pid/p07q3wwl.json
@@ -2,6 +2,31 @@
   "data": {
     "avEmbed": {
       "metadata": {
+        "atiAnalytics": {
+          "campaigns": [
+            {
+              "campaignId": "5a988e3739461b000e9dabfa",
+              "campaignName": "WS - Give me perspective"
+            },
+            {
+              "campaignId": "5a988e4739461b000e9dabfc",
+              "campaignName": "WS - Update me"
+            }
+          ],
+          "categoryName": "News",
+          "contentId": "urn:bbc:cps:curie:asset:6ea0060d-2cb6-9b45-b4d9-08876ea24283",
+          "contentType": "article",
+          "language": "ru",
+          "ldpThingIds": null,
+          "ldpThingLabels": null,
+          "nationsProducer": null,
+          "pageIdentifier": "russian.features.story.49881797.page",
+          "pageTitle": "\"Невыносимые условия\". Как живут деревни возле новой полосы Шереметьево",
+          "timePublished": "2019-10-04T15:36:44.000Z",
+          "timeUpdated": "2019-10-04T15:36:44.000Z",
+          "producerName": "RUSSIAN",
+          "producerId": "75"
+        },
         "id": "urn:bbc:ares::asset:russian/features-49881797",
         "locators": {
           "assetUri": "/russian/features-49881797",
@@ -85,10 +110,6 @@
           "aresMediaMetadata"
         ],
         "includeComments": false,
-        "atiAnalytics": {
-          "producerName": "RUSSIAN",
-          "producerId": "75"
-        },
         "readTime": 4,
         "siteUri": "/russian",
         "allowAdvertising": true,

--- a/data/russian/av-embeds/media-38886884.json
+++ b/data/russian/av-embeds/media-38886884.json
@@ -2,6 +2,21 @@
   "data": {
     "avEmbed": {
       "metadata": {
+        "atiAnalytics": {
+          "categoryName": null,
+          "contentId": "urn:bbc:cps:curie:asset:402fc943-0b94-3942-89fc-223be3586ab5",
+          "contentType": "article-media-asset",
+          "language": "ru",
+          "ldpThingIds": null,
+          "ldpThingLabels": null,
+          "nationsProducer": null,
+          "pageIdentifier": "russian.media.media_asset.38886884.page",
+          "pageTitle": "Тайвань отказывается от АЭС и переходит на энергию Солнца",
+          "timePublished": "2017-02-08T17:41:41.000Z",
+          "timeUpdated": "2017-02-08T17:41:41.000Z",
+          "producerName": "RUSSIAN",
+          "producerId": "75"
+        },
         "id": "urn:bbc:ares::asset:russian/media-38886884",
         "locators": {
           "assetUri": "/russian/media-38886884",
@@ -61,10 +76,6 @@
           "aresMediaMetadata"
         ],
         "includeComments": false,
-        "atiAnalytics": {
-          "producerName": "RUSSIAN",
-          "producerId": "75"
-        },
         "readTime": 1,
         "siteUri": "/russian",
         "mediaType": "video",
@@ -129,6 +140,12 @@
                           }
                         }
                       ]
+                    }
+                  },
+                  {
+                    "type": "captionText",
+                    "model": {
+                      "caption": "Тайвань переходит на энергию Солнца"
                     }
                   }
                 ]

--- a/data/russian/av-embeds/media-38886884/vpid/p04s97g7.json
+++ b/data/russian/av-embeds/media-38886884/vpid/p04s97g7.json
@@ -2,6 +2,21 @@
   "data": {
     "avEmbed": {
       "metadata": {
+        "atiAnalytics": {
+          "categoryName": null,
+          "contentId": "urn:bbc:cps:curie:asset:402fc943-0b94-3942-89fc-223be3586ab5",
+          "contentType": "article-media-asset",
+          "language": "ru",
+          "ldpThingIds": null,
+          "ldpThingLabels": null,
+          "nationsProducer": null,
+          "pageIdentifier": "russian.media.media_asset.38886884.page",
+          "pageTitle": "Тайвань отказывается от АЭС и переходит на энергию Солнца",
+          "timePublished": "2017-02-08T17:41:41.000Z",
+          "timeUpdated": "2017-02-08T17:41:41.000Z",
+          "producerName": "RUSSIAN",
+          "producerId": "75"
+        },
         "id": "urn:bbc:ares::asset:russian/media-38886884",
         "locators": {
           "assetUri": "/russian/media-38886884",
@@ -61,10 +76,6 @@
           "aresMediaMetadata"
         ],
         "includeComments": false,
-        "atiAnalytics": {
-          "producerName": "RUSSIAN",
-          "producerId": "75"
-        },
         "readTime": 1,
         "siteUri": "/russian",
         "mediaType": "video",
@@ -129,6 +140,12 @@
                           }
                         }
                       ]
+                    }
+                  },
+                  {
+                    "type": "captionText",
+                    "model": {
+                      "caption": "Тайвань переходит на энергию Солнца"
                     }
                   }
                 ]

--- a/data/serbian/av-embeds/cyr/srbija-68707945.json
+++ b/data/serbian/av-embeds/cyr/srbija-68707945.json
@@ -2,6 +2,27 @@
   "data": {
     "avEmbed": {
       "metadata": {
+        "atiAnalytics": {
+          "campaigns": [
+            {
+              "campaignId": "5a988e3739461b000e9dabfa",
+              "campaignName": "WS - Give me perspective"
+            }
+          ],
+          "categoryName": "News",
+          "contentId": "urn:bbc:cps:curie:asset:78f55756-ef21-47b4-a4e1-ffe1de4c957a",
+          "contentType": "article",
+          "language": "sr-Cyrl",
+          "ldpThingIds": "1791445f-977a-4e6d-b490-51f84bb4fc52~184cb2f7-e305-4c46-ab4f-2e18f60b0293~5307a8d9-f620-40f5-92d4-f99c919a6ffa~6942cb29-9d3f-4c9c-9806-0a0578c286d6~992e096e-28e6-412d-b6a1-652f78be63c7~a1c14222-e7ab-45a2-a074-3cdc1045607c",
+          "ldpThingLabels": "Serbia~Family~Society~Education~Children~Disability",
+          "nationsProducer": null,
+          "pageIdentifier": "serbiancyr.serbia.story.68707945.page",
+          "pageTitle": "Здравље: Лични пратиоци деце са потешкоћама у развоју, „као члан породице\"",
+          "timePublished": "2024-07-25T07:01:21.000Z",
+          "timeUpdated": "2024-07-25T07:01:21.000Z",
+          "producerName": "SERBIAN",
+          "producerId": "81"
+        },
         "id": "urn:bbc:ares::asset:serbian/cyr/srbija-68707945",
         "locators": {
           "assetUri": "/serbian/cyr/srbija-68707945",
@@ -14,7 +35,7 @@
         "type": "STY",
         "createdBy": "serbian-v6",
         "language": "sr-Cyrl",
-        "lastUpdated": 1721890892000,
+        "lastUpdated": 1724927647000,
         "firstPublished": 1721890881000,
         "lastPublished": 1721890881000,
         "timestamp": 1721890881000,
@@ -426,7 +447,6 @@
           "aresMediaMetadata"
         ],
         "includeComments": false,
-        "atiAnalytics": { "producerName": "SERBIAN", "producerId": "81" },
         "readTime": 5,
         "siteUri": "/serbian/cyr",
         "topics": [
@@ -573,7 +593,9 @@
         "consumableOnRedButton": false,
         "consumableOnlyOnRedButton": false,
         "useSensitiveOnwardJourneys": false,
-        "stats": { "readTime": 5 },
+        "stats": {
+          "readTime": 5
+        },
         "service": "serbian",
         "variant": "cyr"
       },
@@ -606,11 +628,16 @@
                           "duration": 274,
                           "durationISO8601": "PT4M34S",
                           "warnings": {},
-                          "availableTerritories": { "uk": true, "nonUk": true },
+                          "availableTerritories": {
+                            "uk": true,
+                            "nonUk": true
+                          },
                           "availableFrom": 1655477240000
                         }
                       ],
-                      "syndication": { "destinations": [] },
+                      "syndication": {
+                        "destinations": []
+                      },
                       "smpKind": "programme"
                     }
                   },
@@ -893,7 +920,10 @@
             "name": "Дејана Вукадиновић",
             "title": "ББЦ новинарка ",
             "persons": [
-              { "name": "Дејана Вукадиновић", "function": "ББЦ новинарка" }
+              {
+                "name": "Дејана Вукадиновић",
+                "function": "ББЦ новинарка"
+              }
             ]
           },
           "type": "cps"
@@ -1493,7 +1523,9 @@
                                           "availableFrom": 1655477240000
                                         }
                                       ],
-                                      "syndication": { "destinations": [] },
+                                      "syndication": {
+                                        "destinations": []
+                                      },
                                       "smpKind": "programme"
                                     }
                                   },

--- a/src/app/contexts/EventTrackingContext/index.tsx
+++ b/src/app/contexts/EventTrackingContext/index.tsx
@@ -70,7 +70,7 @@ const getCampaignID = (pageType: CampaignPageTypes) => {
     [CPS_ASSET]: '',
     [STATIC_PAGE]: '',
     [UGC_PAGE]: '',
-    [AV_EMBEDS]: '',
+    [AV_EMBEDS]: 'av-embeds',
     [DOWNLOADS_PAGE]: 'downloads',
   }[pageType];
 

--- a/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.test.ts
+++ b/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.test.ts
@@ -40,6 +40,37 @@ describe('Handle AV Route', () => {
     });
   });
 
+  it('should return atiAnalytics in metadata object', async () => {
+    const result = await handleAvRoute(mockGetServerSidePropsContext);
+
+    expect(result?.props?.pageData?.metadata?.atiAnalytics).toEqual({
+      campaigns: [
+        {
+          campaignId: '5a988e3739461b000e9dabfa',
+          campaignName: 'WS - Give me perspective',
+        },
+        {
+          campaignId: '5a988e4739461b000e9dabfc',
+          campaignName: 'WS - Update me',
+        },
+      ],
+      categoryName: 'News',
+      contentId: 'urn:bbc:cps:curie:asset:6ea0060d-2cb6-9b45-b4d9-08876ea24283',
+      contentType: 'article',
+      language: 'ru',
+      ldpThingIds: null,
+      ldpThingLabels: null,
+      nationsProducer: null,
+      pageIdentifier: 'russian.features.story.49881797.page',
+      pageTitle:
+        '"Невыносимые условия". Как живут деревни возле новой полосы Шереметьево',
+      timePublished: '2019-10-04T15:36:44.000Z',
+      timeUpdated: '2019-10-04T15:36:44.000Z',
+      producerName: 'RUSSIAN',
+      producerId: '75',
+    });
+  });
+
   it('should remove the x-frame-options header', async () => {
     await handleAvRoute(mockGetServerSidePropsContext);
 

--- a/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.ts
+++ b/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.ts
@@ -137,6 +137,7 @@ export default async (context: GetServerSidePropsContext) => {
         ? {
             mediaBlock: avEmbed?.content?.model?.blocks ?? null,
             metadata: {
+              atiAnalytics: avEmbed?.metadata?.atiAnalytics ?? null,
               caption,
               headline,
               imageUrl,

--- a/ws-nextjs-app/pages/[service]/av-embeds/types.ts
+++ b/ws-nextjs-app/pages/[service]/av-embeds/types.ts
@@ -1,3 +1,4 @@
+import { ATIData } from '#app/components/ATIAnalytics/types';
 import { MediaBlock } from '#app/components/MediaLoader/types';
 import { PageTypes } from '#app/models/types/global';
 
@@ -5,6 +6,7 @@ export type AvEmbedsPageProps = {
   pageData: {
     mediaBlock: MediaBlock[];
     metadata: {
+      atiAnalytics: ATIData;
       language?: string;
       promoSummary?: string;
       headline?: string;

--- a/ws-nextjs-app/pages/[service]/av-embeds/types.ts
+++ b/ws-nextjs-app/pages/[service]/av-embeds/types.ts
@@ -6,7 +6,7 @@ export type AvEmbedsPageProps = {
   pageData: {
     mediaBlock: MediaBlock[];
     metadata: {
-      atiAnalytics: ATIData;
+      atiAnalytics: ATIData | null;
       language?: string;
       promoSummary?: string;
       headline?: string;

--- a/ws-nextjs-app/pages/[service]/av-embeds/types.ts
+++ b/ws-nextjs-app/pages/[service]/av-embeds/types.ts
@@ -6,7 +6,7 @@ export type AvEmbedsPageProps = {
   pageData: {
     mediaBlock: MediaBlock[];
     metadata: {
-      atiAnalytics: ATIData | null;
+      atiAnalytics?: ATIData | null;
       language?: string;
       promoSummary?: string;
       headline?: string;


### PR DESCRIPTION
Overall changes
======
- Sets and returns the `atiAnalytics` object in `metadata` object
- Updates fixture data to include `atiAnalytics` object
- Adds test to check server-side response returns `atiAnalytics` object
- Enabled by https://github.com/bbc/fabl-modules/pull/7688

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
