### PR TITLE
Adds `decodeURIComponent` to handle non-latin hash characters

### DIFF
--- a/src/app/legacy/containers/PageHandlers/withHashChangeHandler/index.jsx
+++ b/src/app/legacy/containers/PageHandlers/withHashChangeHandler/index.jsx
@@ -18,7 +18,7 @@ const useHashChangeHandler = hash => {
 const getHashProp = path(['location', 'hash']);
 
 const withHashChangeHandler = Component => props => {
-  const hash = getHashProp(props);
+  const hash = decodeURIComponent(getHashProp(props));
 
   useHashChangeHandler(hash);
 

--- a/src/app/legacy/containers/PageHandlers/withHashChangeHandler/index.test.jsx
+++ b/src/app/legacy/containers/PageHandlers/withHashChangeHandler/index.test.jsx
@@ -10,6 +10,15 @@ const Fixture = withHashChangeHandler(() => (
   </>
 ));
 
+const CyrillicFixture = withHashChangeHandler(() => (
+  <>
+    <a href="#Мирнија-сам-неко-брине-о-њој-док-је-у-школи">Go to section 1</a>
+    <section id="Мирнија-сам-неко-брине-о-њој-док-је-у-школи">
+      Section 1
+    </section>
+  </>
+));
+
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
 window.HTMLElement.prototype.focus = jest.fn();
 
@@ -17,6 +26,25 @@ it('should scroll into view and focus on element when hash location changes', as
   const { rerender } = render(<Fixture location={{ hash: '' }} />);
 
   rerender(<Fixture location={{ hash: '#section-1' }} />);
+
+  expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(1);
+  expect(window.HTMLElement.prototype.focus).toHaveBeenCalledTimes(1);
+});
+
+it('should scroll into view and focus on element when hash location changes with Cyrillic characters', async () => {
+  const { rerender } = render(
+    <CyrillicFixture
+      location={{
+        hash: '#%D0%9C%D0%B8%D1%80%D0%BD%D0%B8%D1%98%D0%B0-%D1%81%D0%B0%D0%BC-%D0%BD%D0%B5%D0%BA%D0%BE-%D0%B1%D1%80%D0%B8%D0%BD%D0%B5-%D0%BE-%D1%9A%D0%BE%D1%98-%D0%B4%D0%BE%D0%BA-%D1%98%D0%B5-%D1%83-%D1%88%D0%BA%D0%BE%D0%BB%D0%B8',
+      }}
+    />,
+  );
+
+  rerender(
+    <CyrillicFixture
+      location={{ hash: '#Мирнија-сам-неко-брине-о-њој-док-је-у-школи' }}
+    />,
+  );
 
   expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(1);
   expect(window.HTMLElement.prototype.focus).toHaveBeenCalledTimes(1);

--- a/src/app/legacy/containers/PageHandlers/withHashChangeHandler/index.test.jsx
+++ b/src/app/legacy/containers/PageHandlers/withHashChangeHandler/index.test.jsx
@@ -19,6 +19,13 @@ const CyrillicFixture = withHashChangeHandler(() => (
   </>
 ));
 
+const HindiFixture = withHashChangeHandler(() => (
+  <>
+    <a href="#आंखों-के-सामने-छा-गया-था-अंधेरा">Go to section 1</a>
+    <section id="आंखों-के-सामने-छा-गया-था-अंधेरा">Section 1</section>
+  </>
+));
+
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
 window.HTMLElement.prototype.focus = jest.fn();
 
@@ -45,6 +52,23 @@ describe('withHashChangeHandler', () => {
           hash:
             // This is the encoded version of Мирнија-сам-неко-брине-о-њој-док-је-у-школи
             '#%D0%9C%D0%B8%D1%80%D0%BD%D0%B8%D1%98%D0%B0-%D1%81%D0%B0%D0%BC-%D0%BD%D0%B5%D0%BA%D0%BE-%D0%B1%D1%80%D0%B8%D0%BD%D0%B5-%D0%BE-%D1%9A%D0%BE%D1%98-%D0%B4%D0%BE%D0%BA-%D1%98%D0%B5-%D1%83-%D1%88%D0%BA%D0%BE%D0%BB%D0%B8',
+        }}
+      />,
+    );
+
+    expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(window.HTMLElement.prototype.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('should scroll into view and focus on element when hash location contains Hindi characters', async () => {
+    render(
+      <HindiFixture
+        location={{
+          hash:
+            // This is the encoded version of आंखों-के-सामने-छा-गया-था-अंधेरा
+            '#%E0%A4%86%E0%A4%82%E0%A4%96%E0%A5%8B%E0%A4%82-%E0%A4%95%E0%A5%87-%E0%A4%B8%E0%A4%BE%E0%A4%AE%E0%A4%A8%E0%A5%87-%E0%A4%9B%E0%A4%BE-%E0%A4%97%E0%A4%AF%E0%A4%BE-%E0%A4%A5%E0%A4%BE-%E0%A4%85%E0%A4%82%E0%A4%A7%E0%A5%87%E0%A4%B0%E0%A4%BE',
         }}
       />,
     );

--- a/src/app/legacy/containers/PageHandlers/withHashChangeHandler/index.test.jsx
+++ b/src/app/legacy/containers/PageHandlers/withHashChangeHandler/index.test.jsx
@@ -22,30 +22,40 @@ const CyrillicFixture = withHashChangeHandler(() => (
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
 window.HTMLElement.prototype.focus = jest.fn();
 
-it('should scroll into view and focus on element when hash location changes', async () => {
-  const { rerender } = render(<Fixture location={{ hash: '' }} />);
+describe('withHashChangeHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
-  rerender(<Fixture location={{ hash: '#section-1' }} />);
+  it('should scroll into view and focus on element when hash location changes', async () => {
+    const { rerender } = render(<Fixture location={{ hash: '' }} />);
 
-  expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(1);
-  expect(window.HTMLElement.prototype.focus).toHaveBeenCalledTimes(1);
-});
+    rerender(<Fixture location={{ hash: '#section-1' }} />);
 
-it('should scroll into view and focus on element when hash location changes with Cyrillic characters', async () => {
-  const { rerender } = render(
-    <CyrillicFixture
-      location={{
-        hash: '#%D0%9C%D0%B8%D1%80%D0%BD%D0%B8%D1%98%D0%B0-%D1%81%D0%B0%D0%BC-%D0%BD%D0%B5%D0%BA%D0%BE-%D0%B1%D1%80%D0%B8%D0%BD%D0%B5-%D0%BE-%D1%9A%D0%BE%D1%98-%D0%B4%D0%BE%D0%BA-%D1%98%D0%B5-%D1%83-%D1%88%D0%BA%D0%BE%D0%BB%D0%B8',
-      }}
-    />,
-  );
+    expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(window.HTMLElement.prototype.focus).toHaveBeenCalledTimes(1);
+  });
 
-  rerender(
-    <CyrillicFixture
-      location={{ hash: '#Мирнија-сам-неко-брине-о-њој-док-је-у-школи' }}
-    />,
-  );
+  it('should scroll into view and focus on element when hash location changes with Cyrillic characters', async () => {
+    const { rerender } = render(
+      <CyrillicFixture
+        location={{
+          hash: '#%D0%9C%D0%B8%D1%80%D0%BD%D0%B8%D1%98%D0%B0-%D1%81%D0%B0%D0%BC-%D0%BD%D0%B5%D0%BA%D0%BE-%D0%B1%D1%80%D0%B8%D0%BD%D0%B5-%D0%BE-%D1%9A%D0%BE%D1%98-%D0%B4%D0%BE%D0%BA-%D1%98%D0%B5-%D1%83-%D1%88%D0%BA%D0%BE%D0%BB%D0%B8',
+        }}
+      />,
+    );
 
-  expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(1);
-  expect(window.HTMLElement.prototype.focus).toHaveBeenCalledTimes(1);
+    rerender(
+      <CyrillicFixture
+        location={{ hash: '#Мирнија-сам-неко-брине-о-њој-док-је-у-школи' }}
+      />,
+    );
+
+    expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(window.HTMLElement.prototype.focus).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/app/legacy/containers/PageHandlers/withHashChangeHandler/index.test.jsx
+++ b/src/app/legacy/containers/PageHandlers/withHashChangeHandler/index.test.jsx
@@ -38,18 +38,12 @@ describe('withHashChangeHandler', () => {
     expect(window.HTMLElement.prototype.focus).toHaveBeenCalledTimes(1);
   });
 
-  it('should scroll into view and focus on element when hash location changes with Cyrillic characters', async () => {
-    const { rerender } = render(
+  it('should scroll into view and focus on element when hash location contains Cyrillic characters', async () => {
+    render(
       <CyrillicFixture
         location={{
           hash: '#%D0%9C%D0%B8%D1%80%D0%BD%D0%B8%D1%98%D0%B0-%D1%81%D0%B0%D0%BC-%D0%BD%D0%B5%D0%BA%D0%BE-%D0%B1%D1%80%D0%B8%D0%BD%D0%B5-%D0%BE-%D1%9A%D0%BE%D1%98-%D0%B4%D0%BE%D0%BA-%D1%98%D0%B5-%D1%83-%D1%88%D0%BA%D0%BE%D0%BB%D0%B8',
         }}
-      />,
-    );
-
-    rerender(
-      <CyrillicFixture
-        location={{ hash: '#Мирнија-сам-неко-брине-о-њој-док-је-у-школи' }}
       />,
     );
 

--- a/src/app/legacy/containers/PageHandlers/withHashChangeHandler/index.test.jsx
+++ b/src/app/legacy/containers/PageHandlers/withHashChangeHandler/index.test.jsx
@@ -42,7 +42,9 @@ describe('withHashChangeHandler', () => {
     render(
       <CyrillicFixture
         location={{
-          hash: '#%D0%9C%D0%B8%D1%80%D0%BD%D0%B8%D1%98%D0%B0-%D1%81%D0%B0%D0%BC-%D0%BD%D0%B5%D0%BA%D0%BE-%D0%B1%D1%80%D0%B8%D0%BD%D0%B5-%D0%BE-%D1%9A%D0%BE%D1%98-%D0%B4%D0%BE%D0%BA-%D1%98%D0%B5-%D1%83-%D1%88%D0%BA%D0%BE%D0%BB%D0%B8',
+          hash:
+            // This is the encoded version of Мирнија-сам-неко-брине-о-њој-док-је-у-школи
+            '#%D0%9C%D0%B8%D1%80%D0%BD%D0%B8%D1%98%D0%B0-%D1%81%D0%B0%D0%BC-%D0%BD%D0%B5%D0%BA%D0%BE-%D0%B1%D1%80%D0%B8%D0%BD%D0%B5-%D0%BE-%D1%9A%D0%BE%D1%98-%D0%B4%D0%BE%D0%BA-%D1%98%D0%B5-%D1%83-%D1%88%D0%BA%D0%BE%D0%BB%D0%B8',
         }}
       />,
     );


### PR DESCRIPTION
Overall changes
======
- Uses `decodeURIComponent` to correctly parse the `location.hash` if a non-latin service sets the hash. `location.hash` will store the encoded version, so it must be decoded before trying to navigate the user to the element

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
