### PR TITLE
Hide embeds on Lite

### DIFF
--- a/src/app/components/Embeds/OEmbed/index.test.tsx
+++ b/src/app/components/Embeds/OEmbed/index.test.tsx
@@ -22,10 +22,12 @@ import OEmbedLoader from '.';
 const Component = ({
   props,
   isAmp,
+  isLite,
   service = 'pidgin',
 }: {
   props: OEmbedProps;
   isAmp: boolean;
+  isLite?: boolean;
   service?: Services;
 }) => {
   const OEmbedValue = useMemo(
@@ -33,6 +35,7 @@ const Component = ({
       ({
         id: 'c0000000000o',
         isAmp,
+        isLite,
         isApp: false,
         pageType: ARTICLE_PAGE,
         pathname: '/pathname',
@@ -40,7 +43,7 @@ const Component = ({
         statusCode: 200,
         canonicalLink: 'canonical_link',
       }) as unknown as RequestContextProps,
-    [isAmp, service],
+    [isAmp, isLite, service],
   );
   return (
     <RequestContext.Provider value={OEmbedValue}>
@@ -185,6 +188,15 @@ describe('OEmbed', () => {
 
       expect(iFrameElement).toBe(null);
       expect(errorMessage).toBeInTheDocument();
+    });
+  });
+
+  describe('Lite', () => {
+    it('Should return null if isLite is true', () => {
+      const { container } = render(
+        <Component props={sampleRiddleProps} isAmp={false} isLite />,
+      );
+      expect(container).toBeEmptyDOMElement();
     });
   });
 });

--- a/src/app/components/Embeds/OEmbed/index.tsx
+++ b/src/app/components/Embeds/OEmbed/index.tsx
@@ -12,8 +12,11 @@ import AmpIframeEmbed from '../AmpIframeEmbed';
 import { OEmbedProps } from '../types';
 
 const OEmbedLoader = ({ oembed }: OEmbedProps) => {
-  const { isAmp, canonicalLink } = useContext(RequestContext);
+  const { isAmp, isLite, canonicalLink } = useContext(RequestContext);
   const { translations } = useContext(ServiceContext);
+
+  if (isLite) return null;
+
   const { html, provider_name, oEmbedType, parameters, url } = oembed;
   const isVDJEmbed = oEmbedType === 'vdj-embed';
 


### PR DESCRIPTION
Overall changes
======
- Hides embed components when on Lite as these were missed in the initial implementation
- Adds test fixture to ensure they don't render when `isLite` is `true`

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
