### PR TITLE
WSTEAM1-1056 - Remove AMP metadata on TC2 assets

### DIFF
--- a/src/app/legacy/containers/ArticleMetadata/index.jsx
+++ b/src/app/legacy/containers/ArticleMetadata/index.jsx
@@ -17,11 +17,13 @@ const ArticleMetadata = ({
   description,
   imageLocator = '',
   imageAltText = '',
+  hasAmpPage = true,
 }) => {
   const { service } = useContext(ServiceContext);
   const brandedImage = imageLocator
     ? getBrandedImage(imageLocator, service)
     : null;
+
   return (
     articleId && (
       <Metadata
@@ -34,6 +36,7 @@ const ArticleMetadata = ({
         mentionsTags={mentionsTags}
         image={brandedImage}
         imageAltText={imageAltText}
+        hasAmpPage={hasAmpPage}
       >
         <meta name="article:author" content={author} />
         <meta name="article:modified_time" content={lastPublished} />

--- a/src/app/models/types/optimo.ts
+++ b/src/app/models/types/optimo.ts
@@ -40,6 +40,7 @@ export type ArticleMetadata = {
   };
   analyticsLabels?: {
     producer: string;
+    contentId: string;
   };
   atiAnalytics: ATIData;
   type: string;

--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -106,9 +106,13 @@ const ArticlePage = ({ pageData }) => {
     pageData,
   );
   const recommendationsData = pathOr([], ['recommendations'], pageData);
+
   const isPGL = pageData?.metadata?.type === PHOTO_GALLERY_PAGE;
   const isSTY = pageData?.metadata?.type === STORY_PAGE;
   const isCPS = isPGL || isSTY;
+  const isTC2Asset = pageData?.metadata?.analyticsLabels?.contentId
+    ?.split(':')
+    ?.includes('topcat');
 
   const {
     metadata: { atiAnalytics },
@@ -214,6 +218,7 @@ const ArticlePage = ({ pageData }) => {
         description={description}
         imageLocator={promoImage}
         imageAltText={promoImageAltText}
+        hasAmpPage={!isTC2Asset}
       />
       <LinkedData
         showAuthor

--- a/src/app/pages/ArticlePage/index.test.jsx
+++ b/src/app/pages/ArticlePage/index.test.jsx
@@ -684,6 +684,48 @@ describe('Article Page', () => {
     expect(getByText('Get involved')).toBeInTheDocument();
     expect(getByText('UGC Core Features 1 - Custom Form')).toBeInTheDocument();
   });
+
+  it('should set "amphtml" link tag for asset', async () => {
+    render(
+      <Context service="pidgin">
+        <ArticlePage pageData={articleDataNews} />
+      </Context>,
+    );
+
+    const helmetContent = Helmet.peek()?.linkTags;
+    const ampHtmlLink = helmetContent.find(link => link.rel === 'amphtml');
+
+    expect(ampHtmlLink).toEqual({
+      href: 'https://www.test.bbc.co.uk/pathname.amp',
+      rel: 'amphtml',
+    });
+  });
+
+  it('should not set "amphtml" link tag for TC2 asset', async () => {
+    const pageDataAsTC2Asset = {
+      ...articleDataNews,
+      metadata: {
+        ...articleDataNews.metadata,
+        analyticsLabels: {
+          ...articleDataNews.metadata.analyticsLabels,
+          contentId:
+            'urn:bbc:topcat:curie:asset:7b51390e-c5c3-11e3-a6ee-819a3db9bd6e',
+        },
+      },
+    };
+
+    render(
+      <Context service="pidgin">
+        <ArticlePage pageData={pageDataAsTC2Asset} />
+      </Context>,
+    );
+
+    const helmetContent = Helmet.peek()?.linkTags;
+    const ampHtmlLink = helmetContent.find(link => link.rel === 'amphtml');
+
+    expect(ampHtmlLink).toBeUndefined();
+  });
+
   describe('when rendering a PGL page', () => {
     it('should not render secondary column', async () => {
       const pageDataWithSecondaryColumn = {

--- a/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
@@ -122,6 +122,9 @@ const MediaArticlePage = ({ pageData }: { pageData: Article }) => {
   } = pageData;
 
   const isMap = type === MEDIA_ASSET_PAGE;
+  const isTC2Asset = pageData?.metadata?.analyticsLabels?.contentId
+    ?.split(':')
+    ?.includes('topcat');
 
   const atiData = {
     ...atiAnalytics,
@@ -222,6 +225,7 @@ const MediaArticlePage = ({ pageData }: { pageData: Article }) => {
         description={description}
         imageLocator={promoImage}
         imageAltText={promoImageAltText}
+        hasAmpPage={!isTC2Asset}
       />
       <LinkedData
         showAuthor


### PR DESCRIPTION
Resolves [WSTEAM1-1056](https://jira.dev.bbc.co.uk/browse/WSTEAM1-1056)

Overall changes
======
- Adds check to ArticlePage and MediaArticlePage to see if the asset being rendered is `TC2` (TopCat). If so, don't render the `amphtml` link tag

Code changes
======
- Updates ArticlePage and MediaArticlePage component to check `metadata.analyticsLabels.contentId` value to see if asset is a TC2 asset
- Updates ArticleMetadata to accept the `hasAmpPage` prop
- Adds test cases for TC2 asset AMP scenario

Testing
======
1. Visit http://localhost:7080/mundo/noticias/2014/05/140416_dia_trabajo_eeuu_jgc?renderer_env=live
2. Confirm that the `amphtml` `<link />` tag is not present
3. Visit http://localhost:7080/mundo/articles/c1xv2q1gewvo?renderer_env=test
4. Confirm that the `amphtml` `<link />` tag is present

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
