### PR TITLE
Disable Canonical MAP E2E tests on local

### DIFF
--- a/cypress/support/helpers/runTestsForPage.js
+++ b/cypress/support/helpers/runTestsForPage.js
@@ -9,6 +9,7 @@ import serviceHasPageType from './serviceHasPageType';
 import ampOnlyServices from './ampOnlyServices';
 import visitPage from './visitPage';
 import getAmpUrl from './getAmpUrl';
+import getAppEnv from './getAppEnv';
 
 // This function takes all types of tests we have and runs in this series of steps with the fewest possible page visits
 
@@ -63,8 +64,21 @@ const runTestsForPage = ({
               );
             }
 
-            visitPage(currentPath, pageType);
+            if (!(getAppEnv() === 'local' && pageType === 'mediaAssetPage')) {
+              visitPage(currentPath, pageType);
+            }
           });
+
+          /* MAP tests on local are timing out when running on localhost in production mode,
+           * due to CORS / CSP errors when loading the media loader scripts
+           *
+           * For this reason, we will no longer run MAP canonical tests on local environment
+           *
+           * These tests will run on all other environments:
+           * Scheduled E2Es: Test / Live environment, when smoke: false
+           * Deployment Pipeline: Test / Live environment, when smoke: true
+           */
+          if (getAppEnv === 'local' && pageType === 'mediaAssetPage') return;
 
           const testArgs = {
             service,

--- a/cypress/support/helpers/runTestsForPage.js
+++ b/cypress/support/helpers/runTestsForPage.js
@@ -78,7 +78,7 @@ const runTestsForPage = ({
            * Scheduled E2Es: Test / Live environment, when smoke: false
            * Deployment Pipeline: Test / Live environment, when smoke: true
            */
-          if (getAppEnv === 'local' && pageType === 'mediaAssetPage') return;
+          if (getAppEnv() === 'local' && pageType === 'mediaAssetPage') return;
 
           const testArgs = {
             service,

--- a/src/server/utilities/cspHeader/domainLists.js
+++ b/src/server/utilities/cspHeader/domainLists.js
@@ -7,7 +7,6 @@ export const bbcDomains = [
   '*.bbc.com',
   '*.bbci.co.uk',
   '*.bbci.com',
-  'http://localhost.bbc.com',
 ];
 
 export const advertisingServiceCountryDomains = [


### PR DESCRIPTION
Overall changes
======
Disable canonical MAP E2Es on local, as they are timing out & causing PR checks to fail 

Code changes
======
- Do not run canonical MAP tests on localhost
- Revert setting http://localhost.bbc.com in the CSP directives

Testing
======
PR checks pass
All other E2E tests run in all environments

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
