### PR TITLE
Update Persian and Mundo navigatio bars

### DIFF
--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -412,6 +412,10 @@ export const service: DefaultServiceConfig = {
         url: '/mundo/topics/c2lej05epw5t',
       },
       {
+        title: 'Elecciones EE.UU. 2024',
+        url: '/mundo/topics/c1v8en6r2qgt',
+      },
+      {
         title: 'Hay Festival',
         url: '/mundo/topics/cr50y7p7qyqt',
       },

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -436,8 +436,8 @@ export const service: DefaultServiceConfig = {
         url: '/persian',
       },
       {
-        title: 'جنگ اسرائیل-غزه',
-        url: '/persian/topics/clm0z4jgj3xt',
+        title: 'بحران خاورمیانه',
+        url: '/persian/topics/cj31ldvmg1et',
       },
       {
         title: 'پخش زنده',

--- a/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
@@ -172,8 +172,8 @@ exports[`AMP Articles Header Navigation link should match text and url 1`] = `
 
 exports[`AMP Articles Header Navigation link should match text and url 2`] = `
 {
-  "text": "جنگ اسرائیل-غزه",
-  "url": "/persian/topics/clm0z4jgj3xt",
+  "text": "بحران خاورمیانه",
+  "url": "/persian/topics/cj31ldvmg1et",
 }
 `;
 

--- a/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
@@ -75,8 +75,8 @@ exports[`Canonical Articles Header Navigation link should match text and url 1`]
 
 exports[`Canonical Articles Header Navigation link should match text and url 2`] = `
 {
-  "text": "جنگ اسرائیل-غزه",
-  "url": "/persian/topics/clm0z4jgj3xt",
+  "text": "بحران خاورمیانه",
+  "url": "/persian/topics/cj31ldvmg1et",
 }
 `;
 

--- a/src/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.js.snap
@@ -172,8 +172,8 @@ exports[`AMP Articles Header Navigation link should match text and url 1`] = `
 
 exports[`AMP Articles Header Navigation link should match text and url 2`] = `
 {
-  "text": "جنگ اسرائیل-غزه",
-  "url": "/persian/topics/clm0z4jgj3xt",
+  "text": "بحران خاورمیانه",
+  "url": "/persian/topics/cj31ldvmg1et",
 }
 `;
 

--- a/src/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.js.snap
@@ -75,8 +75,8 @@ exports[`Canonical Articles Header Navigation link should match text and url 1`]
 
 exports[`Canonical Articles Header Navigation link should match text and url 2`] = `
 {
-  "text": "جنگ اسرائیل-غزه",
-  "url": "/persian/topics/clm0z4jgj3xt",
+  "text": "بحران خاورمیانه",
+  "url": "/persian/topics/cj31ldvmg1et",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
@@ -216,8 +216,8 @@ exports[`AMP Media Asset Page Header Navigation link should match text and url 1
 
 exports[`AMP Media Asset Page Header Navigation link should match text and url 2`] = `
 {
-  "text": "جنگ اسرائیل-غزه",
-  "url": "/persian/topics/clm0z4jgj3xt",
+  "text": "بحران خاورمیانه",
+  "url": "/persian/topics/cj31ldvmg1et",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
@@ -75,8 +75,8 @@ exports[`Canonical Media Asset Page Header Navigation link should match text and
 
 exports[`Canonical Media Asset Page Header Navigation link should match text and url 2`] = `
 {
-  "text": "جنگ اسرائیل-غزه",
-  "url": "/persian/topics/clm0z4jgj3xt",
+  "text": "بحران خاورمیانه",
+  "url": "/persian/topics/cj31ldvmg1et",
 }
 `;
 

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
@@ -230,47 +230,54 @@ exports[`AMP Most Read Page Header Navigation link should match text and url 3`]
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 4`] = `
 {
+  "text": "Elecciones EE.UU. 2024",
+  "url": "/mundo/topics/c1v8en6r2qgt",
+}
+`;
+
+exports[`AMP Most Read Page Header Navigation link should match text and url 5`] = `
+{
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 11`] = `
 {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/topics/c404v5z1k8wt",

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
@@ -89,47 +89,54 @@ exports[`Canonical Most Read Page Header Navigation link should match text and u
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 4`] = `
 {
+  "text": "Elecciones EE.UU. 2024",
+  "url": "/mundo/topics/c1v8en6r2qgt",
+}
+`;
+
+exports[`Canonical Most Read Page Header Navigation link should match text and url 5`] = `
+{
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 11`] = `
 {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/topics/c404v5z1k8wt",

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
@@ -230,47 +230,54 @@ exports[`AMP Photo Gallery Page Header Navigation link should match text and url
 
 exports[`AMP Photo Gallery Page Header Navigation link should match text and url 4`] = `
 {
+  "text": "Elecciones EE.UU. 2024",
+  "url": "/mundo/topics/c1v8en6r2qgt",
+}
+`;
+
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 5`] = `
+{
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 11`] = `
 {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/topics/c404v5z1k8wt",

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
@@ -89,47 +89,54 @@ exports[`Canonical Photo Gallery Page Header Navigation link should match text a
 
 exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 4`] = `
 {
+  "text": "Elecciones EE.UU. 2024",
+  "url": "/mundo/topics/c1v8en6r2qgt",
+}
+`;
+
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 5`] = `
+{
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 11`] = `
 {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/topics/c404v5z1k8wt",

--- a/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
@@ -230,47 +230,54 @@ exports[`AMP Story Page Header Navigation link should match text and url 3`] = `
 
 exports[`AMP Story Page Header Navigation link should match text and url 4`] = `
 {
+  "text": "Elecciones EE.UU. 2024",
+  "url": "/mundo/topics/c1v8en6r2qgt",
+}
+`;
+
+exports[`AMP Story Page Header Navigation link should match text and url 5`] = `
+{
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 11`] = `
 {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/topics/c404v5z1k8wt",

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -96,47 +96,54 @@ exports[`Canonical Story Page Header Navigation link should match text and url 3
 
 exports[`Canonical Story Page Header Navigation link should match text and url 4`] = `
 {
+  "text": "Elecciones EE.UU. 2024",
+  "url": "/mundo/topics/c1v8en6r2qgt",
+}
+`;
+
+exports[`Canonical Story Page Header Navigation link should match text and url 5`] = `
+{
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 11`] = `
 {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/topics/c404v5z1k8wt",

--- a/ws-nextjs-app/integration/pages/send/mundo/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/send/mundo/__snapshots__/canonical.test.ts.snap
@@ -87,47 +87,54 @@ exports[`Canonical Send Header Navigation link should match text and url 3`] = `
 
 exports[`Canonical Send Header Navigation link should match text and url 4`] = `
 {
+  "text": "Elecciones EE.UU. 2024",
+  "url": "/mundo/topics/c1v8en6r2qgt",
+}
+`;
+
+exports[`Canonical Send Header Navigation link should match text and url 5`] = `
+{
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 5`] = `
+exports[`Canonical Send Header Navigation link should match text and url 6`] = `
 {
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 6`] = `
+exports[`Canonical Send Header Navigation link should match text and url 7`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 7`] = `
+exports[`Canonical Send Header Navigation link should match text and url 8`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 8`] = `
+exports[`Canonical Send Header Navigation link should match text and url 9`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 9`] = `
+exports[`Canonical Send Header Navigation link should match text and url 10`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 10`] = `
+exports[`Canonical Send Header Navigation link should match text and url 11`] = `
 {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/topics/c404v5z1k8wt",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds US election topic links to the navgation bar of Mundo
- Replace Gaza War topic wiht MIddle East crisis topic on Persian's nav

Code changes
======

- Edited Navigation section of src/app/lib/config/services/mundo.ts to add election topic link in fourth position
- Edited Navigation section of src/app/lib/config/services/persian.ts to add update the second link 
- Updated snapshots


Testing
======
1. Open Mundo front page, fourth link in the nav should point to the US election 2024 and open the election topic
2. Open Persian's front page, second link in the nav shoudld be بحران خاورمیانه and point to /persian/topics/cj31ldvmg1et
<img width="1031" alt="mundo_nav" src="https://github.com/user-attachments/assets/038e7cc5-df5f-4880-85f9-96ca2f94e1de">
<img width="517" alt="persian nav" src="https://github.com/user-attachments/assets/18b82096-2a52-4b15-8d8b-d5880da4f5cf">





Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
