### PR TITLE
Updates to Arabic and Brasil navigation

### DIFF
--- a/src/app/lib/config/services/arabic.ts
+++ b/src/app/lib/config/services/arabic.ts
@@ -436,7 +436,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'تحقيقات',
-        url: '/arabic/tv-and-radio-42414864',
+        url: '/arabic/topics/c51nnzdeg9zt',
       },
       {
         title: 'بودكاست',

--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -418,6 +418,10 @@ export const service: DefaultServiceConfig = {
         url: '/portuguese/topics/cz74k717pw5t',
       },
       {
+        title: 'Eleições municipais',
+        url: '/portuguese/topics/cy6z19wz1zet',
+      },
+      {
         title: 'Eleições EUA',
         url: '/portuguese/topics/c30gn378n6kt',
       },

--- a/src/integration/pages/homePage/arabic/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/homePage/arabic/__snapshots__/amp.test.js.snap
@@ -291,7 +291,7 @@ exports[`AMP Home Page Header Navigation link should match text and url 6`] = `
 exports[`AMP Home Page Header Navigation link should match text and url 7`] = `
 {
   "text": "تحقيقات",
-  "url": "/arabic/tv-and-radio-42414864",
+  "url": "/arabic/topics/c51nnzdeg9zt",
 }
 `;
 

--- a/src/integration/pages/homePage/arabic/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/arabic/__snapshots__/canonical.test.js.snap
@@ -130,7 +130,7 @@ exports[`Canonical Home Page Header Navigation link should match text and url 6`
 exports[`Canonical Home Page Header Navigation link should match text and url 7`] = `
 {
   "text": "تحقيقات",
-  "url": "/arabic/tv-and-radio-42414864",
+  "url": "/arabic/topics/c51nnzdeg9zt",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/amp.test.js.snap
@@ -252,7 +252,7 @@ exports[`AMP Media Asset Page Header Navigation link should match text and url 6
 exports[`AMP Media Asset Page Header Navigation link should match text and url 7`] = `
 {
   "text": "تحقيقات",
-  "url": "/arabic/tv-and-radio-42414864",
+  "url": "/arabic/topics/c51nnzdeg9zt",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
@@ -111,7 +111,7 @@ exports[`Canonical Media Asset Page Header Navigation link should match text and
 exports[`Canonical Media Asset Page Header Navigation link should match text and url 7`] = `
 {
   "text": "تحقيقات",
-  "url": "/arabic/tv-and-radio-42414864",
+  "url": "/arabic/topics/c51nnzdeg9zt",
 }
 `;
 

--- a/src/integration/pages/podcastPage/portugueseBrand/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/podcastPage/portugueseBrand/__snapshots__/canonical.test.js.snap
@@ -82,54 +82,61 @@ exports[`Canonical Podcast Page Header Navigation link should match text and url
 
 exports[`Canonical Podcast Page Header Navigation link should match text and url 3`] = `
 {
+  "text": "Eleições municipais",
+  "url": "/portuguese/topics/cy6z19wz1zet",
+}
+`;
+
+exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
+{
   "text": "Eleições EUA",
   "url": "/portuguese/topics/c30gn378n6kt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Internacional",
   "url": "/portuguese/topics/cmdm4ynm24kt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Economia",
   "url": "/portuguese/topics/cvjp2jr0k9rt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Saúde",
   "url": "/portuguese/topics/c340q430z4vt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Ciência",
   "url": "/portuguese/topics/cr50y580rjxt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnologia",
   "url": "/portuguese/topics/c404v027pd4t",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Vídeos",
   "url": "/portuguese/topics/c9y2j35dn2zt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 11`] = `
 {
   "text": "BBC Lê",
   "url": "/portuguese/topics/cxndrr1qgllt",

--- a/src/integration/pages/podcastPage/portugueseEpisode/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/podcastPage/portugueseEpisode/__snapshots__/canonical.test.js.snap
@@ -82,54 +82,61 @@ exports[`Canonical Podcast Page Header Navigation link should match text and url
 
 exports[`Canonical Podcast Page Header Navigation link should match text and url 3`] = `
 {
+  "text": "Eleições municipais",
+  "url": "/portuguese/topics/cy6z19wz1zet",
+}
+`;
+
+exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
+{
   "text": "Eleições EUA",
   "url": "/portuguese/topics/c30gn378n6kt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Internacional",
   "url": "/portuguese/topics/cmdm4ynm24kt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Economia",
   "url": "/portuguese/topics/cvjp2jr0k9rt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Saúde",
   "url": "/portuguese/topics/c340q430z4vt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Ciência",
   "url": "/portuguese/topics/cr50y580rjxt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnologia",
   "url": "/portuguese/topics/c404v027pd4t",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Vídeos",
   "url": "/portuguese/topics/c9y2j35dn2zt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 11`] = `
 {
   "text": "BBC Lê",
   "url": "/portuguese/topics/cxndrr1qgllt",

--- a/ws-nextjs-app/integration/pages/live/arabic/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/live/arabic/__snapshots__/canonical.test.ts.snap
@@ -47,7 +47,7 @@ exports[`Canonical Live Header Navigation link should match text and url 6`] = `
 exports[`Canonical Live Header Navigation link should match text and url 7`] = `
 {
   "text": "تحقيقات",
-  "url": "/arabic/tv-and-radio-42414864",
+  "url": "/arabic/topics/c51nnzdeg9zt",
 }
 `;
 


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
Update the Arabic nav bar to replace a FIX and Brasil's nav to add the link to local elections

Code changes
======

- Edited the Navigation section of src/app/lib/config/services/arabic.ts to replace the Investigations link
- Edited the Navigation section of src/app/lib/config/services/portuguese.ts to add link to Local elections in third position
- Updates snapshots
 
 
Testing
======
1. Open Arabic's front page, the third link from the end should point to arabic/topics/c51nnzdeg9zt 
2. Open Brasil's front page, the third link should be Eleições municipais and point to the local election topic (cy6z19wz1zet)


<img width="1044" alt="brasil_nav" src="https://github.com/user-attachments/assets/d20ca3bf-d727-41bf-baf0-8e3e6a050930">



Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
