### PR TITLE
WSTEAMA-1391: Do not set the embed url for OD TV pages

### DIFF
--- a/src/app/pages/OnDemandTvPage/OnDemandTvPage.tsx
+++ b/src/app/pages/OnDemandTvPage/OnDemandTvPage.tsx
@@ -6,9 +6,6 @@ import ComscoreAnalytics from '#containers/ComscoreAnalytics';
 import Grid, { GelPageGrid } from '#components/Grid';
 import StyledTvHeadingContainer from '#containers/OnDemandHeading/StyledTvHeadingContainer';
 import OnDemandParagraphContainer from '#containers/OnDemandParagraph';
-import getEmbedUrl, {
-  makeAbsolute,
-} from '#lib/utilities/getUrlHelpers/getEmbedUrl';
 import RecentVideoEpisodes from '#containers/EpisodeList/RecentVideoEpisodes';
 import FooterTimestamp from '#containers/OnDemandFooterTimestamp';
 import useLocation from '#hooks/useLocation';
@@ -88,9 +85,8 @@ const OnDemandTvPage = ({
     contentType,
   } = pageData;
 
-  const { lang, timezone, datetimeLocale, service, brandName } =
+  const { timezone, datetimeLocale, service, brandName } =
     useContext(ServiceContext);
-  const location = useLocation();
 
   const formattedTimestamp = formatUnixTimestamp({
     timestamp: releaseDateTimeStamp,
@@ -98,14 +94,6 @@ const OnDemandTvPage = ({
     timezone,
     locale: datetimeLocale,
     isRelative: false,
-  });
-
-  const mediaId = `${service}/${masterBrand}/${episodeId}/${lang}`;
-
-  const embedUrl = getEmbedUrl({
-    mediaId,
-    type: 'media',
-    queryString: location.search,
   });
 
   const hasRecentEpisodes = recentEpisodes && Boolean(recentEpisodes.length);
@@ -153,7 +141,6 @@ const OnDemandTvPage = ({
                   thumbnailUrl: thumbnailImageUrl,
                   duration: durationISO8601,
                   uploadDate: new Date(releaseDateTimeStamp).toISOString(),
-                  embedURL: makeAbsolute(embedUrl),
                 },
               ]
             : []

--- a/src/app/pages/OnDemandTvPage/OnDemandTvPage.tsx
+++ b/src/app/pages/OnDemandTvPage/OnDemandTvPage.tsx
@@ -8,7 +8,6 @@ import StyledTvHeadingContainer from '#containers/OnDemandHeading/StyledTvHeadin
 import OnDemandParagraphContainer from '#containers/OnDemandParagraph';
 import RecentVideoEpisodes from '#containers/EpisodeList/RecentVideoEpisodes';
 import FooterTimestamp from '#containers/OnDemandFooterTimestamp';
-import useLocation from '#hooks/useLocation';
 import { PageTypes } from '#app/models/types/global';
 import { ContentType } from '#app/components/ChartbeatAnalytics/types';
 import MediaLoader from '#app/components/MediaLoader';

--- a/src/integration/pages/onDemandTVPage/hausa/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/hausa/__snapshots__/canonical.test.js.snap
@@ -497,7 +497,6 @@ exports[`Canonical On Demand T V Page SEO Linked data should match text 1`] = `
       "@type": "VideoObject",
       "description": "Sashen Hausa na BBC ya fara gabatar da shirin talabijin a ranakun Litinin zuwa Juma'a na kowane mako.",
       "duration": "PT10M",
-      "embedURL": "https://www.test.bbc.com/ws/av-embeds/media/hausa/bbc_hausa_tv/w172xcg0kg6vph8/ha?morph_env=live",
       "name": "Labaran Talabijin",
       "thumbnailUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p08b216l.png",
       "uploadDate": "2020-11-23T00:00:00.000Z",

--- a/src/integration/pages/onDemandTVPage/pashtoBrand/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/pashtoBrand/__snapshots__/canonical.test.js.snap
@@ -525,7 +525,6 @@ exports[`Canonical On Demand T V Page SEO Linked data should match text 1`] = `
       "@type": "VideoObject",
       "description": "نړۍ دا وخت، د نړۍ او سیمې وروستۍ پرمختیاوې یادوي",
       "duration": "PT28M",
-      "embedURL": "https://www.test.bbc.com/ws/av-embeds/media/pashto/bbc_pashto_tv/w172zmsln64zg23/ps?morph_env=live",
       "name": " د بي بي سي خبرونه ",
       "thumbnailUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p08b23c8.png",
       "uploadDate": "2024-09-17T00:00:00.000Z",


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAMA-1391

Overall changes
======
Do not set embedUrl for OD TV pages

Code changes
======
- Delete embedUrl code from OD TV page
- Update tests

Testing
======
PR checks
Paste HTML into https://validator.schema.org/ to ensure that embedUrl no longer present on VideoObject