### PR TITLE
Revert "Live Radio `rtl` temp fix"

### DIFF
--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -157,8 +157,6 @@ const MediaContainer = ({
           ? styles.liveRadioMediaContainer
           : styles.mediaContainer
       }
-      // Temporary fix for live radio players not displaying correctly in RTL languages
-      {...(mediaType === 'liveRadio' && { dir: 'ltr' })}
     />
   );
 };

--- a/src/integration/pages/liveRadio/gahuza/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/gahuza/__snapshots__/canonical.test.js.snap
@@ -118,7 +118,6 @@ exports[`Canonical Live Radio Media Loader renders a valid container 1`] = `
   <div
     class="bbc-1eq7znh"
     data-e2e="media-player"
-    dir="ltr"
   />
 </figure>
 `;

--- a/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
@@ -111,7 +111,6 @@ exports[`Canonical Korean Live Radio Page Media Loader renders a valid container
   <div
     class="bbc-1eq7znh"
     data-e2e="media-player"
-    dir="ltr"
   />
 </figure>
 `;

--- a/src/integration/pages/liveRadio/sinhala/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/sinhala/__snapshots__/canonical.test.js.snap
@@ -104,7 +104,6 @@ exports[`Canonical Sinhala Live Radio Page Media Loader renders a valid containe
   <div
     class="bbc-1eq7znh"
     data-e2e="media-player"
-    dir="ltr"
   />
 </figure>
 `;


### PR DESCRIPTION
Reverts bbc/simorgh#11981

- This fix has been applied at the player level, so we no longer need to override this ourselves