### PR TITLE
Re-enable disabled local MAP tests; update CSP to allow scripts to load on http://localhost.bbc.com

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -1613,7 +1613,7 @@ module.exports = () => ({
               '/gahuza/amakuru-23257470', // CPS MAP with video clip
               '/gahuza/amakuru/2016/02/160215_map_amakuru_test1', // TC2 MAP with video clip
             ],
-            enabled: false,
+            enabled: true,
           },
         },
         smoke: true,
@@ -2026,7 +2026,7 @@ module.exports = () => ({
             paths: [
               '/hausa/23269030', // CPS MAP with video clip
             ],
-            enabled: false,
+            enabled: true,
           },
         },
         smoke: true,
@@ -4250,7 +4250,7 @@ module.exports = () => ({
               '/pashto/media-23257523', // CPS MAP with video clip
               '/pashto/world/2016/09/160921_tc2_testmap1', // TC2 MAP with video clip
             ],
-            enabled: false,
+            enabled: true,
           },
         },
         smoke: true,
@@ -4536,7 +4536,7 @@ module.exports = () => ({
               '/persian/iran-23231114', // CPS MAP with audio clip
               '/persian/iran/2016/09/160907_tc2_testmap1', // TC2 MAP with video clip
             ],
-            enabled: false,
+            enabled: true,
           },
         },
         smoke: true,
@@ -4750,7 +4750,7 @@ module.exports = () => ({
           },
           local: {
             paths: ['/pidgin/23248703'], // CPS MAP with video clip
-            enabled: false,
+            enabled: true,
           },
         },
         smoke: true,

--- a/cypress/support/helpers/runTestsForPage.js
+++ b/cypress/support/helpers/runTestsForPage.js
@@ -62,8 +62,28 @@ const runTestsForPage = ({
                 { foo: '123' },
               );
             }
-            visitPage(currentPath, pageType);
+
+            if (
+              Cypress.env('APP_ENV') !== 'local' &&
+              pageType !== 'mediaAssetPage'
+            ) {
+              visitPage(currentPath, pageType);
+            }
           });
+
+          /* MAP tests on local are timing out - we believe it's related to the media loader scripts, but are unable to confirm
+           * For this reason, we will no longer run MAP canonical tests on local environment
+           *
+           * These tests will run on all other environments:
+           * Scheduled E2Es: Test / Live environment, when smoke: false
+           * Deployment Pipeline: Test / Live environment, when smoke: true
+           */
+          if (
+            Cypress.env('APP_ENV') === 'local' &&
+            pageType === 'mediaAssetPage'
+          ) {
+            return;
+          }
 
           const testArgs = {
             service,

--- a/cypress/support/helpers/runTestsForPage.js
+++ b/cypress/support/helpers/runTestsForPage.js
@@ -63,29 +63,8 @@ const runTestsForPage = ({
               );
             }
 
-            if (
-              !(
-                Cypress.env('APP_ENV') === 'local' &&
-                pageType === 'mediaAssetPage'
-              )
-            ) {
-              visitPage(currentPath, pageType);
-            }
+            visitPage(currentPath, pageType);
           });
-
-          /* MAP tests on local are timing out - we believe it's related to the media loader scripts, but are unable to confirm
-           * For this reason, we will no longer run MAP canonical tests on local environment
-           *
-           * These tests will run on all other environments:
-           * Scheduled E2Es: Test / Live environment, when smoke: false
-           * Deployment Pipeline: Test / Live environment, when smoke: true
-           */
-          if (
-            Cypress.env('APP_ENV') === 'local' &&
-            pageType === 'mediaAssetPage'
-          ) {
-            return;
-          }
 
           const testArgs = {
             service,

--- a/cypress/support/helpers/runTestsForPage.js
+++ b/cypress/support/helpers/runTestsForPage.js
@@ -64,8 +64,10 @@ const runTestsForPage = ({
             }
 
             if (
-              Cypress.env('APP_ENV') !== 'local' &&
-              pageType !== 'mediaAssetPage'
+              !(
+                Cypress.env('APP_ENV') === 'local' &&
+                pageType === 'mediaAssetPage'
+              )
             ) {
               visitPage(currentPath, pageType);
             }

--- a/src/server/utilities/cspHeader/domainLists.js
+++ b/src/server/utilities/cspHeader/domainLists.js
@@ -7,6 +7,7 @@ export const bbcDomains = [
   '*.bbc.com',
   '*.bbci.co.uk',
   '*.bbci.com',
+  'http://localhost.bbc.com',
 ];
 
 export const advertisingServiceCountryDomains = [


### PR DESCRIPTION
Overall changes
======
Re-enables the previously disabled cypress tests for media asset pages (MAP)
Updates the CPS to allow scripts to be loaded on http://localhost.bbc.com

Code changes
======
- Re-enable tests
- Add http://localhost.bbc.com to BBC domains in CSP

Testing
======
PR checks pass