### PR TITLE
Update Russian and Swahili navs to add US election topic

### DIFF
--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -441,6 +441,10 @@ export const service: DefaultServiceConfig = {
         url: '/russian/topics/cez0n29ggrdt',
       },
       {
+        title: 'Выборы в США',
+        url: '/russian/topics/ce802g1vrdgt',
+      },
+      {
         title: 'Истории',
         url: '/russian/topics/cv27xky1pppt',
       },

--- a/src/app/lib/config/services/swahili.ts
+++ b/src/app/lib/config/services/swahili.ts
@@ -328,6 +328,10 @@ export const service: DefaultServiceConfig = {
         url: '/swahili',
       },
       {
+        title: 'Uchaguzi wa Marekani 2024',
+        url: '/swahili/topics/c3v8qp1qz4xt',
+      },
+      {
         title: 'Michezo',
         url: '/swahili/topics/ckdxndddjkxt',
       },


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
Adds the US election topic link to the navigation bar of Russian and Swahil



Code changes
======
- Edited Navigation section of src/app/lib/config/services/russian.ts to add election topic link in third position
- Edited Navigation section of src/app/lib/config/services/swahili.ts to add election topic link in second positiontion



Testing
======
1. Open Russian's front page, thrid link in the nav should be Выборы в США and open the US election topic
2. Open Swahili front page, second link in the nav should be Uchaguzi wa Marekani 2024 and open the US election topic


<img width="452" alt="russian_nav" src="https://github.com/user-attachments/assets/e76974a4-2d55-4f8b-bf38-7875205f4266">
<img width="525" alt="swahili_nav" src="https://github.com/user-attachments/assets/6448f19c-0f28-4f60-9815-7c725cde97ac">





Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
