### PR TITLE
Update Bengali nav to remove quota reform link

### DIFF
--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -328,10 +328,6 @@ export const service: DefaultServiceConfig = {
         url: '/bengali',
       },
       {
-        title: 'কোটা আন্দোলন',
-        url: '/bengali/topics/cz47p4p81qdt',
-      },
-      {
         title: 'রাজনীতি',
         url: '/bengali/topics/cqywj91rkg6t',
       },


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Remove Quota reform topic link from the navgation bar of Bengali


Code changes
======

- Edited Navigation section of src/app/lib/config/services/bengali.ts to remove the quota reform topic link

Testing
======
1. Open Bengali's front page, কোটা আন্দোলন should no longer be the second link in the nav


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
