### PR TITLE
WSTEAMA-1423 - Remove `morph_env` references

### DIFF
--- a/src/app/components/LinkedData/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/LinkedData/__snapshots__/index.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`LinkedData should correctly render linked data for Ondemand Radio page 
       "@type": "AudioObject",
       "description": "د بي بي سي ورلډ سروس څخه پروګرام کول",
       "duration": "PT29M30S",
-      "embedURL": "https://test.bbc.com/ws/av-embeds/media/korean/externalId/id/ko?morph_env=live",
+      "embedURL": "https://test.bbc.com/ws/av-embeds/media/korean/externalId/id/ko",
       "name": "ماښامنۍ خپرونه",
       "thumbnailUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg",
       "uploadDate": "2020-04-23T15:30:00.000Z",

--- a/src/app/components/LinkedData/index.test.tsx
+++ b/src/app/components/LinkedData/index.test.tsx
@@ -95,7 +95,7 @@ describe('LinkedData', () => {
         description: 'د بي بي سي ورلډ سروس څخه پروګرام کول',
         duration: 'PT29M30S',
         embedURL:
-          'https://test.bbc.com/ws/av-embeds/media/korean/externalId/id/ko?morph_env=live',
+          'https://test.bbc.com/ws/av-embeds/media/korean/externalId/id/ko',
         thumbnailUrl:
           'https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg',
         uploadDate: '2020-04-23T15:30:00.000Z',


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAMA-1423

Overall changes
======
- Removes last `morph_env` query param reference, as this isn't used anymore

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
