### PR TITLE
Hide election banner 320 or lower

### DIFF
--- a/src/app/components/Embeds/EmbedHtml/index.styles.tsx
+++ b/src/app/components/Embeds/EmbedHtml/index.styles.tsx
@@ -1,3 +1,4 @@
+import pixelsToRem from '#app/utilities/pixelsToRem';
 import { css, Theme } from '@emotion/react';
 
 const styles = {
@@ -15,6 +16,18 @@ const styles = {
       [mq.GROUP_4_MIN_WIDTH]: {
         paddingLeft: '0',
         paddingRight: '0',
+      },
+    }),
+  // TODO: Remove this styling after the US Elections
+  electionBannerOverrides: ({ mq }: Theme) =>
+    css({
+      [`@media (max-width:${pixelsToRem(320)}rem)`]: {
+        display: 'none',
+      },
+
+      [mq.GROUP_2_MIN_WIDTH]: {
+        paddingLeft: 0,
+        paddingRight: 0,
       },
     }),
 };

--- a/src/app/components/Embeds/EmbedHtml/index.tsx
+++ b/src/app/components/Embeds/EmbedHtml/index.tsx
@@ -10,9 +10,17 @@ type Props = {
 const EmbedHtml = ({ embeddableContent }: PropsWithChildren<Props>) => {
   if (!embeddableContent) return null;
 
+  // TODO: Remove this logic after the US Elections
+  const isUSElectionBanner = embeddableContent.includes(
+    '2024-us-presidential-election-banner',
+  );
+
   return (
     <div
-      css={styles.embedDiv}
+      css={[
+        styles.embedDiv,
+        isUSElectionBanner && styles.electionBannerOverrides,
+      ]}
       suppressHydrationWarning
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: embeddableContent }}

--- a/src/app/pages/ArticlePage/ElectionBanner/index.styles.ts
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.styles.ts
@@ -6,6 +6,10 @@ export default {
   electionBannerWrapper: ({ spacings }: Theme) =>
     css({
       marginBottom: `${spacings.FULL}rem`,
+
+      [`@media (max-width:${pixelsToRem(320)}rem)`]: {
+        display: 'none',
+      },
     }),
 
   electionBannerIframe: ({ mq }: Theme) =>
@@ -26,6 +30,10 @@ export default {
     css({
       overflow: 'hidden',
       marginBottom: `${spacings.FULL}rem`,
+
+      [`@media (max-width:${pixelsToRem(320)}rem)`]: {
+        display: 'none',
+      },
 
       '> div': { padding: '0' },
       '& amp-img': {


### PR DESCRIPTION
Overall changes
======
- Hides the election banner on article, home and topic pages when the device width is `<=320px`

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
