### PR TITLE
Stop TC2 MAPs URLs being tested for AMP Cookie banner tests

### DIFF
--- a/cypress/e2e/specialFeatures/cookieBanner/index.cy.js
+++ b/cypress/e2e/specialFeatures/cookieBanner/index.cy.js
@@ -39,7 +39,7 @@ const getPaths = service =>
   );
 
 const pageType = 'all';
-const urlsToExcludeFromAmpTests = ['_tv', '_radio'];
+const urlsToExcludeFromAmpTests = ['_tv', '_radio', '/20'];
 
 Object.keys(config)
   .filter(service => serviceFilter(service))


### PR DESCRIPTION
To stop the current test failures. An application error on TC2 MAPs on AMP causes the tests to fail.

I added a substring of the TC2 MAP URLs to an array that was already excluding other URLs from the amp tests.

Resolves JIRA [number]

Overall changes
======
_A very high-level summary of easily-reproducible changes that can be understood by non-devs, and why these changes where made._

Code changes
======

- _A bullet point list of key code changes that have been made._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
