### PR TITLE
Remove iframe checks from preroll ads e2es

### DIFF
--- a/cypress/e2e/specialFeatures/prerollAds/index.cy.js
+++ b/cypress/e2e/specialFeatures/prerollAds/index.cy.js
@@ -16,13 +16,7 @@ describe('Media Asset Pages - Preroll Ads', () => {
           paths.forEach(url => {
             it(url, () => {
               cy.visit(url);
-              cy.get('iframe').then(iframe => {
-                const embedUrl = iframe.prop('src');
-                cy.visit(embedUrl);
-                cy.get(`script[src*="dotcom-bootstrap.js"]`).should(
-                  'not.exist',
-                );
-              });
+              cy.get(`script[src*="dotcom-bootstrap.js"]`).should('not.exist');
             });
           });
         });
@@ -48,13 +42,9 @@ describe('Media Asset Pages - Preroll Ads', () => {
 
                   if (adsEnabled) {
                     cy.visit(url);
-                    cy.get('iframe').then(iframe => {
-                      const embedUrl = iframe.prop('src');
-                      cy.visit(embedUrl);
-                      cy.get(`script[src*="dotcom-bootstrap.js"]`).should(
-                        'exist',
-                      );
-                    });
+                    cy.get(`script[src*="dotcom-bootstrap.js"]`).should(
+                      'exist',
+                    );
                   }
                 });
               });


### PR DESCRIPTION
Overall changes
======
- Removes iframe check/navigation from `prerollAds` e2e tests

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
