### PR TITLE
Add election topic links to the Hindi, Korean and Marathi navigation bars

### DIFF
--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -435,6 +435,10 @@ export const service: DefaultServiceConfig = {
         url: '/hindi/topics/ckdxnkz7607t',
       },
       {
+        title: 'अमेरिकी चुनाव 2024',
+        url: '/hindi/topics/cp9r94x30m5t',
+      },
+      {
         title: 'विदेश',
         url: '/hindi/topics/c9wpm0en87xt',
       },

--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -325,6 +325,10 @@ export const service: DefaultServiceConfig = {
         url: '/korean',
       },
       {
+        title: '2024 미국 대선',
+        url: '/korean/topics/cxdyjwpx5v0t',
+      },
+      {
         title: '비디오',
         url: '/korean/topics/cnwng7v0e54t',
       },

--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -342,6 +342,10 @@ export const service: DefaultServiceConfig = {
         url: '/marathi/topics/c5qvpxvv7y3t',
       },
       {
+        title: 'विधानसभा निवडणूक',
+        url: '/marathi/topics/c625x8zjyj7t',
+      },
+      {
         title: 'भारत',
         url: '/marathi/topics/cxnyk3y49x6t',
       },

--- a/src/integration/pages/homePage/hindi/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/homePage/hindi/__snapshots__/amp.test.js.snap
@@ -214,47 +214,54 @@ exports[`AMP Home Page Header Navigation link should match text and url 2`] = `
 
 exports[`AMP Home Page Header Navigation link should match text and url 3`] = `
 {
+  "text": "अमेरिकी चुनाव 2024",
+  "url": "/hindi/topics/cp9r94x30m5t",
+}
+`;
+
+exports[`AMP Home Page Header Navigation link should match text and url 4`] = `
+{
   "text": "विदेश",
   "url": "/hindi/topics/c9wpm0en87xt",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 4`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 5`] = `
 {
   "text": "मनोरंजन",
   "url": "/hindi/topics/c06gq3n0pp7t",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 6`] = `
 {
   "text": "खेल",
   "url": "/hindi/topics/cwr9j8g1kj9t",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 7`] = `
 {
   "text": "विज्ञान-टेक्नॉलॉजी",
   "url": "/hindi/topics/c2lej0594knt",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 8`] = `
 {
   "text": "सोशल",
   "url": "/hindi/topics/c2e4q0z9qznt",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 9`] = `
 {
   "text": "वीडियो",
   "url": "/hindi/topics/cw9kv0kpxydt",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 10`] = `
 {
   "text": "पॉडकास्ट",
   "url": "/hindi/institutional-61824775",

--- a/src/integration/pages/homePage/hindi/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/hindi/__snapshots__/canonical.test.js.snap
@@ -84,47 +84,54 @@ exports[`Canonical Home Page Header Navigation link should match text and url 2`
 
 exports[`Canonical Home Page Header Navigation link should match text and url 3`] = `
 {
+  "text": "अमेरिकी चुनाव 2024",
+  "url": "/hindi/topics/cp9r94x30m5t",
+}
+`;
+
+exports[`Canonical Home Page Header Navigation link should match text and url 4`] = `
+{
   "text": "विदेश",
   "url": "/hindi/topics/c9wpm0en87xt",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 5`] = `
 {
   "text": "मनोरंजन",
   "url": "/hindi/topics/c06gq3n0pp7t",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 6`] = `
 {
   "text": "खेल",
   "url": "/hindi/topics/cwr9j8g1kj9t",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 7`] = `
 {
   "text": "विज्ञान-टेक्नॉलॉजी",
   "url": "/hindi/topics/c2lej0594knt",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 8`] = `
 {
   "text": "सोशल",
   "url": "/hindi/topics/c2e4q0z9qznt",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 9`] = `
 {
   "text": "वीडियो",
   "url": "/hindi/topics/cw9kv0kpxydt",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 10`] = `
 {
   "text": "पॉडकास्ट",
   "url": "/hindi/institutional-61824775",

--- a/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
@@ -75,26 +75,33 @@ exports[`Canonical Korean Live Radio Page Header Navigation link should match te
 
 exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 2`] = `
 {
+  "text": "2024 미국 대선",
+  "url": "/korean/topics/cxdyjwpx5v0t",
+}
+`;
+
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 3`] = `
+{
   "text": "비디오",
   "url": "/korean/topics/cnwng7v0e54t",
 }
 `;
 
-exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 3`] = `
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 4`] = `
 {
   "text": "라디오",
   "url": "/korean/bbc_korean_radio/programmes/w13xttll",
 }
 `;
 
-exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 5`] = `
 {
   "text": "다운로드",
   "url": "/korean/downloads",
 }
 `;
 
-exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 6`] = `
 {
   "text": "TOP 뉴스",
   "url": "/korean/popular/read",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds US election topic links to the navgation bar of Hindi and Korean
- Adds Maharashtra assembly election topic link to the Marathi nav bar

Code changes
======

- Edited Navigation section of src/app/lib/config/services/hindi.ts to add US election topic link in third position
- Edited Navigation section of src/app/lib/config/services/korean.ts to add US election topic link in second position
- Edited Navigation section of src/app/lib/config/services/marathi.ts to add asembly election topic link in third position
- Updated snapshots


Testing
======
1. Open Hindi's front page, third link in the nav should be अमेरिकी चुनाव 2024 and open the US election topic
2. Open Gujarati's front page, second link in the nav should be 2024 미국 대선 and open US the election topic
3. Open Gujarati's front page, second link in the nav should be विधानसभा निवडणूक and open the Aseembly election topic



<img width="480" alt="hindi_nav" src="https://github.com/user-attachments/assets/558a980a-86af-4deb-89aa-e780e1f5bf5d">
<img width="493" alt="korean_nav" src="https://github.com/user-attachments/assets/89506581-79d1-48f4-9654-9f26471c9a17">
<img width="471" alt="marathi_nav" src="https://github.com/user-attachments/assets/ff6545f3-dcc0-4ff7-9cbb-6a4e9ddda3a8">





Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
