### PR TITLE
Return blank 200 page for `/legacy/` av-embeds routes

### DIFF
--- a/src/app/routes/utils/parseAvRoute/index.test.ts
+++ b/src/app/routes/utils/parseAvRoute/index.test.ts
@@ -86,6 +86,13 @@ const EXAMPLE_ROUTES = [
       lang: 'pcm',
     },
   },
+  {
+    route:
+      '/ws/av-embeds/legacy/arabic/multimedia/2013/12/131208_iraq_blast_/28780250/ar',
+    expectedOutput: {
+      isLegacyRoute: true,
+    },
+  },
 ];
 
 describe('parseAvRoute', () => {

--- a/src/app/routes/utils/parseAvRoute/index.ts
+++ b/src/app/routes/utils/parseAvRoute/index.ts
@@ -165,6 +165,7 @@ export default function parseAvRoute(resolvedUrl: string) {
   const query = resolvedUrlWithoutQuery.split(/[/.]/).filter(Boolean);
 
   const isWsRoute = query.includes('ws');
+  const isLegacyRoute = query.includes('legacy');
   const isAmp = extractAmp(query);
 
   const service = extractService(query);
@@ -177,6 +178,7 @@ export default function parseAvRoute(resolvedUrl: string) {
 
   return {
     isWsRoute,
+    isLegacyRoute,
     isAmp,
     service,
     variant,

--- a/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.test.ts
+++ b/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.test.ts
@@ -100,4 +100,14 @@ describe('Handle AV Route', () => {
       'public, stale-if-error=90, stale-while-revalidate=30, max-age=30',
     );
   });
+
+  it('should return 200 with empty pageData if isLegacyRoute is true', async () => {
+    mockGetServerSidePropsContext.resolvedUrl =
+      '/ws/av-embeds/legacy/arabic/multimedia/2013/12/131208_iraq_blast_/28780250/ar';
+
+    const result = await handleAvRoute(mockGetServerSidePropsContext);
+
+    expect(result?.props?.status).toEqual(200);
+    expect(result?.props?.pageData).toBeNull();
+  });
 });


### PR DESCRIPTION
Overall changes
======
- Returns a 200 response with a blank page for `/legacy/` style av-embeds routes to prevent unsupported data fetches for these types of assets

Code changes
======
- Updates `parseAvRoute` to check and return `isLegacyRoute` boolean
- Uses this value to return an empty, but "successful" page response to prevent unsupported data fetches to the API which would cause a 404

Testing
======
1. Visit http://localhost:7081/ws/av-embeds/legacy/arabic/multimedia/2013/12/131208_iraq_blast_/28780250/ar?renderer_env=live
2. Confirm it returns a blank page
3. Visit http://localhost:7081/ws/av-embeds/articles/cdx6ddxw755o/p0jnkvzp/ha/amp?renderer_env=live
4. Confirm it returns a media player

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
