### PR TITLE
Prevent `Metadata` component rendering when embedded

### DIFF
--- a/src/app/components/MediaLoader/Metadata/index.tsx
+++ b/src/app/components/MediaLoader/Metadata/index.tsx
@@ -45,10 +45,9 @@ const getUploadDate = (availableFrom?: string, firstPublished?: string) => {
 type Props = {
   blocks: MediaBlock[];
   embedURL?: string;
-  embedded?: boolean;
 };
 
-const Metadata = ({ blocks, embedURL, embedded = false }: Props) => {
+const Metadata = ({ blocks, embedURL }: Props) => {
   const { pageType } = useContext(RequestContext);
 
   if (!SUPPORTED_PAGE_TYPES.includes(pageType)) return null;
@@ -87,7 +86,6 @@ const Metadata = ({ blocks, embedURL, embedded = false }: Props) => {
 
   return (
     <Helmet>
-      {embedded && embedURL && <meta property="og:url" content={embedURL} />}
       <script type="application/ld+json">{JSON.stringify(metadataJson)}</script>
     </Helmet>
   );

--- a/src/app/components/MediaLoader/index.test.tsx
+++ b/src/app/components/MediaLoader/index.test.tsx
@@ -150,7 +150,25 @@ describe('MediaLoader', () => {
   });
 
   describe('Metadata', () => {
-    it('should render metadata tags when media player is embedded', async () => {
+    it('should render metadata tags when media player is not embedded', async () => {
+      await act(async () => {
+        render(
+          <MediaPlayer
+            blocks={aresMediaBlocks as MediaBlock[]}
+            embedded={false}
+          />,
+          {
+            id: 'cn8jgj8rjppo',
+          },
+        );
+      });
+
+      const helmetMetaTags = Helmet.peek().metaTags;
+
+      expect(helmetMetaTags).not.toBeNull();
+    });
+
+    it('should not render metadata tags when media player is embedded', async () => {
       await act(async () => {
         render(
           <MediaPlayer blocks={aresMediaBlocks as MediaBlock[]} embedded />,
@@ -162,10 +180,7 @@ describe('MediaLoader', () => {
 
       const helmetMetaTags = Helmet.peek().metaTags;
 
-      expect(helmetMetaTags[0]).toEqual({
-        property: 'og:url',
-        content: '/ws/av-embeds/articles/cn8jgj8rjppo/p01k6msp/en-GB',
-      });
+      expect(helmetMetaTags).toEqual([]);
     });
   });
 });

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -211,11 +211,12 @@ const MediaLoader = ({ blocks, embedded, className }: Props) => {
 
   return (
     <>
-      <Metadata
-        blocks={blocks}
-        embedURL={playerConfig?.externalEmbedUrl}
-        embedded={embedded}
-      />
+      {
+        // Prevents the av-embeds route itself rendering the Metadata component
+        !embedded && (
+          <Metadata blocks={blocks} embedURL={playerConfig?.externalEmbedUrl} />
+        )
+      }
       <figure
         data-e2e="media-loader__container"
         css={styles.figure}

--- a/ws-nextjs-app/pages/[service]/av-embeds/AvEmbedsPageLayout.test.tsx
+++ b/ws-nextjs-app/pages/[service]/av-embeds/AvEmbedsPageLayout.test.tsx
@@ -31,7 +31,7 @@ describe('AV Embeds Page', () => {
     expect(getByTestId('avembeds-mediaplayer')).toBeInTheDocument();
   });
 
-  it('should render og:url meta tag on AV Embeds page', async () => {
+  it('should render meta tags on AV Embeds page', async () => {
     await act(async () => {
       return render(
         <AvEmbedsPage
@@ -54,10 +54,29 @@ describe('AV Embeds Page', () => {
 
     const helmetMetaTags = Helmet.peek()?.metaTags;
 
-    // @ts-expect-error - 'property' does not exist on type 'MetaTag'.
-    const actual = helmetMetaTags.filter(tag => tag.property === 'og:url')[0]
-      .content;
-
-    expect(actual).toEqual('/serbian/cyr/av-embeds/srbija-68707945');
+    expect(helmetMetaTags).toEqual([
+      {
+        name: 'viewport',
+        content: 'width=device-width, initial-scale=1, user-scalable=1',
+      },
+      { charset: 'utf-8' },
+      { 'http-equiv': 'X-UA-Compatible', content: 'IE=edge,chrome=1' },
+      { property: 'og:type', content: 'video' },
+      { property: 'og:site_name', content: 'BBC News' },
+      { property: 'og:locale', content: 'sr-Cyrl' },
+      {
+        property: 'article:author',
+        content: 'https://www.facebook.com/bbcnews',
+      },
+      { name: 'twitter:card', content: 'summary_large_image' },
+      { name: 'twitter:site', content: '@bbcnews' },
+      { name: 'twitter:creator', content: '@bbcnews' },
+      { name: 'twitter:domain', content: 'www.bbc.com' },
+      { name: 'apple-mobile-web-app-title', content: 'BBC News' },
+      { name: 'application-name', content: 'BBC News' },
+      { name: 'msapplication-TileImage', content: 'BBC News' },
+      { name: 'msapplication-TileColor', content: '#bb1919' },
+      { name: 'mobile-web-app-capable', content: 'yes' },
+    ]);
   });
 });


### PR DESCRIPTION
Overall changes
======
Prevents the media `Metadata` component rendering when the media player has been embedded on the page. Prior to this, there would have been 2 instances of the JSON+LD schema being added to the DOM, 1 for the media player on AMP as it uses this component to render the iframe: https://github.com/bbc/simorgh/blob/eb13e8820661c929cd4cb7c3b2ebb0e0d65cc6a4/src/app/legacy/containers/MediaPlayer/index.jsx#L148-L151 and then another 1 rendered by the new medialoader component, which is ultimately used by the AMP iframe https://github.com/bbc/simorgh/blob/72f6242a4630cc67aa414a569a20271b5bce388f/src/app/components/MediaLoader/index.tsx#L217

This logic should ensure that its only rendered once for our use cases

Code changes
======
- Updates logic to ensure `Metadata` component isn't rendered when the media player is embedded (e.g. on AMP)
- Removes `og:url` logic from `Metadata` as this should be handled by the page types own Metadata component:
https://github.com/bbc/simorgh/blob/b963f2f2eaa6e0a853ee59f4a54865a0921d4557/src/app/components/Metadata/index.tsx#L176

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
