### PR TITLE
Override date time format for posts on the live page for Zhongwen

### DIFF
--- a/src/app/lib/config/services/zhongwen.ts
+++ b/src/app/lib/config/services/zhongwen.ts
@@ -180,6 +180,8 @@ export const service: ZhongwenConfig = {
         postedAt: '张贴于',
         summary: '概要',
         shareButtonText: '分享',
+        postDateTimeFormat: 'YYYY年M月DD日',
+        postDateFormat: 'YYYY年M月D日',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',
@@ -481,6 +483,8 @@ export const service: ZhongwenConfig = {
         postedAt: '張貼在',
         summary: '概要',
         shareButtonText: '分享',
+        postDateTimeFormat: 'YYYY年M月DD日',
+        postDateFormat: 'YYYY年M月D日',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/models/types/translations.ts
+++ b/src/app/models/types/translations.ts
@@ -38,6 +38,8 @@ export interface Translations {
     postedAt: string;
     summary: string;
     shareButtonText: string;
+    postDateTimeFormat?: string;
+    postDateFormat?: string;
   };
   downloads?: {
     instructions?: string;

--- a/ws-nextjs-app/pages/[service]/live/[id]/Post/index.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Post/index.test.tsx
@@ -25,26 +25,33 @@ describe('Post', () => {
   });
 
   describe('Timestamp', () => {
-    it('Shows timestamp as a stamp for articles over 10 hours old.', async () => {
-      const { container } = await act(async () => {
-        const postData = {
-          ...samplePost,
-          dates: {
-            firstPublished: '2023-04-28T10:33:09+00:00',
-            lastPublished: '2023-04-28T10:33:09+00:00',
-            time: null,
-            curated: '2023-04-28T10:33:10.293Z',
-          },
-        };
+    it.each`
+      service       | expectedTime
+      ${'pidgin'}   | ${'28 April 2023'}
+      ${'zhongwen'} | ${'2023年4月28日'}
+    `(
+      'Shows timestamp in the expected format for $service for articles over 10 hours old.',
+      async ({ service, expectedTime }) => {
+        const { container } = await act(async () => {
+          const postData = {
+            ...samplePost,
+            dates: {
+              firstPublished: '2023-04-28T10:33:09+00:00',
+              lastPublished: '2023-04-28T10:33:09+00:00',
+              time: null,
+              curated: '2023-04-28T10:33:10.293Z',
+            },
+          };
 
-        return render(<Post post={postData} />, {
-          service: 'pidgin',
+          return render(<Post post={postData} />, {
+            service,
+          });
         });
-      });
 
-      const time = container.querySelector('time');
-      expect(time?.textContent).toEqual('28 April 2023');
-    });
+        const time = container.querySelector('time');
+        expect(time?.textContent).toEqual(expectedTime);
+      },
+    );
 
     it('Shows timestamp as a relative time for articles under 10 hours old.', async () => {
       jest.useFakeTimers().setSystemTime(new Date('2023-04-28T10:35:10.293Z'));
@@ -67,6 +74,7 @@ describe('Post', () => {
       expect(time?.textContent).toEqual('2 minutes wey don pass');
     });
   });
+
   describe('Header', () => {
     it('should render h3 title when provided', async () => {
       await act(async () => {

--- a/ws-nextjs-app/pages/[service]/live/[id]/Post/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Post/index.tsx
@@ -61,7 +61,11 @@ const PostHeaderBanner = ({
     service,
     script,
     translations: {
-      liveExperiencePage: { breaking = 'Breaking' },
+      liveExperiencePage: {
+        breaking = 'Breaking',
+        postDateTimeFormat,
+        postDateFormat,
+      },
     },
   } = useContext(ServiceContext);
   const isRelative = isTenHoursAgo(new Date(curated).getTime());
@@ -70,8 +74,8 @@ const PostHeaderBanner = ({
       <TimeStampContainer
         css={styles.timeStamp}
         timestamp={curated}
-        dateTimeFormat="DD MMMM YYYY"
-        format="D MMMM YYYY"
+        dateTimeFormat={postDateTimeFormat || 'DD MMMM YYYY'}
+        format={postDateFormat || 'D MMMM YYYY'}
         locale={locale}
         timezone={timezone}
         service={service}


### PR DESCRIPTION
Overall changes
======
Allows services to override the date time format for posts on Live Pages

Code changes
======
- Add new entries to the translations for Live Experience Pages
- Zhongwen implements the new translation entries for Live Experience Pages
- The Post Component uses the translations from the service context to override the date / time formats for posts
- Add unit tests

Testing
======
Visit http://localhost:7081/zhongwen/live/67920158/simp?renderer_env=live & observe that the timestamp is in the correct format
Visit other live pages and observe that the timestamp is the same as the live version of the page
- http://localhost:7081/pidgin/live/c7p765ynk9qt?renderer_env=test
- http://localhost:7081/afrique/live/region-42772370?renderer_env=live

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
