### PR TITLE
Sinhala nav add election 2024

### DIFF
--- a/src/app/lib/config/services/sinhala.ts
+++ b/src/app/lib/config/services/sinhala.ts
@@ -314,6 +314,10 @@ export const service: DefaultServiceConfig = {
         url: '/sinhala',
       },
       {
+        title: 'ජනාධිපතිවරණය 2024',
+        url: '/sinhala/topics/cg3e84v9ky0t',
+      },
+      {
         title: 'ශ්‍රී ලංකා',
         url: '/sinhala/topics/cg7267dz901t',
       },

--- a/src/integration/pages/liveRadio/sinhala/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/sinhala/__snapshots__/canonical.test.js.snap
@@ -68,26 +68,33 @@ exports[`Canonical Sinhala Live Radio Page Header Navigation link should match t
 
 exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 2`] = `
 {
+  "text": "ජනාධිපතිවරණය 2024",
+  "url": "/sinhala/topics/cg3e84v9ky0t",
+}
+`;
+
+exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 3`] = `
+{
   "text": "ශ්‍රී ලංකා",
   "url": "/sinhala/topics/cg7267dz901t",
 }
 `;
 
-exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 3`] = `
+exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 4`] = `
 {
   "text": "ලෝකය",
   "url": "/sinhala/topics/c83plvepnq1t",
 }
 `;
 
-exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 5`] = `
 {
   "text": "වීඩියෝ",
   "url": "/sinhala/topics/crldzm9n2lnt",
 }
 `;
 
-exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 6`] = `
 {
   "text": "කලා",
   "url": "/sinhala/topics/c7zp5zxk8jxt",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds election topic links to the navgation bar of Sinhala

Code changes
======

- Edited Navigation section of src/app/lib/config/services/sinhala.ts to add election topic link in second position



Testing
======
1. Open Sinhala front page, second link in the nav should point to the election  2024 and open the election topic

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
