### PR TITLE
Lite site `none` meta tag

### DIFF
--- a/src/server/Document/Renderers/LiteRenderer.tsx
+++ b/src/server/Document/Renderers/LiteRenderer.tsx
@@ -18,7 +18,7 @@ export default function LitePageRenderer({
   return (
     <html lang="en-GB" {...htmlAttrs}>
       <head>
-        <meta name="robots" content="noindex" />
+        <meta name="robots" content="none" />
         {title}
         {helmetMetaTags}
         {helmetLinkTags}

--- a/src/server/Document/__snapshots__/component.test.jsx.snap
+++ b/src/server/Document/__snapshots__/component.test.jsx.snap
@@ -168,7 +168,7 @@ exports[`Document Component should render LITE version correctly 1`] = `
 >
   <head>
     <meta
-      content="noindex"
+      content="none"
       name="robots"
     />
     <title


### PR DESCRIPTION
Overall changes
======
- Sets the `robots` meta tag to `none` so that crawlers don't attempt to index links within `.lite` pages yet
- `none` is shorthand for `noindex,nofollow`

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
