### PR TITLE
Add election banner production path

### DIFF
--- a/src/app/pages/ArticlePage/ElectionBanner/config.ts
+++ b/src/app/pages/ArticlePage/ElectionBanner/config.ts
@@ -1,8 +1,6 @@
 import { getEnvConfig } from '#app/lib/utilities/getEnvConfig';
 
-const { SIMORGH_INCLUDES_BASE_URL, SIMORGH_APP_ENV } = getEnvConfig();
-
-const isDevelopmentPath = ['local', 'test'].includes(SIMORGH_APP_ENV);
+const { SIMORGH_INCLUDES_BASE_URL } = getEnvConfig();
 
 export default {
   heights: {
@@ -10,7 +8,8 @@ export default {
     tablet: 480,
     mobile: 540,
   },
-  iframeSrc: `${SIMORGH_INCLUDES_BASE_URL}/include/vjafwest/1365-2024-us-presidential-election-banner${isDevelopmentPath ? '/develop' : ''}/{service}/app`,
+  iframeSrc: `${SIMORGH_INCLUDES_BASE_URL}/include/vjafwest/1365-2024-us-presidential-election-banner/{service}/app`,
+  iframeDevSrc: `${SIMORGH_INCLUDES_BASE_URL}/include/vjafwest/1365-2024-us-presidential-election-banner/develop/{service}/app`,
   thingIds: [
     '647d5613-e0e2-4ef5-b0ce-b491de38bdbd', // https://www.bbc.co.uk/things/647d5613-e0e2-4ef5-b0ce-b491de38bdbd
   ],

--- a/src/app/pages/ArticlePage/ElectionBanner/config.ts
+++ b/src/app/pages/ArticlePage/ElectionBanner/config.ts
@@ -1,7 +1,12 @@
 import { getEnvConfig } from '#app/lib/utilities/getEnvConfig';
 
-const { SIMORGH_INCLUDES_BASE_URL, SIMORGH_INCLUDES_BASE_AMP_URL } =
-  getEnvConfig();
+const {
+  SIMORGH_INCLUDES_BASE_URL,
+  SIMORGH_INCLUDES_BASE_AMP_URL,
+  SIMORGH_APP_ENV,
+} = getEnvConfig();
+
+const isDevelopmentPath = ['local', 'test'].includes(SIMORGH_APP_ENV);
 
 export default {
   heights: {
@@ -9,8 +14,8 @@ export default {
     tablet: 480,
     mobile: 540,
   },
-  iframeSrc: `${SIMORGH_INCLUDES_BASE_URL}/include/vjafwest/1365-2024-us-presidential-election-banner/develop/{service}/app`,
-  iframeSrcAmp: `${SIMORGH_INCLUDES_BASE_AMP_URL}/include/vjafwest/1365-2024-us-presidential-election-banner/develop/{service}/app/amp`,
+  iframeSrc: `${SIMORGH_INCLUDES_BASE_URL}/include/vjafwest/1365-2024-us-presidential-election-banner${isDevelopmentPath ? '/develop' : ''}/{service}/app`,
+  iframeSrcAmp: `${SIMORGH_INCLUDES_BASE_AMP_URL}/include/vjafwest/1365-2024-us-presidential-election-banner${isDevelopmentPath ? '/develop' : ''}/{service}/app/amp`,
   thingIds: [
     '647d5613-e0e2-4ef5-b0ce-b491de38bdbd', // https://www.bbc.co.uk/things/647d5613-e0e2-4ef5-b0ce-b491de38bdbd
   ],

--- a/src/app/pages/ArticlePage/ElectionBanner/config.ts
+++ b/src/app/pages/ArticlePage/ElectionBanner/config.ts
@@ -1,10 +1,6 @@
 import { getEnvConfig } from '#app/lib/utilities/getEnvConfig';
 
-const {
-  SIMORGH_INCLUDES_BASE_URL,
-  SIMORGH_INCLUDES_BASE_AMP_URL,
-  SIMORGH_APP_ENV,
-} = getEnvConfig();
+const { SIMORGH_INCLUDES_BASE_URL, SIMORGH_APP_ENV } = getEnvConfig();
 
 const isDevelopmentPath = ['local', 'test'].includes(SIMORGH_APP_ENV);
 
@@ -15,7 +11,6 @@ export default {
     mobile: 540,
   },
   iframeSrc: `${SIMORGH_INCLUDES_BASE_URL}/include/vjafwest/1365-2024-us-presidential-election-banner${isDevelopmentPath ? '/develop' : ''}/{service}/app`,
-  iframeSrcAmp: `${SIMORGH_INCLUDES_BASE_AMP_URL}/include/vjafwest/1365-2024-us-presidential-election-banner${isDevelopmentPath ? '/develop' : ''}/{service}/app/amp`,
   thingIds: [
     '647d5613-e0e2-4ef5-b0ce-b491de38bdbd', // https://www.bbc.co.uk/things/647d5613-e0e2-4ef5-b0ce-b491de38bdbd
   ],

--- a/src/app/pages/ArticlePage/ElectionBanner/config.ts
+++ b/src/app/pages/ArticlePage/ElectionBanner/config.ts
@@ -1,15 +1,13 @@
-import { getEnvConfig } from '#app/lib/utilities/getEnvConfig';
-
-const { SIMORGH_INCLUDES_BASE_URL } = getEnvConfig();
-
 export default {
   heights: {
     desktop: 465,
     tablet: 480,
     mobile: 540,
   },
-  iframeSrc: `${SIMORGH_INCLUDES_BASE_URL}/include/vjafwest/1365-2024-us-presidential-election-banner/{service}/app`,
-  iframeDevSrc: `${SIMORGH_INCLUDES_BASE_URL}/include/vjafwest/1365-2024-us-presidential-election-banner/develop/{service}/app`,
+  iframeSrc:
+    'include/vjafwest/1365-2024-us-presidential-election-banner/{service}/app',
+  iframeDevSrc:
+    'include/vjafwest/1365-2024-us-presidential-election-banner/develop/{service}/app',
   thingIds: [
     '647d5613-e0e2-4ef5-b0ce-b491de38bdbd', // https://www.bbc.co.uk/things/647d5613-e0e2-4ef5-b0ce-b491de38bdbd
   ],

--- a/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
@@ -22,7 +22,9 @@ describe('ElectionBanner', () => {
     expect(queryByTestId(ELEMENT_ID)).not.toBeInTheDocument();
   });
 
-  it('should user the production URL for the iframe when SIMORGH_APP_ENV is "live"', () => {
+  it('should use the production URL for the iframe when SIMORGH_APP_ENV is "live"', () => {
+    process.env.SIMORGH_APP_ENV = 'live';
+
     const { getByTestId } = render(
       <ElectionBanner aboutTags={mockAboutTags} />,
       {
@@ -37,7 +39,9 @@ describe('ElectionBanner', () => {
     expect(iframeSrc).not.toContain('/develop/');
   });
 
-  it('should user the test URL for the iframe when SIMORGH_APP_ENV is "test"', () => {
+  it('should use the test URL for the iframe when SIMORGH_APP_ENV is "test"', () => {
+    process.env.SIMORGH_APP_ENV = 'test';
+
     const { getByTestId } = render(
       <ElectionBanner aboutTags={mockAboutTags} />,
       {
@@ -65,15 +69,6 @@ describe('ElectionBanner', () => {
       );
 
       expect(getByTestId(ELEMENT_ID)).toBeInTheDocument();
-
-      const iframe = getByTestId(ELEMENT_ID).querySelector(
-        isAmp ? 'amp-iframe' : 'iframe',
-      );
-
-      expect(iframe).toHaveAttribute(
-        'src',
-        `${BANNER_CONFIG.iframeSrc.replace('{service}', 'news')}${isAmp ? '/amp' : ''}`,
-      );
     });
 
     it('should not render ElectionBanner when aboutTags do not contain the correct thingLabel', () => {

--- a/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
@@ -13,6 +13,12 @@ const mockAboutTags = [
 const ELEMENT_ID = 'election-banner';
 
 describe('ElectionBanner', () => {
+  beforeEach(() => {
+    delete process.env.SIMORGH_APP_ENV;
+    delete process.env.SIMORGH_INCLUDES_BASE_URL;
+    delete process.env.SIMORGH_INCLUDES_BASE_AMP_URL;
+  });
+
   it('should not render ElectionBanner when isLite is true', () => {
     const { queryByTestId } = render(
       <ElectionBanner aboutTags={mockAboutTags} />,
@@ -54,9 +60,7 @@ describe('ElectionBanner', () => {
 
         const wrappingEl = getByTestId(ELEMENT_ID);
 
-        const iframe = isAmp
-          ? wrappingEl.querySelector('amp-iframe')
-          : wrappingEl.querySelector('iframe');
+        const iframe = wrappingEl.querySelector('iframe, amp-iframe');
         const iframeSrc = iframe?.getAttribute('src');
 
         const configSrc = BANNER_CONFIG[

--- a/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
@@ -13,10 +13,10 @@ const mockAboutTags = [
 const ELEMENT_ID = 'election-banner';
 
 describe('ElectionBanner', () => {
-  beforeEach(() => {
-    delete process.env.SIMORGH_APP_ENV;
-    delete process.env.SIMORGH_INCLUDES_BASE_URL;
-    delete process.env.SIMORGH_INCLUDES_BASE_AMP_URL;
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = originalEnv;
   });
 
   it('should not render ElectionBanner when isLite is true', () => {

--- a/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
@@ -22,6 +22,30 @@ describe('ElectionBanner', () => {
     expect(queryByTestId(ELEMENT_ID)).not.toBeInTheDocument();
   });
 
+  it('should user the production URL for the iframe when SIMORGH_APP_ENV is "live"', () => {
+    const { getByTestId } = render(
+      <ElectionBanner aboutTags={mockAboutTags} />,
+      { toggles: { electionBanner: { enabled: true } }, isAmp: false },
+    );
+
+    const iframe = getByTestId(ELEMENT_ID).querySelector('iframe');
+    const iframeSrc = iframe?.getAttribute('src');
+
+    expect(iframeSrc).not.toContain('/develop/');
+  });
+
+  it('should user the test URL for the iframe when SIMORGH_APP_ENV is "test"', () => {
+    const { getByTestId } = render(
+      <ElectionBanner aboutTags={mockAboutTags} />,
+      { toggles: { electionBanner: { enabled: true } }, isAmp: false },
+    );
+
+    const iframe = getByTestId(ELEMENT_ID).querySelector('iframe');
+    const iframeSrc = iframe?.getAttribute('src');
+
+    expect(iframeSrc).toContain('/develop/');
+  });
+
   describe.each(['canonical', 'amp'])('%s', platform => {
     const isAmp = platform === 'amp';
 

--- a/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
@@ -36,7 +36,9 @@ describe('ElectionBanner', () => {
     const iframe = getByTestId(ELEMENT_ID).querySelector('iframe');
     const iframeSrc = iframe?.getAttribute('src');
 
-    expect(iframeSrc).not.toContain('/develop/');
+    const configSrc = BANNER_CONFIG.iframeSrc.replace('{service}', 'news');
+
+    expect(iframeSrc).toEqual(configSrc);
   });
 
   it('should use the test URL for the iframe when SIMORGH_APP_ENV is "test"', () => {
@@ -53,7 +55,9 @@ describe('ElectionBanner', () => {
     const iframe = getByTestId(ELEMENT_ID).querySelector('iframe');
     const iframeSrc = iframe?.getAttribute('src');
 
-    expect(iframeSrc).toContain('/develop/');
+    const configSrc = BANNER_CONFIG.iframeDevSrc.replace('{service}', 'news');
+
+    expect(iframeSrc).toEqual(configSrc);
   });
 
   describe.each(['canonical', 'amp'])('%s', platform => {

--- a/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
@@ -25,7 +25,10 @@ describe('ElectionBanner', () => {
   it('should user the production URL for the iframe when SIMORGH_APP_ENV is "live"', () => {
     const { getByTestId } = render(
       <ElectionBanner aboutTags={mockAboutTags} />,
-      { toggles: { electionBanner: { enabled: true } }, isAmp: false },
+      {
+        toggles: { electionBanner: { enabled: true } },
+        isAmp: false,
+      },
     );
 
     const iframe = getByTestId(ELEMENT_ID).querySelector('iframe');
@@ -37,7 +40,10 @@ describe('ElectionBanner', () => {
   it('should user the test URL for the iframe when SIMORGH_APP_ENV is "test"', () => {
     const { getByTestId } = render(
       <ElectionBanner aboutTags={mockAboutTags} />,
-      { toggles: { electionBanner: { enabled: true } }, isAmp: false },
+      {
+        toggles: { electionBanner: { enabled: true } },
+        isAmp: false,
+      },
     );
 
     const iframe = getByTestId(ELEMENT_ID).querySelector('iframe');
@@ -66,10 +72,7 @@ describe('ElectionBanner', () => {
 
       expect(iframe).toHaveAttribute(
         'src',
-        BANNER_CONFIG[isAmp ? 'iframeSrcAmp' : 'iframeSrc'].replace(
-          '{service}',
-          'news',
-        ),
+        `${BANNER_CONFIG.iframeSrc.replace('{service}', 'news')}${isAmp ? '/amp' : ''}`,
       );
     });
 

--- a/src/app/pages/ArticlePage/ElectionBanner/index.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.tsx
@@ -7,6 +7,7 @@ import AmpIframe from '#app/components/AmpIframe';
 import useToggle from '#app/hooks/useToggle';
 import { Tag } from '#app/components/Metadata/types';
 import { ServiceContext } from '#app/contexts/ServiceContext';
+import { getEnvConfig } from '#app/lib/utilities/getEnvConfig';
 import styles from './index.styles';
 import BANNER_CONFIG from './config';
 
@@ -18,7 +19,11 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
 
   if (isLite) return null;
 
-  const { heights, iframeSrc, thingIds } = BANNER_CONFIG;
+  const { heights, iframeSrc, iframeDevSrc, thingIds } = BANNER_CONFIG;
+
+  const iframeSrcToUse =
+    getEnvConfig()?.SIMORGH_APP_ENV === 'live' ? iframeSrc : iframeDevSrc;
+  console.log('iframeSrcToUse', iframeSrcToUse);
 
   const validAboutTag = aboutTags?.find(tag => thingIds.includes(tag.thingId));
 
@@ -33,7 +38,7 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
           ampMetadata={{
             imageWidth: 1,
             imageHeight: 1,
-            src: `${iframeSrc.replace('{service}', service)}/amp`,
+            src: `${iframeSrcToUse.replace('{service}', service)}/amp`,
             image:
               'https://news.files.bbci.co.uk/include/vjassets/img/app-launcher.png',
             title: validAboutTag.thingLabel,
@@ -47,7 +52,7 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
     <div data-testid="election-banner" css={styles.electionBannerWrapper}>
       <iframe
         title={validAboutTag.thingLabel}
-        src={iframeSrc.replace('{service}', service)}
+        src={iframeSrcToUse.replace('{service}', service)}
         scrolling="no"
         css={styles.electionBannerIframe}
         height={heights.desktop}

--- a/src/app/pages/ArticlePage/ElectionBanner/index.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.tsx
@@ -18,7 +18,7 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
 
   if (isLite) return null;
 
-  const { heights, iframeSrc, iframeSrcAmp, thingIds } = BANNER_CONFIG;
+  const { heights, iframeSrc, thingIds } = BANNER_CONFIG;
 
   const validAboutTag = aboutTags?.find(tag => thingIds.includes(tag.thingId));
 
@@ -33,7 +33,7 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
           ampMetadata={{
             imageWidth: 1,
             imageHeight: 1,
-            src: iframeSrcAmp.replace('{service}', service),
+            src: `${iframeSrc.replace('{service}', service)}/amp`,
             image:
               'https://news.files.bbci.co.uk/include/vjassets/img/app-launcher.png',
             title: validAboutTag.thingLabel,

--- a/src/app/pages/ArticlePage/ElectionBanner/index.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.tsx
@@ -23,7 +23,6 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
 
   const iframeSrcToUse =
     getEnvConfig()?.SIMORGH_APP_ENV === 'live' ? iframeSrc : iframeDevSrc;
-  console.log('iframeSrcToUse', iframeSrcToUse);
 
   const validAboutTag = aboutTags?.find(tag => thingIds.includes(tag.thingId));
 

--- a/src/app/pages/ArticlePage/ElectionBanner/index.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.tsx
@@ -34,6 +34,7 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
   } = getEnvConfig();
 
   const iframeSrcToUse = SIMORGH_APP_ENV === 'live' ? iframeSrc : iframeDevSrc;
+  const iframeSrcWithService = iframeSrcToUse.replace('{service}', service);
 
   if (isAmp) {
     return (
@@ -42,7 +43,7 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
           ampMetadata={{
             imageWidth: 1,
             imageHeight: 1,
-            src: `${SIMORGH_INCLUDES_BASE_AMP_URL}/${iframeSrcToUse.replace('{service}', service)}/amp`,
+            src: `${SIMORGH_INCLUDES_BASE_AMP_URL}/${iframeSrcWithService}/amp`,
             image:
               'https://news.files.bbci.co.uk/include/vjassets/img/app-launcher.png',
             title: validAboutTag.thingLabel,
@@ -56,7 +57,7 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
     <div data-testid="election-banner" css={styles.electionBannerWrapper}>
       <iframe
         title={validAboutTag.thingLabel}
-        src={`${SIMORGH_INCLUDES_BASE_URL}/${iframeSrcToUse.replace('{service}', service)}`}
+        src={`${SIMORGH_INCLUDES_BASE_URL}/${iframeSrcWithService}`}
         scrolling="no"
         css={styles.electionBannerIframe}
         height={heights.desktop}

--- a/src/app/pages/ArticlePage/ElectionBanner/index.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.tsx
@@ -18,7 +18,7 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
 
   if (isLite) return null;
 
-  const { iframeSrc, iframeSrcAmp, thingIds } = BANNER_CONFIG;
+  const { heights, iframeSrc, iframeSrcAmp, thingIds } = BANNER_CONFIG;
 
   const validAboutTag = aboutTags?.find(tag => thingIds.includes(tag.thingId));
 
@@ -50,7 +50,7 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
         src={iframeSrc.replace('{service}', service)}
         scrolling="no"
         css={styles.electionBannerIframe}
-        height={BANNER_CONFIG.heights.desktop}
+        height={heights.desktop}
         width="100%"
       />
     </div>

--- a/src/app/pages/ArticlePage/ElectionBanner/index.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.tsx
@@ -21,14 +21,19 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
 
   const { heights, iframeSrc, iframeDevSrc, thingIds } = BANNER_CONFIG;
 
-  const iframeSrcToUse =
-    getEnvConfig()?.SIMORGH_APP_ENV === 'live' ? iframeSrc : iframeDevSrc;
-
   const validAboutTag = aboutTags?.find(tag => thingIds.includes(tag.thingId));
 
   const showBanner = validAboutTag && electionBannerEnabled;
 
   if (!showBanner) return null;
+
+  const {
+    SIMORGH_APP_ENV,
+    SIMORGH_INCLUDES_BASE_URL,
+    SIMORGH_INCLUDES_BASE_AMP_URL,
+  } = getEnvConfig();
+
+  const iframeSrcToUse = SIMORGH_APP_ENV === 'live' ? iframeSrc : iframeDevSrc;
 
   if (isAmp) {
     return (
@@ -37,7 +42,7 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
           ampMetadata={{
             imageWidth: 1,
             imageHeight: 1,
-            src: `${iframeSrcToUse.replace('{service}', service)}/amp`,
+            src: `${SIMORGH_INCLUDES_BASE_AMP_URL}/${iframeSrcToUse.replace('{service}', service)}/amp`,
             image:
               'https://news.files.bbci.co.uk/include/vjassets/img/app-launcher.png',
             title: validAboutTag.thingLabel,
@@ -51,7 +56,7 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
     <div data-testid="election-banner" css={styles.electionBannerWrapper}>
       <iframe
         title={validAboutTag.thingLabel}
-        src={iframeSrcToUse.replace('{service}', service)}
+        src={`${SIMORGH_INCLUDES_BASE_URL}/${iframeSrcToUse.replace('{service}', service)}`}
         scrolling="no"
         css={styles.electionBannerIframe}
         height={heights.desktop}


### PR DESCRIPTION
Overall changes
======
- Adds the production path for the election banner embed
- Removes explicit AMP path in favour of just appending `/amp` to the `amp-iframe` src
- Adds tests to check the correct path is used based on the running environment
- Adds tests to ensure correct URL is used on AMP and canonical

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
