### PR TITLE
Allow Storybook to render the script link

### DIFF
--- a/.storybook/withServicesDecorator/index.tsx
+++ b/.storybook/withServicesDecorator/index.tsx
@@ -54,9 +54,9 @@ export default (overrideProps?: { defaultService?: Services }) =>
   ) => {
     const defaultServiceOverride = overrideProps?.defaultService;
     const serviceToUse = defaultServiceOverride || selectedService;
-
+    console.log('HELLO', serviceToUse, '2', selectedService);
     const variant = getVariant(serviceToUse as Services)(TEXT_VARIANTS);
-
+    console.log(variant);
     const service = variant
       ? getService(serviceToUse as Services)(TEXT_VARIANTS)
       : serviceToUse;

--- a/.storybook/withServicesDecorator/text-variants.ts
+++ b/.storybook/withServicesDecorator/text-variants.ts
@@ -1,3 +1,4 @@
+import serbian from '#app/lib/config/services/serbian';
 import { Services, Variants } from '#app/models/types/global';
 
 type TextVariant = {
@@ -285,6 +286,9 @@ const TEXT_VARIANTS: Record<string, TextVariant> = {
     locale: 'ru',
     timezone: 'GMT',
     articlePath: '/russian/articles/ck7pz7re3zgo',
+  },
+  serbian: {
+    variant: 'cyr',
   },
   serbianCyr: {
     service: 'serbian',

--- a/src/app/components/Header/ScriptLink/index.tsx
+++ b/src/app/components/Header/ScriptLink/index.tsx
@@ -59,15 +59,23 @@ const ScriptLink = ({ scriptSwitchId = '' }) => {
   const { service, scriptLink } = useContext(ServiceContext);
   const { isNextJs } = useContext(RequestContext);
   const { enabled: scriptLinkEnabled } = useToggle('scriptLink');
-
+  const isStoryBook = process.env.STORYBOOK;
+  let path;
+  let params;
   // TODO: Next.JS doesn't support `react-router-dom` hooks, so we need to
   // revisit this to support both Express and Next.JS in the future.
   if (!scriptLinkEnabled || isNextJs) return null;
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const { path, params }: UseRouteMatcher = useRouteMatch();
-  const { text, variant } = scriptLink || {};
-  if (!variant) return null;
+  if (!isStoryBook) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const match = useRouteMatch();
+    path = match.path;
+    params = match.params;
+  }
 
+  const { text, variant } = scriptLink || {};
+  console.log('hello?123', isStoryBook);
+  if (!variant) return null;
   return (
     <a
       css={styles.link}

--- a/src/app/hooks/useToggle/index.js
+++ b/src/app/hooks/useToggle/index.js
@@ -4,7 +4,7 @@ import { ToggleContext } from '#contexts/ToggleContext';
 const useToggle = toggleName => {
   const featureToggle = useContext(ToggleContext).toggleState[toggleName];
   const { enabled = null, value } = featureToggle || {};
-
+  console.log('maybe??', featureToggle, enabled);
   if (featureToggle) {
     return {
       ...{ enabled, value },

--- a/src/app/legacy/containers/Brand/index.jsx
+++ b/src/app/legacy/containers/Brand/index.jsx
@@ -28,7 +28,6 @@ const BrandContainer = ({
   const svgRatio = brandSVG && brandSVG.ratio;
   const minWidth = svgRatio * svgMinHeight;
   const maxWidth = svgRatio * svgMaxHeight;
-
   return (
     <StyledBrand
       product={product}

--- a/src/app/legacy/containers/Header/index.jsx
+++ b/src/app/legacy/containers/Header/index.jsx
@@ -11,7 +11,7 @@ import BrandContainer from '../Brand';
 
 const Header = ({ brandRef, borderBottom, skipLink, scriptLink, linkId }) => {
   const [showConsentBanner, setShowConsentBanner] = useState(true);
-
+  console.log('HELLO23', scriptLink);
   const handleBannerBlur = event => {
     const isRejectButton =
       event.target?.getAttribute('data-terms-banner') === 'reject' ||
@@ -49,7 +49,7 @@ const HeaderContainer = ({
   const { service, script, translations, dir, scriptLink, lang, serviceLang } =
     useContext(ServiceContext);
   const { skipLinkText } = translations;
-
+  console.log(renderScriptSwitch);
   const isOperaMini = useOperaMiniDetection();
 
   const brandRef = useRef(null);
@@ -78,7 +78,7 @@ const HeaderContainer = ({
       shouldRenderScriptSwitch = true;
     }
   }
-
+  console.log('render?', shouldRenderScriptSwitch);
   if (isApp) return null;
 
   return (

--- a/src/app/legacy/containers/Header/index.stories.jsx
+++ b/src/app/legacy/containers/Header/index.stories.jsx
@@ -1,7 +1,29 @@
 import React from 'react';
 import HeaderContainer from '.';
+import { ServiceContext } from '#app/contexts/ServiceContext';
+import { ToggleContextProvider } from '#contexts/ToggleContext';
 
-const Component = () => <HeaderContainer />;
+const Component = () => {
+  return (
+    <ToggleContextProvider
+      toggles={{
+        scriptLink: { enabled: true },
+      }}
+    >
+      <ServiceContext.Provider
+        value={{
+          scriptLink: {
+            text: 'Ћир',
+            variant: 'cyr',
+          },
+          translations: { skipLinkText: 'text' },
+        }}
+      >
+        <HeaderContainer />
+      </ServiceContext.Provider>
+    </ToggleContextProvider>
+  );
+};
 
 export default {
   title: 'Containers/Header',

--- a/src/app/legacy/psammead/psammead-brand/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-brand/src/index.jsx
@@ -175,7 +175,7 @@ const Brand = forwardRef((props, ref) => {
     linkId = null,
     ...rest
   } = props;
-
+  console.log('final?', scriptLink);
   return (
     <Banner
       svgHeight={svgHeight}
@@ -200,7 +200,7 @@ const Brand = forwardRef((props, ref) => {
           <StyledBrand {...props} />
         )}
         {skipLink}
-        {scriptLink && <div>{scriptLink}</div>}
+        {scriptLink && <div> {scriptLink}</div>}
       </SvgWrapper>
     </Banner>
   );


### PR DESCRIPTION


Overall changes
======
The script link doesnt render anywhere on storybook as far as i can tell?
Its own [storybook file](https://github.com/bbc/simorgh/blob/latest/src/app/components/Header/ScriptLink/index.stories.tsx) doesnt even show up 

So far just have it sort of hacked together to show for all services on the Header Container

Code changes
======

- _A bullet point list of key code changes that have been made._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
