### PR TITLE
Election banner - Handle Turkce service URL

### DIFF
--- a/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.test.tsx
@@ -108,6 +108,25 @@ describe('ElectionBanner', () => {
       expect(getByTestId(ELEMENT_ID)).toBeInTheDocument();
     });
 
+    it('should render the correct VJ URL for Turkce service', () => {
+      const { getByTestId } = render(
+        <ElectionBanner aboutTags={mockAboutTags} taggings={mockTaggings} />,
+        {
+          toggles: { electionBanner: { enabled: true } },
+          isAmp,
+          service: 'turkce',
+        },
+      );
+
+      const wrappingEl = getByTestId(ELEMENT_ID);
+
+      const iframe = wrappingEl.querySelector('iframe, amp-iframe');
+      const iframeSrc = iframe?.getAttribute('src');
+
+      expect(iframeSrc).not.toContain('turkce');
+      expect(iframeSrc).toContain('turkish');
+    });
+
     it('should not render ElectionBanner when taggings contain the editorialSensitivityId', () => {
       const { queryByTestId } = render(
         <ElectionBanner

--- a/src/app/pages/ArticlePage/ElectionBanner/index.tsx
+++ b/src/app/pages/ArticlePage/ElectionBanner/index.tsx
@@ -9,12 +9,22 @@ import { Tag } from '#app/components/Metadata/types';
 import { ServiceContext } from '#app/contexts/ServiceContext';
 import { getEnvConfig } from '#app/lib/utilities/getEnvConfig';
 import { MetadataTaggings } from '#app/models/types/metadata';
+import { Services } from '#app/models/types/global';
 import styles from './index.styles';
 import BANNER_CONFIG from './config';
 
 type Props = {
   aboutTags: Tag[];
   taggings: MetadataTaggings;
+};
+
+const handleUrlServiceTransform = (url: string, service: Services) => {
+  switch (service) {
+    case 'turkce':
+      return url.replace('{service}', 'turkish');
+    default:
+      return url.replace('{service}', service);
+  }
 };
 
 export default function ElectionBanner({ aboutTags, taggings }: Props) {
@@ -53,7 +63,10 @@ export default function ElectionBanner({ aboutTags, taggings }: Props) {
   } = getEnvConfig();
 
   const iframeSrcToUse = SIMORGH_APP_ENV === 'live' ? iframeSrc : iframeDevSrc;
-  const iframeSrcWithService = iframeSrcToUse.replace('{service}', service);
+  const iframeSrcWithService = handleUrlServiceTransform(
+    iframeSrcToUse,
+    service,
+  );
 
   if (isAmp) {
     return (


### PR DESCRIPTION
Overall changes
======
- Adds unique case for the `turkce` service to format the election banner URL correctly

Testing
======
1. Visit http://localhost:7080/turkce/articles/cj3mex17yxpo?renderer_env=live
2. Confirm the banner renders as expected

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
