### PR TITLE
Add US election topic to Bengali and Persian nav bars

### DIFF
--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -328,6 +328,10 @@ export const service: DefaultServiceConfig = {
         url: '/bengali',
       },
       {
+        title: 'যুক্তরাষ্ট্র নির্বাচন ২০২৪',
+        url: '/bengali/topics/cjlgjr0d2d2t',
+      },
+      {
         title: 'রাজনীতি',
         url: '/bengali/topics/cqywj91rkg6t',
       },

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -440,6 +440,10 @@ export const service: DefaultServiceConfig = {
         url: '/persian/topics/cj31ldvmg1et',
       },
       {
+        title: 'انتخابات آمریکا',
+        url: '/persian/topics/cj1gj22k6z6t',
+      },
+      {
         title: 'پخش زنده',
         url: '/persian/media-49522521',
       },

--- a/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
@@ -179,75 +179,82 @@ exports[`AMP Articles Header Navigation link should match text and url 2`] = `
 
 exports[`AMP Articles Header Navigation link should match text and url 3`] = `
 {
+  "text": "انتخابات آمریکا",
+  "url": "/persian/topics/cj1gj22k6z6t",
+}
+`;
+
+exports[`AMP Articles Header Navigation link should match text and url 4`] = `
+{
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 4`] = `
+exports[`AMP Articles Header Navigation link should match text and url 5`] = `
 {
   "text": "ویدیو",
   "url": "/persian/topics/c6z7mnr559gt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 5`] = `
+exports[`AMP Articles Header Navigation link should match text and url 6`] = `
 {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 6`] = `
+exports[`AMP Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 7`] = `
+exports[`AMP Articles Header Navigation link should match text and url 8`] = `
 {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 8`] = `
+exports[`AMP Articles Header Navigation link should match text and url 9`] = `
 {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 9`] = `
+exports[`AMP Articles Header Navigation link should match text and url 10`] = `
 {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 10`] = `
+exports[`AMP Articles Header Navigation link should match text and url 11`] = `
 {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 11`] = `
+exports[`AMP Articles Header Navigation link should match text and url 12`] = `
 {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 12`] = `
+exports[`AMP Articles Header Navigation link should match text and url 13`] = `
 {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 13`] = `
+exports[`AMP Articles Header Navigation link should match text and url 14`] = `
 {
   "text": "فراتر از خبر",
   "url": "/persian/topics/cxr3ex12k6et",

--- a/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
@@ -82,75 +82,82 @@ exports[`Canonical Articles Header Navigation link should match text and url 2`]
 
 exports[`Canonical Articles Header Navigation link should match text and url 3`] = `
 {
+  "text": "انتخابات آمریکا",
+  "url": "/persian/topics/cj1gj22k6z6t",
+}
+`;
+
+exports[`Canonical Articles Header Navigation link should match text and url 4`] = `
+{
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 4`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 5`] = `
 {
   "text": "ویدیو",
   "url": "/persian/topics/c6z7mnr559gt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 5`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 6`] = `
 {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 6`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 7`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 8`] = `
 {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 8`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 9`] = `
 {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 9`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 10`] = `
 {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 10`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 11`] = `
 {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 11`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 12`] = `
 {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 12`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 13`] = `
 {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 13`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 14`] = `
 {
   "text": "فراتر از خبر",
   "url": "/persian/topics/cxr3ex12k6et",

--- a/src/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.js.snap
@@ -179,75 +179,82 @@ exports[`AMP Articles Header Navigation link should match text and url 2`] = `
 
 exports[`AMP Articles Header Navigation link should match text and url 3`] = `
 {
+  "text": "انتخابات آمریکا",
+  "url": "/persian/topics/cj1gj22k6z6t",
+}
+`;
+
+exports[`AMP Articles Header Navigation link should match text and url 4`] = `
+{
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 4`] = `
+exports[`AMP Articles Header Navigation link should match text and url 5`] = `
 {
   "text": "ویدیو",
   "url": "/persian/topics/c6z7mnr559gt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 5`] = `
+exports[`AMP Articles Header Navigation link should match text and url 6`] = `
 {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 6`] = `
+exports[`AMP Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 7`] = `
+exports[`AMP Articles Header Navigation link should match text and url 8`] = `
 {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 8`] = `
+exports[`AMP Articles Header Navigation link should match text and url 9`] = `
 {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 9`] = `
+exports[`AMP Articles Header Navigation link should match text and url 10`] = `
 {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 10`] = `
+exports[`AMP Articles Header Navigation link should match text and url 11`] = `
 {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 11`] = `
+exports[`AMP Articles Header Navigation link should match text and url 12`] = `
 {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 12`] = `
+exports[`AMP Articles Header Navigation link should match text and url 13`] = `
 {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 13`] = `
+exports[`AMP Articles Header Navigation link should match text and url 14`] = `
 {
   "text": "فراتر از خبر",
   "url": "/persian/topics/cxr3ex12k6et",

--- a/src/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.js.snap
@@ -82,75 +82,82 @@ exports[`Canonical Articles Header Navigation link should match text and url 2`]
 
 exports[`Canonical Articles Header Navigation link should match text and url 3`] = `
 {
+  "text": "انتخابات آمریکا",
+  "url": "/persian/topics/cj1gj22k6z6t",
+}
+`;
+
+exports[`Canonical Articles Header Navigation link should match text and url 4`] = `
+{
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 4`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 5`] = `
 {
   "text": "ویدیو",
   "url": "/persian/topics/c6z7mnr559gt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 5`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 6`] = `
 {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 6`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 7`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 8`] = `
 {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 8`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 9`] = `
 {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 9`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 10`] = `
 {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 10`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 11`] = `
 {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 11`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 12`] = `
 {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 12`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 13`] = `
 {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 13`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 14`] = `
 {
   "text": "فراتر از خبر",
   "url": "/persian/topics/cxr3ex12k6et",

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
@@ -223,75 +223,82 @@ exports[`AMP Media Asset Page Header Navigation link should match text and url 2
 
 exports[`AMP Media Asset Page Header Navigation link should match text and url 3`] = `
 {
+  "text": "انتخابات آمریکا",
+  "url": "/persian/topics/cj1gj22k6z6t",
+}
+`;
+
+exports[`AMP Media Asset Page Header Navigation link should match text and url 4`] = `
+{
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 4`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 5`] = `
 {
   "text": "ویدیو",
   "url": "/persian/topics/c6z7mnr559gt",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 6`] = `
 {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 7`] = `
 {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 8`] = `
 {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 9`] = `
 {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 10`] = `
 {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 11`] = `
 {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 11`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 12`] = `
 {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 12`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 13`] = `
 {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 13`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 14`] = `
 {
   "text": "فراتر از خبر",
   "url": "/persian/topics/cxr3ex12k6et",

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
@@ -82,75 +82,82 @@ exports[`Canonical Media Asset Page Header Navigation link should match text and
 
 exports[`Canonical Media Asset Page Header Navigation link should match text and url 3`] = `
 {
+  "text": "انتخابات آمریکا",
+  "url": "/persian/topics/cj1gj22k6z6t",
+}
+`;
+
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 4`] = `
+{
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 5`] = `
 {
   "text": "ویدیو",
   "url": "/persian/topics/c6z7mnr559gt",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 6`] = `
 {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 7`] = `
 {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 8`] = `
 {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 9`] = `
 {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 10`] = `
 {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 11`] = `
 {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 12`] = `
 {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 12`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 13`] = `
 {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 13`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 14`] = `
 {
   "text": "فراتر از خبر",
   "url": "/persian/topics/cxr3ex12k6et",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds election topic links to the navigation bar of Bengali and Persian

Code changes
======

- Edited Navigation section of src/app/lib/config/services/bengali.ts to add election topic link in second position
- Edited Navigation section of src/app/lib/config/services/persian.ts to add election topic link in third position
- Updated snapshots

Testing
======
1. Open Bengali's front page, second link in the nav should be যুক্তরাষ্ট্র নির্বাচন ২০২৪ and open the US election topic
2. Open Persian's front page, third  link in the nav should be انتخابات آمریکا and open the US election topic

<img width="486" alt="bengali_nav" src="https://github.com/user-attachments/assets/b1a26bc7-0a3f-451c-a2f9-12a7e9c3068f">
<img width="550" alt="persian_nav" src="https://github.com/user-attachments/assets/4b859ebd-e712-4af1-bb4b-b95ceccdd384">





Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
