### PR TITLE
Temp: Hide MostRead on transliterated articles

### DIFF
--- a/cypress/e2e/pages/articles/helpers.js
+++ b/cypress/e2e/pages/articles/helpers.js
@@ -50,3 +50,16 @@ export const getVideoEmbedUrl = (body, language, isAmp = false) => {
 
   return isAmp ? `${embedUrl}/amp` : embedUrl;
 };
+
+export const isTransliteratedService = service => {
+  const transliteratedServices = [
+    'serbianCyr',
+    'serbianLat',
+    'zhongwenSimp',
+    'zhongwenTrad',
+    'uzbekCyr',
+    'uzbekLat',
+  ];
+
+  return transliteratedServices.includes(service);
+};

--- a/cypress/e2e/pages/articles/tests.js
+++ b/cypress/e2e/pages/articles/tests.js
@@ -113,9 +113,22 @@ export const testsThatFollowSmokeTestConfig = ({
       });
     });
 
+    // TODO: Remove once transliterated services support MostRead component
+    const transliteratedServices = [
+      'serbianCyr',
+      'serbianLat',
+      'zhongwenSimp',
+      'zhongwenTrad',
+      'uzbekCyr',
+      'uzbekLat',
+    ];
+
     /**
      * Most Read Component
      */
-    mostReadAssertions({ service, variant });
+
+    if (!transliteratedServices.includes(service) && pageType !== 'articles') {
+      mostReadAssertions({ service, variant });
+    }
   });
 };

--- a/cypress/e2e/pages/articles/tests.js
+++ b/cypress/e2e/pages/articles/tests.js
@@ -1,6 +1,7 @@
 import config from '../../../support/config/services';
 import appConfig from '../../../../src/server/utilities/serviceConfigs';
 import { crossPlatform as mostReadAssertions } from '../mostReadPage/mostReadAssertions';
+import { isTransliteratedService } from './helpers';
 
 // TODO: Remove after https://github.com/bbc/simorgh/issues/2959
 const serviceHasFigure = service =>
@@ -113,21 +114,12 @@ export const testsThatFollowSmokeTestConfig = ({
       });
     });
 
-    // TODO: Remove once transliterated services support MostRead component
-    const transliteratedServices = [
-      'serbianCyr',
-      'serbianLat',
-      'zhongwenSimp',
-      'zhongwenTrad',
-      'uzbekCyr',
-      'uzbekLat',
-    ];
-
     /**
      * Most Read Component
      */
 
-    if (!transliteratedServices.includes(service) && pageType !== 'articles') {
+    // TODO: Remove once transliterated services support MostRead component
+    if (!isTransliteratedService(service) && pageType !== 'articles') {
       mostReadAssertions({ service, variant });
     }
   });

--- a/cypress/e2e/pages/articles/testsForAMPOnly.js
+++ b/cypress/e2e/pages/articles/testsForAMPOnly.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import { ampOnly as mostReadAssertions } from '../mostReadPage/mostReadAssertions';
+import { isTransliteratedService } from './helpers';
 
 // TODO: Remove after https://github.com/bbc/simorgh/issues/2959
 const serviceHasFigure = service =>
@@ -58,21 +59,13 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
       });
     });
 
-    // TODO: Remove once transliterated services support MostRead component
-    const transliteratedServices = [
-      'serbianCyr',
-      'serbianLat',
-      'zhongwenSimp',
-      'zhongwenTrad',
-      'uzbekCyr',
-      'uzbekLat',
-    ];
-
     /* Most Read Component
      * These cypress tests are needed as unit tests cannot be run on the jsdom.
      * web workers (which run on amp pages) do not run on the virtual dom.
      */
-    if (!transliteratedServices.includes(service) && pageType !== 'articles') {
+
+    // TODO: Remove once transliterated services support MostRead component
+    if (!isTransliteratedService(service) && pageType !== 'articles') {
       mostReadAssertions({ service, variant });
     }
   });

--- a/cypress/e2e/pages/articles/testsForAMPOnly.js
+++ b/cypress/e2e/pages/articles/testsForAMPOnly.js
@@ -58,10 +58,22 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
       });
     });
 
+    // TODO: Remove once transliterated services support MostRead component
+    const transliteratedServices = [
+      'serbianCyr',
+      'serbianLat',
+      'zhongwenSimp',
+      'zhongwenTrad',
+      'uzbekCyr',
+      'uzbekLat',
+    ];
+
     /* Most Read Component
      * These cypress tests are needed as unit tests cannot be run on the jsdom.
      * web workers (which run on amp pages) do not run on the virtual dom.
      */
-    mostReadAssertions({ service, variant });
+    if (!transliteratedServices.includes(service) && pageType !== 'articles') {
+      mostReadAssertions({ service, variant });
+    }
   });
 };

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -226,6 +226,8 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
     showRelatedTopics && topics.length > 0 && !isTransliterated,
   );
 
+  const showMostRead = Boolean(!isApp && !isPGL && !isTransliterated);
+
   return (
     <div css={styles.pageWrapper}>
       {shouldEnableExperimentTopStories && (
@@ -295,7 +297,7 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
         </div>
         {!isApp && !isPGL && <SecondaryColumn pageData={pageData} />}
       </div>
-      {!isApp && !isPGL && (
+      {showMostRead && (
         <MostRead
           css={styles.mostReadSection}
           data={mostReadInitialData}

--- a/src/app/pages/ArticlePage/index.test.tsx
+++ b/src/app/pages/ArticlePage/index.test.tsx
@@ -756,19 +756,37 @@ describe('Article Page', () => {
     expect(ampHtmlLink).toBeUndefined();
   });
 
-  const services = ['serbian', 'uzbek', 'zhongwen'] satisfies Services[];
+  const transliteratedServices = [
+    'serbian',
+    'uzbek',
+    'zhongwen',
+  ] satisfies Services[];
 
-  services.forEach(service => {
-    it(`should not render a relatedTopics onward journey for a ${service} optimo article`, async () => {
-      const { queryByTestId } = render(
-        <Context service={service}>
-          <ArticlePage pageData={articleDataNews} />
-        </Context>,
-      );
-      const relatedTopics = queryByTestId('related-topics');
-      expect(relatedTopics).toBeNull();
-    });
-  });
+  describe.each(transliteratedServices)(
+    'when rendering a %s article',
+    service => {
+      it('should not render a relatedTopics onward journey', async () => {
+        const { queryByTestId } = render(
+          <Context service={service}>
+            <ArticlePage pageData={articleDataNews} />
+          </Context>,
+        );
+        const relatedTopics = queryByTestId('related-topics');
+        expect(relatedTopics).toBeNull();
+      });
+
+      it('should not render a MostRead onward journey', async () => {
+        const { queryByTestId } = render(
+          <Context service={service}>
+            <ArticlePage pageData={articleDataNews} />
+          </Context>,
+        );
+        const mostRead = queryByTestId('most-read');
+        expect(mostRead).toBeNull();
+      });
+    },
+  );
+
   describe('when rendering a PGL page', () => {
     it('should not render secondary column', async () => {
       const pageDataWithSecondaryColumn = {


### PR DESCRIPTION
Overall changes
======
- Hides MostRead component on transliterated articles (Zhongwen, Serbian and Uzbek) as this component does not fully work with Optimo transliterated content yet

Testing
======
1. Visit http://localhost:7080/serbian/articles/cy9j40v4n75o/lat?renderer_env=live
2. Scroll to the very bottom of the page and confirm that the Most Read component is removed
3. Visit http://localhost:7080/serbian/cyr/srbija-68707945?renderer_env=live
4. Scroll to the very bottom of the page and confirm that the Most Read component is visible

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
