### PR TITLE
Disable flaky hausa MAP test

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -2026,7 +2026,7 @@ module.exports = () => ({
             paths: [
               '/hausa/23269030', // CPS MAP with video clip
             ],
-            enabled: true,
+            enabled: false,
           },
         },
         smoke: true,


### PR DESCRIPTION
Overall changes
======
Disables a flaky hausa MAP cypress test on local 

Code changes
======

Disable test

Testing
======
PR checks pass

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
