### PR TITLE
Prevent Features and most read section re-rendering 

### DIFF
--- a/src/app/legacy/components/ScrollablePromo/index.jsx
+++ b/src/app/legacy/components/ScrollablePromo/index.jsx
@@ -21,6 +21,7 @@ import useViewTracker from '#hooks/useViewTracker';
 import useClickTrackerHandler from '#hooks/useClickTrackerHandler';
 import idSanitiser from '#lib/utilities/idSanitiser';
 import { OptimizelyContext } from '@optimizely/react-sdk';
+import useOptimizelyScrollDepth from '#app/hooks/useOptimizelyScrollDepth';
 import { ServiceContext } from '../../../contexts/ServiceContext';
 import Promo from './Promo';
 import PromoList from './PromoList';
@@ -101,6 +102,8 @@ const ScrollablePromo = ({ blocks, blockGroupIndex = null }) => {
           ),
         }),
   };
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useOptimizelyScrollDepth();
 
   return (
     <GridItemMediumNoMargin {...a11yAttributes}>

--- a/src/app/legacy/components/ScrollablePromo/index.jsx
+++ b/src/app/legacy/components/ScrollablePromo/index.jsx
@@ -72,6 +72,8 @@ const ScrollablePromo = ({ blocks, blockGroupIndex = null }) => {
   const viewRef = useViewTracker(eventTrackingData);
   const handleClickTracking = useClickTrackerHandler(eventTrackingData);
 
+  useOptimizelyScrollDepth();
+
   if (!blocks || isEmpty(blocks)) {
     return null;
   }
@@ -102,8 +104,6 @@ const ScrollablePromo = ({ blocks, blockGroupIndex = null }) => {
           ),
         }),
   };
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  useOptimizelyScrollDepth();
 
   return (
     <GridItemMediumNoMargin {...a11yAttributes}>

--- a/src/app/legacy/components/ScrollablePromo/index.test.jsx
+++ b/src/app/legacy/components/ScrollablePromo/index.test.jsx
@@ -12,6 +12,11 @@ import ScrollablePromo from '.';
 import { edOjA, edOjB } from './fixtures';
 import { MEDIA_ARTICLE_PAGE } from '../../../routes/utils/pageTypes';
 
+jest.mock('#app/hooks/useOptimizelyVariation', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
 describe('ScrollablePromo', () => {
   it('should return null if no data is passed', () => {
     const { container } = render(<ScrollablePromo blocks={[]} />);

--- a/src/app/legacy/components/ScrollablePromo/index.test.jsx
+++ b/src/app/legacy/components/ScrollablePromo/index.test.jsx
@@ -12,7 +12,7 @@ import ScrollablePromo from '.';
 import { edOjA, edOjB } from './fixtures';
 import { MEDIA_ARTICLE_PAGE } from '../../../routes/utils/pageTypes';
 
-jest.mock('#app/hooks/useOptimizelyVariation', () => ({
+jest.mock('#app/hooks/useOptimizelyScrollDepth', () => ({
   __esModule: true,
   default: jest.fn(),
 }));

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -44,7 +44,6 @@ import { Article, OptimoBylineBlock } from '#app/models/types/optimo';
 import useOptimizelyVariation from '#app/hooks/useOptimizelyVariation';
 import OptimizelyArticleCompleteTracking from '#app/legacy/containers/OptimizelyArticleCompleteTracking';
 import OptimizelyPageViewTracking from '#app/legacy/containers/OptimizelyPageViewTracking';
-import useOptimizelyScrollDepth from '#app/hooks/useOptimizelyScrollDepth';
 import ImageWithCaption from '../../components/ImageWithCaption';
 import AdContainer from '../../components/Ad';
 import EmbedImages from '../../components/Embeds/EmbedImages';
@@ -218,8 +217,6 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
   const showTopics = Boolean(
     showRelatedTopics && topics.length > 0 && !isTransliterated,
   );
-
-  useOptimizelyScrollDepth();
 
   return (
     <div css={styles.pageWrapper}>


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======

The ` useOptimizelyScrollDepth` hook caused the features and most read sections to re-render. Moving this hook inside the `scrollablePromo` component prevents this

Code changes
======

- _A bullet point list of key code changes that have been made._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
