### PR TITLE
Election banner: Support editorial sensitivity tag in Articles

### DIFF
--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -273,7 +273,7 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
       {allowAdvertising && (
         <AdContainer slotType="leaderboard" adcampaign={adcampaign} />
       )}
-      <ElectionBanner aboutTags={aboutTags} />
+      <ElectionBanner aboutTags={aboutTags} taggings={taggings} />
       <div css={styles.grid}>
         <div css={!isPGL ? styles.primaryColumn : styles.pglColumn}>
           <main css={styles.mainContent} role="main">

--- a/src/app/pages/ArticlePage/ElectionBanner/config.ts
+++ b/src/app/pages/ArticlePage/ElectionBanner/config.ts
@@ -8,7 +8,6 @@ export default {
     'include/vjafwest/1365-2024-us-presidential-election-banner/{service}/app',
   iframeDevSrc:
     'include/vjafwest/1365-2024-us-presidential-election-banner/develop/{service}/app',
-  thingIds: [
-    '647d5613-e0e2-4ef5-b0ce-b491de38bdbd', // https://www.bbc.co.uk/things/647d5613-e0e2-4ef5-b0ce-b491de38bdbd
-  ],
+  thingId: '647d5613-e0e2-4ef5-b0ce-b491de38bdbd',
+  editorialSensitivityId: 'f2b5dd0e-dda0-454c-893d-792d46ff48c3',
 };

--- a/src/app/pages/ArticlePage/ElectionBanner/config.ts
+++ b/src/app/pages/ArticlePage/ElectionBanner/config.ts
@@ -8,6 +8,6 @@ export default {
     'include/vjafwest/1365-2024-us-presidential-election-banner/{service}/app',
   iframeDevSrc:
     'include/vjafwest/1365-2024-us-presidential-election-banner/develop/{service}/app',
-  thingId: '647d5613-e0e2-4ef5-b0ce-b491de38bdbd',
+  usElectionThingId: '647d5613-e0e2-4ef5-b0ce-b491de38bdbd',
   editorialSensitivityId: 'f2b5dd0e-dda0-454c-893d-792d46ff48c3',
 };

--- a/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
@@ -8,7 +8,7 @@ import ElectionBanner from '.';
 const mockAboutTags = [
   { thingId: 'thing1' },
   { thingId: 'thing2' },
-  { thingId: BANNER_CONFIG.thingId },
+  { thingId: BANNER_CONFIG.usElectionThingId },
 ] as Tag[];
 
 const mockTaggings: MetadataTaggings = [

--- a/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
@@ -1,14 +1,33 @@
 import React from 'react';
 import { render } from '#app/components/react-testing-library-with-providers';
 import { Tag } from '#app/components/Metadata/types';
+import { MetadataTaggings } from '#app/models/types/metadata';
 import BANNER_CONFIG from './config';
 import ElectionBanner from '.';
 
 const mockAboutTags = [
   { thingId: 'thing1' },
   { thingId: 'thing2' },
-  ...BANNER_CONFIG.thingIds.map(thingId => ({ thingId })),
+  { thingId: BANNER_CONFIG.thingId },
 ] as Tag[];
+
+const mockTaggings: MetadataTaggings = [
+  {
+    predicate: 'http://www.bbc.co.uk/ontologies/bbc/infoClass',
+    value:
+      'http://www.bbc.co.uk/things/0db2b959-cbf8-4661-965f-050974a69bb5#id',
+  },
+  {
+    predicate: 'http://www.bbc.co.uk/ontologies/bbc/assetType',
+    value:
+      'http://www.bbc.co.uk/things/22ea958e-2004-4f34-80a7-bf5acad52f6f#id',
+  },
+  {
+    predicate: 'http://www.bbc.co.uk/ontologies/creativework/about',
+    value:
+      'http://www.bbc.co.uk/things/647d5613-e0e2-4ef5-b0ce-b491de38bdbd#id',
+  },
+];
 
 const ELEMENT_ID = 'election-banner';
 
@@ -21,7 +40,7 @@ describe('ElectionBanner', () => {
 
   it('should not render ElectionBanner when isLite is true', () => {
     const { queryByTestId } = render(
-      <ElectionBanner aboutTags={mockAboutTags} />,
+      <ElectionBanner aboutTags={mockAboutTags} taggings={mockTaggings} />,
       { isLite: true },
     );
 
@@ -51,7 +70,7 @@ describe('ElectionBanner', () => {
         process.env.SIMORGH_APP_ENV = appEnv;
 
         const { getByTestId } = render(
-          <ElectionBanner aboutTags={mockAboutTags} />,
+          <ElectionBanner aboutTags={mockAboutTags} taggings={mockTaggings} />,
           {
             toggles: { electionBanner: { enabled: true } },
             isAmp,
@@ -79,7 +98,7 @@ describe('ElectionBanner', () => {
 
     it('should render ElectionBanner when aboutTags contain the correct thingLabel', () => {
       const { getByTestId } = render(
-        <ElectionBanner aboutTags={mockAboutTags} />,
+        <ElectionBanner aboutTags={mockAboutTags} taggings={mockTaggings} />,
         {
           toggles: { electionBanner: { enabled: true } },
           isAmp,
@@ -89,9 +108,34 @@ describe('ElectionBanner', () => {
       expect(getByTestId(ELEMENT_ID)).toBeInTheDocument();
     });
 
+    it('should not render ElectionBanner when taggings contain the editorialSensitivityId', () => {
+      const { queryByTestId } = render(
+        <ElectionBanner
+          aboutTags={mockAboutTags}
+          taggings={[
+            {
+              predicate:
+                'http://www.bbc.co.uk/ontologies/bbc/editorialSensitivity',
+              value:
+                'http://www.bbc.co.uk/things/f2b5dd0e-dda0-454c-893d-792d46ff48c3#id',
+            },
+          ]}
+        />,
+        {
+          toggles: { electionBanner: { enabled: true } },
+          isAmp,
+        },
+      );
+
+      expect(queryByTestId(ELEMENT_ID)).not.toBeInTheDocument();
+    });
+
     it('should not render ElectionBanner when aboutTags do not contain the correct thingLabel', () => {
       const { queryByTestId } = render(
-        <ElectionBanner aboutTags={[{ thingLabel: 'thing1' }] as Tag[]} />,
+        <ElectionBanner
+          aboutTags={[{ thingLabel: 'thing1' }] as Tag[]}
+          taggings={mockTaggings}
+        />,
         { isAmp },
       );
 
@@ -99,16 +143,19 @@ describe('ElectionBanner', () => {
     });
 
     it('should not render ElectionBanner when aboutTags is empty', () => {
-      const { queryByTestId } = render(<ElectionBanner aboutTags={[]} />, {
-        isAmp,
-      });
+      const { queryByTestId } = render(
+        <ElectionBanner aboutTags={[]} taggings={mockTaggings} />,
+        {
+          isAmp,
+        },
+      );
 
       expect(queryByTestId(ELEMENT_ID)).not.toBeInTheDocument();
     });
 
     it('should not render ElectionBanner when toggle is disabled', () => {
       const { queryByTestId } = render(
-        <ElectionBanner aboutTags={mockAboutTags} />,
+        <ElectionBanner aboutTags={mockAboutTags} taggings={mockTaggings} />,
         {
           toggles: { electionBanner: { enabled: false } },
           isAmp,
@@ -120,7 +167,7 @@ describe('ElectionBanner', () => {
 
     it('should not render ElectionBanner when toggle is null', () => {
       const { queryByTestId } = render(
-        <ElectionBanner aboutTags={mockAboutTags} />,
+        <ElectionBanner aboutTags={mockAboutTags} taggings={mockTaggings} />,
         {
           toggles: {
             someOtherToggle: { enabled: true },

--- a/src/app/pages/ArticlePage/ElectionBanner/index.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.tsx
@@ -8,10 +8,16 @@ import useToggle from '#app/hooks/useToggle';
 import { Tag } from '#app/components/Metadata/types';
 import { ServiceContext } from '#app/contexts/ServiceContext';
 import { getEnvConfig } from '#app/lib/utilities/getEnvConfig';
+import { MetadataTaggings } from '#app/models/types/metadata';
 import styles from './index.styles';
 import BANNER_CONFIG from './config';
 
-export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
+type Props = {
+  aboutTags: Tag[];
+  taggings: MetadataTaggings;
+};
+
+export default function ElectionBanner({ aboutTags, taggings }: Props) {
   const { service } = useContext(ServiceContext);
   const { isAmp, isLite } = useContext(RequestContext);
   const { enabled: electionBannerEnabled }: { enabled: boolean | null } =
@@ -19,11 +25,17 @@ export default function ElectionBanner({ aboutTags }: { aboutTags: Tag[] }) {
 
   if (isLite) return null;
 
-  const { heights, iframeSrc, iframeDevSrc, thingIds } = BANNER_CONFIG;
+  const { heights, iframeSrc, iframeDevSrc, thingId, editorialSensitivityId } =
+    BANNER_CONFIG;
 
-  const validAboutTag = aboutTags?.find(tag => thingIds.includes(tag.thingId));
+  const isEditoriallySensitive = taggings?.find(tag =>
+    tag.value.includes(editorialSensitivityId),
+  );
 
-  const showBanner = validAboutTag && electionBannerEnabled;
+  const validAboutTag = aboutTags?.find(tag => tag.thingId === thingId);
+
+  const showBanner =
+    !isEditoriallySensitive && validAboutTag && electionBannerEnabled;
 
   if (!showBanner) return null;
 

--- a/src/app/pages/ArticlePage/ElectionBanner/index.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.tsx
@@ -25,14 +25,21 @@ export default function ElectionBanner({ aboutTags, taggings }: Props) {
 
   if (isLite) return null;
 
-  const { heights, iframeSrc, iframeDevSrc, thingId, editorialSensitivityId } =
-    BANNER_CONFIG;
+  const {
+    heights,
+    iframeSrc,
+    iframeDevSrc,
+    editorialSensitivityId,
+    usElectionThingId,
+  } = BANNER_CONFIG;
 
-  const isEditoriallySensitive = taggings?.find(tag =>
-    tag.value.includes(editorialSensitivityId),
+  const isEditoriallySensitive = taggings?.find(({ value }) =>
+    value.includes(editorialSensitivityId),
   );
 
-  const validAboutTag = aboutTags?.find(tag => tag.thingId === thingId);
+  const validAboutTag = aboutTags?.find(
+    ({ thingId }) => thingId === usElectionThingId,
+  );
 
   const showBanner =
     !isEditoriallySensitive && validAboutTag && electionBannerEnabled;


### PR DESCRIPTION
Overall changes
======
- Adds check for `editorialSensitivity` tagging in the article metadata, hiding the election banner if the article is tagged as being editorially sensitive
- Adds tests for this new logic

Testing
======
1. Visit http://localhost:7080/mundo/articles/cmyk0d45ddpo?renderer_env=test
2. Confirm the election banner doesn't appear as the editorialSensitivity tag is present
3. Visit http://localhost:7080/afaanoromoo/articles/czmxgwem0ydo?renderer_env=test
4. Confirm the election banner does appear as the editorialSensitivity tag is not present
5. Visit http://localhost:7080/kyrgyz/articles/c8ekd7r9r76o?renderer_env=live
6. Confirm the election banner doesn't appear as the article doesn't contain the relevant aboutTag for the US Election

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
