### PR TITLE
Add CSP pagetype to article entrypoint

### DIFF
--- a/src/app/routes/article/index.tsx
+++ b/src/app/routes/article/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '#app/routes/utils/regex';
 import {
   ARTICLE_PAGE,
+  CORRESPONDENT_STORY_PAGE,
   MEDIA_ARTICLE_PAGE,
   MEDIA_ASSET_PAGE,
   ERROR_PAGE,
@@ -24,6 +25,7 @@ import getInitialData from './getInitialData';
 
 type SupportedPageTypes =
   | typeof ARTICLE_PAGE
+  | typeof CORRESPONDENT_STORY_PAGE
   | typeof STORY_PAGE
   | typeof PHOTO_GALLERY_PAGE
   | typeof MEDIA_ARTICLE_PAGE
@@ -39,6 +41,7 @@ const ArticleVariation = (props: { pageData: Article }) => {
 
   const PageType = {
     [ARTICLE_PAGE]: ArticlePage,
+    [CORRESPONDENT_STORY_PAGE]: ArticlePage,
     [STORY_PAGE]: ArticlePage,
     [PHOTO_GALLERY_PAGE]: ArticlePage,
     [MEDIA_ARTICLE_PAGE]: MediaArticlePage,


### PR DESCRIPTION
Overall changes
======
- Adds `CORRESPONDENT_STORY_PAGE` page type to article route entry point, as this was missed during the CPS component removal

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
