### PR TITLE
Wsteam1 cta refactor

### DIFF
--- a/src/app/components/CallToActionLink/README.md
+++ b/src/app/components/CallToActionLink/README.md
@@ -1,0 +1,58 @@
+## Description
+
+A standalone link component. Used on banners, uploader CTAs and download pages.
+
+By default centre align and text-decoration: underline styles are applied. These can be overriden with bottom border styles.
+
+## Props
+
+| Name                | type                  | Description                                                                         |
+| ------------------- | --------------------- | ----------------------------------------------------------------------------------- |
+| href                | string                | Link to the CTA link destination                                                    |
+| className           | string                | used for passing styles                                                             |
+| children            | JSX Node              | Contains text for link and/or chevron                                               |
+| eventTrackingData   | EventTrackingMetadata | Contains click and view tracking data for Piano                                     |
+| size                | GelFontSize           | used for Text component                                                             |
+| fontVariant         | FontVariant           | used for Text component                                                             |
+| download            | boolean               | adds html download attribute                                                        |
+| ignoreLiteExtension | boolean               | removes .lite extension from href                                                   |
+| borderStyleOverride | string                | overrides text-decoration:underline behaviour and flex centre align styles          |
+| linkText            | boolean               | Text for link. Required for borderStyleOverride to prevent chevron being underlined |
+
+## Example ltr/rtl
+
+### With default centre align and underline styles
+
+```javascript
+<CallToActionLink href={link} eventTrackingData={eventTrackingData}>
+  {linkText}
+  {isRtl ? (
+    <LeftChevron css={styles.chevron} />
+  ) : (
+    <RightChevron css={styles.chevron} />
+  )}
+</CallToActionLink>
+```
+
+### With bottom border styles and with a chevron
+
+```javascript
+<CallToActionLink href={link} text={linkText} borderStyleOverride>
+  {isRtl ? (
+    <LeftChevron css={styles.chevron} />
+  ) : (
+    <RightChevron css={styles.chevron} />
+  )}
+</CallToActionLink>
+```
+
+### With bottom border styles and without a chevron
+
+```javascript
+<CallToActionLink
+  href={link}
+  text={linkText}
+  borderStyleOverride
+  css={[styles.bottomLinkSpacing, styles.link]}
+/>
+```

--- a/src/app/components/CallToActionLink/index.stories.tsx
+++ b/src/app/components/CallToActionLink/index.stories.tsx
@@ -1,42 +1,51 @@
 import React, { PropsWithChildren } from 'react';
-import readme from './README.md';
 
 import { CallToActionLinkProps } from './types';
 import CallToActionLink from '.';
+import Text from '../Text';
 
 const Component = ({
   href,
   children,
-  linkText,
-  borderStyleOverride,
 }: PropsWithChildren<CallToActionLinkProps>) => (
-  <CallToActionLink
-    linkText={linkText}
-    href={href}
-    borderStyleOverride={borderStyleOverride}
-  >
-    {children}
-  </CallToActionLink>
+  <CallToActionLink href={href}>{children}</CallToActionLink>
 );
 
 export default {
   title: 'Components/Call To Action Link',
   Component,
-  parameters: {
-    docs: { readme },
+  args: {
+    fontVariant: 'sansBold',
+  },
+  argTypes: {
+    fontVariant: {
+      control: { type: 'select' },
+      options: [
+        'sansRegular',
+        'sansRegularItalic',
+        'sansBold',
+        'sansBoldItalic',
+        'sansLight',
+        'serifRegular',
+        'serifMedium',
+        'serifMediumItalic',
+        'serifBold',
+        'serifLight',
+      ],
+    },
   },
 };
 
-export const DefaultStyles = () => {
+export const Example = () => {
   return <Component href="www.bbc.com/afrique">Call To Action</Component>;
 };
 
-export const BottomBorderStyles = () => {
+export const CustomCTALink = ({ fontVariant }: { fontVariant: string }) => {
   return (
-    <Component
-      href="www.bbc.com/afrique"
-      borderStyleOverride
-      linkText="My Link Text"
-    />
+    <Component href="www.bbc.com/afrique">
+      <Text size="brevier" fontVariant={fontVariant}>
+        Custom Font Call To Action
+      </Text>
+    </Component>
   );
 };

--- a/src/app/components/CallToActionLink/index.stories.tsx
+++ b/src/app/components/CallToActionLink/index.stories.tsx
@@ -1,4 +1,5 @@
 import React, { PropsWithChildren } from 'react';
+import readme from './README.md';
 
 import { CallToActionLinkProps } from './types';
 import CallToActionLink from '.';
@@ -6,15 +7,36 @@ import CallToActionLink from '.';
 const Component = ({
   href,
   children,
+  linkText,
+  borderStyleOverride,
 }: PropsWithChildren<CallToActionLinkProps>) => (
-  <CallToActionLink href={href}>{children}</CallToActionLink>
+  <CallToActionLink
+    linkText={linkText}
+    href={href}
+    borderStyleOverride={borderStyleOverride}
+  >
+    {children}
+  </CallToActionLink>
 );
 
 export default {
   title: 'Components/Call To Action Link',
   Component,
+  parameters: {
+    docs: { readme },
+  },
 };
 
-export const Example = () => {
+export const DefaultStyles = () => {
   return <Component href="www.bbc.com/afrique">Call To Action</Component>;
+};
+
+export const BottomBorderStyles = () => {
+  return (
+    <Component
+      href="www.bbc.com/afrique"
+      borderStyleOverride
+      linkText="My Link Text"
+    />
+  );
 };

--- a/src/app/components/CallToActionLink/index.stories.tsx
+++ b/src/app/components/CallToActionLink/index.stories.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from 'react';
-
+import readme from './README.md';
 import { CallToActionLinkProps } from './types';
 import CallToActionLink from '.';
 import Text from '../Text';
@@ -14,6 +14,9 @@ const Component = ({
 export default {
   title: 'Components/Call To Action Link',
   Component,
+  parameters: {
+    docs: { readme },
+  },
   args: {
     fontVariant: 'sansBold',
   },

--- a/src/app/components/CallToActionLink/index.tsx
+++ b/src/app/components/CallToActionLink/index.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
-import { PropsWithChildren } from 'react';
+/* @jsxFrag React.Fragment */
+import React, { PropsWithChildren } from 'react';
 import { jsx } from '@emotion/react';
 import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import Text from '../Text';
@@ -12,6 +13,11 @@ const CallToActionLink = ({
   children,
   eventTrackingData,
   download = false,
+  ignoreLiteExtension = false,
+  text = '',
+  size = 'pica',
+  fontVariant = 'sansBold',
+  centerAlign = true,
 }: PropsWithChildren<CallToActionLinkProps>) => {
   const clickTrackerHandler = useClickTrackerHandler(eventTrackingData);
 
@@ -22,12 +28,22 @@ const CallToActionLink = ({
       css={styles.linkBackground}
       onClick={clickTrackerHandler}
       download={download}
+      {...(ignoreLiteExtension && { 'data-ignore-lite': true })}
     >
-      <div css={styles.linkTextWrapper}>
-        <Text size="pica" fontVariant="sansBold" css={styles.linkText}>
+      {centerAlign ? (
+        <div css={styles.linkTextWrapper}>
+          <Text size={size} fontVariant={fontVariant} css={styles.linkText}>
+            {children}
+          </Text>
+        </div>
+      ) : (
+        <>
+          <Text size={size} fontVariant={fontVariant}>
+            {text}
+          </Text>
           {children}
-        </Text>
-      </div>
+        </>
+      )}
     </a>
   );
 };

--- a/src/app/components/CallToActionLink/index.tsx
+++ b/src/app/components/CallToActionLink/index.tsx
@@ -1,6 +1,5 @@
 /** @jsx jsx */
-/* @jsxFrag React.Fragment */
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 import { jsx } from '@emotion/react';
 import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import Text from '../Text';
@@ -12,14 +11,19 @@ const CallToActionLink = ({
   className,
   children,
   eventTrackingData,
-  size = 'pica',
-  fontVariant = 'sansBold',
   download = false,
+  ignoreStyling = false,
   ignoreLiteExtension = false,
-  linkText = '',
-  borderStyleOverride = false,
 }: PropsWithChildren<CallToActionLinkProps>) => {
   const clickTrackerHandler = useClickTrackerHandler(eventTrackingData);
+
+  const styledContent = (
+    <div css={styles.linkTextWrapper}>
+      <Text size="pica" fontVariant="sansBold" css={styles.linkText}>
+        {children}
+      </Text>
+    </div>
+  );
 
   return (
     <a
@@ -30,20 +34,7 @@ const CallToActionLink = ({
       download={download}
       {...(ignoreLiteExtension && { 'data-ignore-lite': true })}
     >
-      {borderStyleOverride ? (
-        <>
-          <Text size={size} fontVariant={fontVariant}>
-            {linkText}
-          </Text>
-          {children}
-        </>
-      ) : (
-        <div css={styles.linkTextWrapper}>
-          <Text size={size} fontVariant={fontVariant} css={styles.linkText}>
-            {children}
-          </Text>
-        </div>
-      )}
+      {ignoreStyling ? children : styledContent}
     </a>
   );
 };

--- a/src/app/components/CallToActionLink/index.tsx
+++ b/src/app/components/CallToActionLink/index.tsx
@@ -12,12 +12,12 @@ const CallToActionLink = ({
   className,
   children,
   eventTrackingData,
-  download = false,
-  ignoreLiteExtension = false,
-  text = '',
   size = 'pica',
   fontVariant = 'sansBold',
-  centerAlign = true,
+  download = false,
+  ignoreLiteExtension = false,
+  linkText = '',
+  borderStyleOverride = false,
 }: PropsWithChildren<CallToActionLinkProps>) => {
   const clickTrackerHandler = useClickTrackerHandler(eventTrackingData);
 
@@ -30,19 +30,19 @@ const CallToActionLink = ({
       download={download}
       {...(ignoreLiteExtension && { 'data-ignore-lite': true })}
     >
-      {centerAlign ? (
+      {borderStyleOverride ? (
+        <>
+          <Text size={size} fontVariant={fontVariant}>
+            {linkText}
+          </Text>
+          {children}
+        </>
+      ) : (
         <div css={styles.linkTextWrapper}>
           <Text size={size} fontVariant={fontVariant} css={styles.linkText}>
             {children}
           </Text>
         </div>
-      ) : (
-        <>
-          <Text size={size} fontVariant={fontVariant}>
-            {text}
-          </Text>
-          {children}
-        </>
       )}
     </a>
   );

--- a/src/app/components/CallToActionLink/types.ts
+++ b/src/app/components/CallToActionLink/types.ts
@@ -5,10 +5,10 @@ export type CallToActionLinkProps = {
   href?: string;
   className?: string;
   eventTrackingData?: EventTrackingMetadata;
-  download?: boolean;
   size?: GelFontSize;
   fontVariant?: FontVariant;
+  download?: boolean;
   ignoreLiteExtension?: boolean;
-  centerAlign?: boolean;
-  text?: string;
+  borderStyleOverride?: boolean;
+  linkText?: string;
 };

--- a/src/app/components/CallToActionLink/types.ts
+++ b/src/app/components/CallToActionLink/types.ts
@@ -11,4 +11,5 @@ export type CallToActionLinkProps = {
   ignoreLiteExtension?: boolean;
   borderStyleOverride?: boolean;
   linkText?: string;
+  ignoreStyling?: boolean;
 };

--- a/src/app/components/CallToActionLink/types.ts
+++ b/src/app/components/CallToActionLink/types.ts
@@ -1,8 +1,14 @@
 import { EventTrackingMetadata } from '#app/models/types/eventTracking';
+import { GelFontSize, FontVariant } from '../../models/types/theming';
 
 export type CallToActionLinkProps = {
   href?: string;
   className?: string;
   eventTrackingData?: EventTrackingMetadata;
   download?: boolean;
+  size?: GelFontSize;
+  fontVariant?: FontVariant;
+  ignoreLiteExtension?: boolean;
+  centerAlign?: boolean;
+  text?: string;
 };

--- a/src/app/components/LiteSiteCta/index.styles.tsx
+++ b/src/app/components/LiteSiteCta/index.styles.tsx
@@ -61,6 +61,19 @@ export default {
         },
       },
     }),
+  linkText: ({ palette }: Theme) =>
+    css({
+      borderBottom: `${pixelsToRem(1)}rem solid ${palette.GREY_10}`,
+      textDecoration: 'none',
+      'a:visited &': {
+        color: palette.METAL,
+        borderBottom: `${pixelsToRem(1)}rem solid ${palette.METAL}`,
+      },
+      'a:focus &, a:hover &': {
+        borderBottom: `${pixelsToRem(2)}rem solid ${palette.POSTBOX}`,
+        color: palette.POSTBOX,
+      },
+    }),
   bottomLinkSpacing: ({ spacings }: Theme) =>
     css({
       padding: `${spacings.FULL}rem 0 ${spacings.DOUBLE}rem`,

--- a/src/app/components/LiteSiteCta/index.styles.tsx
+++ b/src/app/components/LiteSiteCta/index.styles.tsx
@@ -39,10 +39,27 @@ export default {
         color: palette.POSTBOX,
       },
     }),
-  link: () =>
+  link: ({ palette }: Theme) =>
     css({
       display: 'inline-block',
       textDecoration: 'none',
+      span: {
+        borderBottom: `${pixelsToRem(1)}rem solid ${palette.GREY_10}`,
+        textDecoration: 'none',
+      },
+      '&:visited': {
+        span: {
+          color: palette.METAL,
+          borderBottom: `${pixelsToRem(1)}rem solid ${palette.METAL}`,
+        },
+      },
+      '&:hover, &:focus': {
+        textDecoration: 'none',
+        span: {
+          color: palette.POSTBOX,
+          borderBottom: `${pixelsToRem(2)}rem solid ${palette.POSTBOX}`,
+        },
+      },
     }),
   bottomLinkSpacing: ({ spacings }: Theme) =>
     css({
@@ -51,18 +68,5 @@ export default {
   topLinkSpacing: ({ spacings }: Theme) =>
     css({
       padding: `${spacings.DOUBLE}rem 0 ${spacings.FULL}rem`,
-    }),
-  linkText: ({ palette }: Theme) =>
-    css({
-      borderBottom: `${pixelsToRem(1)}rem solid ${palette.GREY_10}`,
-      textDecoration: 'none',
-      'a:visited &': {
-        color: palette.METAL,
-        borderBottom: `${pixelsToRem(1)}rem solid ${palette.METAL}`,
-      },
-      'a:focus &, a:hover &': {
-        borderBottom: `${pixelsToRem(2)}rem solid ${palette.POSTBOX}`,
-        color: palette.POSTBOX,
-      },
     }),
 };

--- a/src/app/components/LiteSiteCta/index.tsx
+++ b/src/app/components/LiteSiteCta/index.tsx
@@ -41,14 +41,13 @@ const LiteSiteCta = () => {
         <Paragraph data-e2e="to-main-site">
           <CallToActionLink
             href={canonicalLink}
-            linkText={toMainSite}
-            ignoreLiteExtension
-            size="brevier"
-            fontVariant="sansBold"
-            className="touchTarget"
-            borderStyleOverride
             css={[styles.topLinkSpacing, styles.link]}
+            ignoreStyling
+            ignoreLiteExtension
           >
+            <Text size="brevier" fontVariant="sansBold" css={styles.linkText}>
+              {toMainSite}
+            </Text>
             {isRtl ? (
               <LeftChevron css={styles.chevron} />
             ) : (
@@ -59,13 +58,18 @@ const LiteSiteCta = () => {
         <Paragraph data-e2e="information-page">
           <CallToActionLink
             href={informationPageLink}
-            linkText={informationPage}
-            size="brevier"
-            fontVariant="sansRegular"
-            className="touchTarget"
-            borderStyleOverride
             css={[styles.bottomLinkSpacing, styles.link]}
-          />
+            ignoreStyling
+            ignoreLiteExtension
+          >
+            <Text
+              size="brevier"
+              fontVariant="sansRegular"
+              css={styles.linkText}
+            >
+              {informationPage}
+            </Text>
+          </CallToActionLink>
         </Paragraph>
       </div>
     </section>

--- a/src/app/components/LiteSiteCta/index.tsx
+++ b/src/app/components/LiteSiteCta/index.tsx
@@ -41,12 +41,12 @@ const LiteSiteCta = () => {
         <Paragraph data-e2e="to-main-site">
           <CallToActionLink
             href={canonicalLink}
-            text={toMainSite}
+            linkText={toMainSite}
             ignoreLiteExtension
             size="brevier"
             fontVariant="sansBold"
             className="touchTarget"
-            centerAlign={false}
+            borderStyleOverride
             css={[styles.topLinkSpacing, styles.link]}
           >
             {isRtl ? (
@@ -59,11 +59,11 @@ const LiteSiteCta = () => {
         <Paragraph data-e2e="information-page">
           <CallToActionLink
             href={informationPageLink}
-            text={informationPage}
+            linkText={informationPage}
             size="brevier"
             fontVariant="sansRegular"
             className="touchTarget"
-            centerAlign={false}
+            borderStyleOverride
             css={[styles.bottomLinkSpacing, styles.link]}
           />
         </Paragraph>

--- a/src/app/components/LiteSiteCta/index.tsx
+++ b/src/app/components/LiteSiteCta/index.tsx
@@ -8,46 +8,7 @@ import { ServiceContext } from '../../contexts/ServiceContext';
 import { RequestContext } from '../../contexts/RequestContext';
 import styles from './index.styles';
 import { defaultTranslations } from './liteSiteConfig';
-
-type CtaLinkProps = {
-  isRtl: boolean;
-  href: string;
-  text: string;
-  fontVariant?: string;
-  showChevron?: boolean;
-  ignoreLiteExtension?: boolean;
-  className?: string;
-};
-
-const CtaLink = ({
-  isRtl,
-  href,
-  text,
-  fontVariant = 'sansRegular',
-  showChevron = false,
-  ignoreLiteExtension = false,
-  className,
-}: CtaLinkProps) => {
-  const chevron = isRtl ? (
-    <LeftChevron css={styles.chevron} />
-  ) : (
-    <RightChevron css={styles.chevron} />
-  );
-
-  return (
-    <a
-      href={href}
-      className={className}
-      css={styles.link}
-      {...(ignoreLiteExtension && { 'data-ignore-lite': true })}
-    >
-      <Text size="brevier" fontVariant={fontVariant} css={styles.linkText}>
-        {text}
-      </Text>
-      {showChevron && chevron}
-    </a>
-  );
-};
+import CallToActionLink from '../CallToActionLink';
 
 const LiteSiteCta = () => {
   const { dir, translations } = useContext(ServiceContext);
@@ -78,22 +39,32 @@ const LiteSiteCta = () => {
           {onboardingMessage}
         </Paragraph>
         <Paragraph data-e2e="to-main-site">
-          <CtaLink
-            fontVariant="sansBold"
-            isRtl={isRtl}
+          <CallToActionLink
             href={canonicalLink}
             text={toMainSite}
-            css={styles.topLinkSpacing}
             ignoreLiteExtension
-            showChevron
-          />
+            size="brevier"
+            fontVariant="sansBold"
+            className="touchTarget"
+            centerAlign={false}
+            css={[styles.topLinkSpacing, styles.link]}
+          >
+            {isRtl ? (
+              <LeftChevron css={styles.chevron} />
+            ) : (
+              <RightChevron css={styles.chevron} />
+            )}
+          </CallToActionLink>
         </Paragraph>
         <Paragraph data-e2e="information-page">
-          <CtaLink
-            isRtl={isRtl}
+          <CallToActionLink
             href={informationPageLink}
             text={informationPage}
-            css={styles.bottomLinkSpacing}
+            size="brevier"
+            fontVariant="sansRegular"
+            className="touchTarget"
+            centerAlign={false}
+            css={[styles.bottomLinkSpacing, styles.link]}
           />
         </Paragraph>
       </div>

--- a/src/app/components/LiteSiteCta/index.tsx
+++ b/src/app/components/LiteSiteCta/index.tsx
@@ -60,7 +60,6 @@ const LiteSiteCta = () => {
             href={informationPageLink}
             css={[styles.bottomLinkSpacing, styles.link]}
             ignoreStyling
-            ignoreLiteExtension
           >
             <Text
               size="brevier"

--- a/src/integration/pages/articles/gahuzaLiteSite/__snapshots__/lite.test.js.snap
+++ b/src/integration/pages/articles/gahuzaLiteSite/__snapshots__/lite.test.js.snap
@@ -27,12 +27,12 @@ exports[`Lite Site Articles Lite Site Cta should match snapshot 1`] = `
       data-e2e="to-main-site"
     >
       <a
-        class="bbc-12216v1"
+        class="touchTarget bbc-2ezaih"
         data-ignore-lite="true"
         href="http://localhost:7080/gahuza/articles/cey23zx8wx8o"
       >
         <span
-          class="bbc-x7bqmd"
+          class="bbc-sokel8"
         >
           Njana ku rubuga nyamukuru canke aho gusoma gusa
         </span>
@@ -55,11 +55,11 @@ exports[`Lite Site Articles Lite Site Cta should match snapshot 1`] = `
       data-e2e="information-page"
     >
       <a
-        class="bbc-1hvke8g"
+        class="touchTarget bbc-1c7rt7i"
         href="https://www.bbc.com/gahuza/articles/cn7y7pvem0vo.lite"
       >
         <span
-          class="bbc-1qfjcgd"
+          class="bbc-inosqz"
         >
           Ibindi vyerekeye ingene urwo rubuga rugutwara uburyo (ama mega) buke
         </span>

--- a/src/integration/pages/articles/gahuzaLiteSite/__snapshots__/lite.test.js.snap
+++ b/src/integration/pages/articles/gahuzaLiteSite/__snapshots__/lite.test.js.snap
@@ -56,8 +56,7 @@ exports[`Lite Site Articles Lite Site Cta should match snapshot 1`] = `
     >
       <a
         class="bbc-1c7rt7i"
-        data-ignore-lite="true"
-        href="https://www.bbc.com/gahuza/articles/cn7y7pvem0vo"
+        href="https://www.bbc.com/gahuza/articles/cn7y7pvem0vo.lite"
       >
         <span
           class="bbc-1qfjcgd"

--- a/src/integration/pages/articles/gahuzaLiteSite/__snapshots__/lite.test.js.snap
+++ b/src/integration/pages/articles/gahuzaLiteSite/__snapshots__/lite.test.js.snap
@@ -27,12 +27,12 @@ exports[`Lite Site Articles Lite Site Cta should match snapshot 1`] = `
       data-e2e="to-main-site"
     >
       <a
-        class="touchTarget bbc-2ezaih"
+        class="bbc-2ezaih"
         data-ignore-lite="true"
         href="http://localhost:7080/gahuza/articles/cey23zx8wx8o"
       >
         <span
-          class="bbc-sokel8"
+          class="bbc-x7bqmd"
         >
           Njana ku rubuga nyamukuru canke aho gusoma gusa
         </span>
@@ -55,11 +55,12 @@ exports[`Lite Site Articles Lite Site Cta should match snapshot 1`] = `
       data-e2e="information-page"
     >
       <a
-        class="touchTarget bbc-1c7rt7i"
-        href="https://www.bbc.com/gahuza/articles/cn7y7pvem0vo.lite"
+        class="bbc-1c7rt7i"
+        data-ignore-lite="true"
+        href="https://www.bbc.com/gahuza/articles/cn7y7pvem0vo"
       >
         <span
-          class="bbc-inosqz"
+          class="bbc-1qfjcgd"
         >
           Ibindi vyerekeye ingene urwo rubuga rugutwara uburyo (ama mega) buke
         </span>


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Possible refactor for https://github.com/bbc/simorgh/pull/12097

We didn't initially go for this because the styling is fairly different. The existing CTA component uses text-decoration:underline whereas this component uses bottom border.

This is significant because text-decoration:underline ignores SVGs by default but bottom border doesn't. So we have to change the HTML structure so that the SVG doesn't get wrapped in the text element.

There is room for improvement - e.g. if we moved the flex/ centre align styles out of this component and applied these via a className override. And maybe including the chevron here.

Or we could review with UX and see if we can align the A11y behaviours/ styling across the site.

Code changes
======

- _A bullet point list of key code changes that have been made._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
