### PR TITLE
Delete Eleições municipais topic from the portuguese nav bar

### DIFF
--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -418,10 +418,6 @@ export const service: DefaultServiceConfig = {
         url: '/portuguese/topics/cz74k717pw5t',
       },
       {
-        title: 'Eleições municipais',
-        url: '/portuguese/topics/cy6z19wz1zet',
-      },
-      {
         title: 'Eleições EUA',
         url: '/portuguese/topics/c30gn378n6kt',
       },

--- a/src/integration/pages/podcastPage/portugueseBrand/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/podcastPage/portugueseBrand/__snapshots__/canonical.test.js.snap
@@ -82,61 +82,54 @@ exports[`Canonical Podcast Page Header Navigation link should match text and url
 
 exports[`Canonical Podcast Page Header Navigation link should match text and url 3`] = `
 {
-  "text": "Eleições municipais",
-  "url": "/portuguese/topics/cy6z19wz1zet",
-}
-`;
-
-exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
-{
   "text": "Eleições EUA",
   "url": "/portuguese/topics/c30gn378n6kt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Internacional",
   "url": "/portuguese/topics/cmdm4ynm24kt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Economia",
   "url": "/portuguese/topics/cvjp2jr0k9rt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Saúde",
   "url": "/portuguese/topics/c340q430z4vt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Ciência",
   "url": "/portuguese/topics/cr50y580rjxt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Tecnologia",
   "url": "/portuguese/topics/c404v027pd4t",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Vídeos",
   "url": "/portuguese/topics/c9y2j35dn2zt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 10`] = `
 {
   "text": "BBC Lê",
   "url": "/portuguese/topics/cxndrr1qgllt",

--- a/src/integration/pages/podcastPage/portugueseEpisode/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/podcastPage/portugueseEpisode/__snapshots__/canonical.test.js.snap
@@ -82,61 +82,54 @@ exports[`Canonical Podcast Page Header Navigation link should match text and url
 
 exports[`Canonical Podcast Page Header Navigation link should match text and url 3`] = `
 {
-  "text": "Eleições municipais",
-  "url": "/portuguese/topics/cy6z19wz1zet",
-}
-`;
-
-exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
-{
   "text": "Eleições EUA",
   "url": "/portuguese/topics/c30gn378n6kt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Internacional",
   "url": "/portuguese/topics/cmdm4ynm24kt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Economia",
   "url": "/portuguese/topics/cvjp2jr0k9rt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Saúde",
   "url": "/portuguese/topics/c340q430z4vt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Ciência",
   "url": "/portuguese/topics/cr50y580rjxt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Tecnologia",
   "url": "/portuguese/topics/c404v027pd4t",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Vídeos",
   "url": "/portuguese/topics/c9y2j35dn2zt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 10`] = `
 {
   "text": "BBC Lê",
   "url": "/portuguese/topics/cxndrr1qgllt",


### PR DESCRIPTION
Overall changes
======
Remove topic from navigation as it is no longer required 

Code changes
======

- update portuguese service file navigation

Testing
======
Eleições municipais no longer appears
