### PR TITLE
WSTEAMA-1429 Add languages link to footer for all services

### DIFF
--- a/src/app/lib/config/services/afaanoromoo.ts
+++ b/src/app/lib/config/services/afaanoromoo.ts
@@ -311,6 +311,10 @@ export const service: DefaultServiceConfig = {
           text: 'BBC qunnami',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -318,6 +318,10 @@ export const service: DefaultServiceConfig = {
           text: 'Contactez la BBC',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/amharic.ts
+++ b/src/app/lib/config/services/amharic.ts
@@ -362,6 +362,10 @@ export const service: DefaultServiceConfig = {
           text: 'ቢቢሲን ያግኙ',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/arabic.ts
+++ b/src/app/lib/config/services/arabic.ts
@@ -399,6 +399,10 @@ export const service: DefaultServiceConfig = {
           text: 'اتصل بـ بي بي سي',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/azeri.ts
+++ b/src/app/lib/config/services/azeri.ts
@@ -303,6 +303,14 @@ export const service: DefaultServiceConfig = {
           text: 'BBC ilə Əlaqə',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/azeri.ts
+++ b/src/app/lib/config/services/azeri.ts
@@ -307,10 +307,6 @@ export const service: DefaultServiceConfig = {
           text: 'Other Languages',
         },
         {
-          href: 'https://www.bbc.com/ws/languages',
-          text: 'Other Languages',
-        },
-        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -312,6 +312,14 @@ export const service: DefaultServiceConfig = {
           text: 'বিবিসির সাথে যোগাযোগ করুন',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -316,10 +316,6 @@ export const service: DefaultServiceConfig = {
           text: 'Other Languages',
         },
         {
-          href: 'https://www.bbc.com/ws/languages',
-          text: 'Other Languages',
-        },
-        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/burmese.ts
+++ b/src/app/lib/config/services/burmese.ts
@@ -334,6 +334,10 @@ export const service: DefaultServiceConfig = {
           text: 'ဘီဘီစီကို ဆက်သွယ်ရန်',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/gahuza.ts
+++ b/src/app/lib/config/services/gahuza.ts
@@ -334,6 +334,10 @@ export const service: DefaultServiceConfig = {
           text: 'Vugana na BBC',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/gujarati.ts
+++ b/src/app/lib/config/services/gujarati.ts
@@ -309,6 +309,14 @@ export const service: DefaultServiceConfig = {
           text: 'BBC નો સંપર્ક કરો',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/gujarati.ts
+++ b/src/app/lib/config/services/gujarati.ts
@@ -313,10 +313,6 @@ export const service: DefaultServiceConfig = {
           text: 'Other Languages',
         },
         {
-          href: 'https://www.bbc.com/ws/languages',
-          text: 'Other Languages',
-        },
-        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/hausa.ts
+++ b/src/app/lib/config/services/hausa.ts
@@ -396,6 +396,10 @@ export const service: DefaultServiceConfig = {
           text: 'Tuntubi BBC',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -413,6 +413,10 @@ export const service: DefaultServiceConfig = {
           text: 'बीबीसी से संपर्क',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/igbo.ts
+++ b/src/app/lib/config/services/igbo.ts
@@ -327,6 +327,10 @@ export const service: DefaultServiceConfig = {
           text: 'Kpọtụrụ BBC',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/indonesia.ts
+++ b/src/app/lib/config/services/indonesia.ts
@@ -337,6 +337,10 @@ export const service: DefaultServiceConfig = {
           text: 'Hubungi BBC',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/japanese.ts
+++ b/src/app/lib/config/services/japanese.ts
@@ -292,6 +292,10 @@ export const service: DefaultServiceConfig = {
           text: 'BBC に連絡する',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -310,6 +310,10 @@ export const service: DefaultServiceConfig = {
           text: '고객센터',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/kyrgyz.ts
+++ b/src/app/lib/config/services/kyrgyz.ts
@@ -311,6 +311,10 @@ export const service: DefaultServiceConfig = {
           text: 'Би-Би-Си менен байланышыңыз',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -321,6 +321,10 @@ export const service: DefaultServiceConfig = {
           text: 'बीबीसीशी संपर्क साधाा',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -388,6 +388,10 @@ export const service: DefaultServiceConfig = {
           text: 'Escribe a BBC Mundo',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/nepali.ts
+++ b/src/app/lib/config/services/nepali.ts
@@ -307,6 +307,10 @@ export const service: DefaultServiceConfig = {
           text: 'बीबीसीलाई सम्पर्क गर्नुहोस्',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/pashto.ts
+++ b/src/app/lib/config/services/pashto.ts
@@ -321,6 +321,10 @@ export const service: DefaultServiceConfig = {
           text: 'زموږ سره اړیکي',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -421,6 +421,14 @@ export const service: DefaultServiceConfig = {
           text: 'تماس با بی بی سی',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -425,10 +425,6 @@ export const service: DefaultServiceConfig = {
           text: 'Other Languages',
         },
         {
-          href: 'https://www.bbc.com/ws/languages',
-          text: 'Other Languages',
-        },
-        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/pidgin.ts
+++ b/src/app/lib/config/services/pidgin.ts
@@ -338,6 +338,10 @@ export const service: DefaultServiceConfig = {
           text: 'Call BBC',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -398,6 +398,10 @@ export const service: DefaultServiceConfig = {
           text: 'Contate a BBC',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/punjabi.ts
+++ b/src/app/lib/config/services/punjabi.ts
@@ -326,6 +326,10 @@ export const service: DefaultServiceConfig = {
           text: 'ਬੀਬੀਸੀ ਨਾਲ ਸੰਪਰਕ ਕਰੋ',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -421,6 +421,10 @@ export const service: DefaultServiceConfig = {
           text: 'Связаться с Би-би-си',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -91,6 +91,10 @@ export const service: SerbianConfig = {
           text: 'Kontaktirajte BBC',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',
@@ -482,6 +486,10 @@ export const service: SerbianConfig = {
         {
           href: 'https://www.bbc.co.uk/serbian/send/u50853665',
           text: 'Контактирајте ББЦ',
+        },
+        {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
         },
         {
           id: 'COOKIE_SETTINGS',

--- a/src/app/lib/config/services/sinhala.ts
+++ b/src/app/lib/config/services/sinhala.ts
@@ -299,6 +299,10 @@ export const service: DefaultServiceConfig = {
           text: 'බීබීසී ය අමතන්න',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/somali.ts
+++ b/src/app/lib/config/services/somali.ts
@@ -319,10 +319,6 @@ export const service: DefaultServiceConfig = {
           text: 'Other Languages',
         },
         {
-          href: 'https://www.bbc.com/ws/languages',
-          text: 'Other Languages',
-        },
-        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/somali.ts
+++ b/src/app/lib/config/services/somali.ts
@@ -315,6 +315,14 @@ export const service: DefaultServiceConfig = {
           text: 'La xiriir BBC',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/swahili.ts
+++ b/src/app/lib/config/services/swahili.ts
@@ -313,6 +313,10 @@ export const service: DefaultServiceConfig = {
           text: 'Wasiliana na BBC',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/tamil.ts
+++ b/src/app/lib/config/services/tamil.ts
@@ -393,6 +393,10 @@ export const service: DefaultServiceConfig = {
           text: 'பிபிசியுடன் தொடர்பு கொள்ள',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/telugu.ts
+++ b/src/app/lib/config/services/telugu.ts
@@ -312,6 +312,10 @@ export const service: DefaultServiceConfig = {
           text: 'BBCని సంప్రదించండి',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/thai.ts
+++ b/src/app/lib/config/services/thai.ts
@@ -330,6 +330,10 @@ export const service: DefaultServiceConfig = {
           text: 'ติดต่อบีบีซี',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/tigrinya.ts
+++ b/src/app/lib/config/services/tigrinya.ts
@@ -287,6 +287,10 @@ export const service: DefaultServiceConfig = {
           text: 'ንቢቢሲ የዛርቡ',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -305,6 +305,10 @@ export const service: DefaultServiceConfig = {
           text: "BBC'ye ulaş",
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/ukrainian.ts
+++ b/src/app/lib/config/services/ukrainian.ts
@@ -317,6 +317,10 @@ const baseServiceConfig = {
         text: 'Напишіть на ВВС',
       },
       {
+        href: 'https://www.bbc.com/ws/languages',
+        text: 'Other Languages',
+      },
+      {
         id: 'COOKIE_SETTINGS',
         href: '#',
         text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/urdu.ts
+++ b/src/app/lib/config/services/urdu.ts
@@ -394,6 +394,10 @@ export const service: DefaultServiceConfig = {
           text: 'بی بی سی سے رابطہ کریں',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -312,6 +312,10 @@ const defaultCyrillicConfig = {
         text: "'Bi-bi-si bilan bog’laning'",
       },
       {
+        href: 'https://www.bbc.com/ws/languages',
+        text: 'Other Languages',
+      },
+      {
         id: 'COOKIE_SETTINGS',
         href: '#',
         text: 'Do not share or sell my info',
@@ -641,6 +645,10 @@ export const service: UzbekConfig = {
         {
           href: 'https://www.bbc.co.uk/uzbek/send/u50853929',
           text: "'Bi-bi-si bilan bog’laning'",
+        },
+        {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
         },
         {
           id: 'COOKIE_SETTINGS',

--- a/src/app/lib/config/services/vietnamese.ts
+++ b/src/app/lib/config/services/vietnamese.ts
@@ -308,6 +308,10 @@ export const service: DefaultServiceConfig = {
           text: 'Liên hệ BBC',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/yoruba.ts
+++ b/src/app/lib/config/services/yoruba.ts
@@ -294,6 +294,10 @@ export const service: DefaultServiceConfig = {
           text: 'Kàn sí BBC',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',

--- a/src/app/lib/config/services/zhongwen.ts
+++ b/src/app/lib/config/services/zhongwen.ts
@@ -100,6 +100,10 @@ export const service: ZhongwenConfig = {
           text: '联络BBC',
         },
         {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
+        },
+        {
           id: 'COOKIE_SETTINGS',
           href: '#',
           text: 'Do not share or sell my info',
@@ -401,6 +405,10 @@ export const service: ZhongwenConfig = {
         {
           href: 'https://www.bbc.com/zhongwen/trad/institutional-38664417',
           text: '聯絡BBC',
+        },
+        {
+          href: 'https://www.bbc.com/ws/languages',
+          text: 'Other Languages',
         },
         {
           id: 'COOKIE_SETTINGS',

--- a/src/integration/pages/articles/hausa/__snapshots__/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/hausa/__snapshots__/__snapshots__/amp.test.js.snap
@@ -145,6 +145,13 @@ exports[`AMP Articles Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Articles Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Articles Footer Anchors should match text and url 9`] = `
+{
   "text": "Karanta hanyoyin da muke bi dangane da adireshin waje.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/articles/hausa/__snapshots__/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/hausa/__snapshots__/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Articles Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Articles Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Articles Footer Anchors should match text and url 9`] = `
+{
   "text": "Karanta hanyoyin da muke bi dangane da adireshin waje.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
@@ -152,13 +152,6 @@ exports[`AMP Articles Footer Anchors should match text and url 8`] = `
 
 exports[`AMP Articles Footer Anchors should match text and url 9`] = `
 {
-  "text": "Other Languages",
-  "url": "https://www.bbc.com/ws/languages",
-}
-`;
-
-exports[`AMP Articles Footer Anchors should match text and url 10`] = `
-{
   "text": "سیاست ما درباره لینک دادن به سایت های دیگر.",
   "url": "https://www.bbc.com/persian/institutional/2011/04/000001_links",
 }

--- a/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
@@ -145,6 +145,20 @@ exports[`AMP Articles Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Articles Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Articles Footer Anchors should match text and url 9`] = `
+{
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Articles Footer Anchors should match text and url 10`] = `
+{
   "text": "سیاست ما درباره لینک دادن به سایت های دیگر.",
   "url": "https://www.bbc.com/persian/institutional/2011/04/000001_links",
 }

--- a/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,20 @@ exports[`Canonical Articles Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Articles Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Articles Footer Anchors should match text and url 9`] = `
+{
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Articles Footer Anchors should match text and url 10`] = `
+{
   "text": "سیاست ما درباره لینک دادن به سایت های دیگر.",
   "url": "https://www.bbc.com/persian/institutional/2011/04/000001_links",
 }

--- a/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
@@ -62,13 +62,6 @@ exports[`Canonical Articles Footer Anchors should match text and url 8`] = `
 
 exports[`Canonical Articles Footer Anchors should match text and url 9`] = `
 {
-  "text": "Other Languages",
-  "url": "https://www.bbc.com/ws/languages",
-}
-`;
-
-exports[`Canonical Articles Footer Anchors should match text and url 10`] = `
-{
   "text": "سیاست ما درباره لینک دادن به سایت های دیگر.",
   "url": "https://www.bbc.com/persian/institutional/2011/04/000001_links",
 }

--- a/src/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.js.snap
@@ -152,13 +152,6 @@ exports[`AMP Articles Footer Anchors should match text and url 8`] = `
 
 exports[`AMP Articles Footer Anchors should match text and url 9`] = `
 {
-  "text": "Other Languages",
-  "url": "https://www.bbc.com/ws/languages",
-}
-`;
-
-exports[`AMP Articles Footer Anchors should match text and url 10`] = `
-{
   "text": "سیاست ما درباره لینک دادن به سایت های دیگر.",
   "url": "https://www.bbc.com/persian/institutional/2011/04/000001_links",
 }

--- a/src/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.js.snap
@@ -145,6 +145,20 @@ exports[`AMP Articles Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Articles Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Articles Footer Anchors should match text and url 9`] = `
+{
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Articles Footer Anchors should match text and url 10`] = `
+{
   "text": "سیاست ما درباره لینک دادن به سایت های دیگر.",
   "url": "https://www.bbc.com/persian/institutional/2011/04/000001_links",
 }

--- a/src/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,20 @@ exports[`Canonical Articles Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Articles Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Articles Footer Anchors should match text and url 9`] = `
+{
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Articles Footer Anchors should match text and url 10`] = `
+{
   "text": "سیاست ما درباره لینک دادن به سایت های دیگر.",
   "url": "https://www.bbc.com/persian/institutional/2011/04/000001_links",
 }

--- a/src/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.js.snap
@@ -62,13 +62,6 @@ exports[`Canonical Articles Footer Anchors should match text and url 8`] = `
 
 exports[`Canonical Articles Footer Anchors should match text and url 9`] = `
 {
-  "text": "Other Languages",
-  "url": "https://www.bbc.com/ws/languages",
-}
-`;
-
-exports[`Canonical Articles Footer Anchors should match text and url 10`] = `
-{
   "text": "سیاست ما درباره لینک دادن به سایت های دیگر.",
   "url": "https://www.bbc.com/persian/institutional/2011/04/000001_links",
 }

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
@@ -189,6 +189,13 @@ exports[`AMP Feature Index page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Feature Index page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Feature Index page Footer Anchors should match text and url 9`] = `
+{
   "text": "Découvrez notre approche en matière de liens externes.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Feature Index page Footer Anchors should match text and url 7
 
 exports[`Canonical Feature Index page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Feature Index page Footer Anchors should match text and url 9`] = `
+{
   "text": "Découvrez notre approche en matière de liens externes.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/featureIdxPage/urdu/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/featureIdxPage/urdu/__snapshots__/amp.test.js.snap
@@ -189,6 +189,13 @@ exports[`AMP Feature Index page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Feature Index page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Feature Index page Footer Anchors should match text and url 9`] = `
+{
   "text": "بیرونی لنکس کے بارے میں ہماری پالیسی.",
   "url": "https://www.bbc.com/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/featureIdxPage/urdu/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/urdu/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Feature Index page Footer Anchors should match text and url 7
 
 exports[`Canonical Feature Index page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Feature Index page Footer Anchors should match text and url 9`] = `
+{
   "text": "بیرونی لنکس کے بارے میں ہماری پالیسی.",
   "url": "https://www.bbc.com/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/homePage/arabic/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/homePage/arabic/__snapshots__/amp.test.js.snap
@@ -228,6 +228,13 @@ exports[`AMP Home Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Home Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Home Page Footer Anchors should match text and url 9`] = `
+{
   "text": "سياستنا بخصوص الروابط الخارجية.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/homePage/arabic/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/arabic/__snapshots__/canonical.test.js.snap
@@ -69,12 +69,19 @@ exports[`Canonical Home Page Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Home Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Home Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Do not share or sell my info",
   "url": "#",
 }
 `;
 
-exports[`Canonical Home Page Footer Anchors should match text and url 9`] = `
+exports[`Canonical Home Page Footer Anchors should match text and url 10`] = `
 {
   "text": "سياستنا بخصوص الروابط الخارجية.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",

--- a/src/integration/pages/homePage/hindi/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/homePage/hindi/__snapshots__/amp.test.js.snap
@@ -178,6 +178,13 @@ exports[`AMP Home Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Home Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Home Page Footer Anchors should match text and url 9`] = `
+{
   "text": "बाहरी साइटों का लिंक देने की हमारी नीति के बारे में पढ़ें.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/homePage/hindi/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/hindi/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Home Page Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Home Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Home Page Footer Anchors should match text and url 9`] = `
+{
   "text": "बाहरी साइटों का लिंक देने की हमारी नीति के बारे में पढ़ें.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/homePage/kyrgyz/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/homePage/kyrgyz/__snapshots__/amp.test.js.snap
@@ -178,6 +178,13 @@ exports[`AMP Home Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Home Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Home Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Башка интернет сайттардын мазмуну боюнча биздин позиция.",
   "url": "https://www.bbc.com/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/homePage/kyrgyz/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/kyrgyz/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Home Page Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Home Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Home Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Башка интернет сайттардын мазмуну боюнча биздин позиция.",
   "url": "https://www.bbc.com/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/homePage/serbianCyr/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/homePage/serbianCyr/__snapshots__/amp.test.js.snap
@@ -178,6 +178,13 @@ exports[`AMP Home Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Home Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Home Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Прочитајте наша правила о линковању других сајтова.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/homePage/serbianCyr/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/serbianCyr/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Home Page Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Home Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Home Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Прочитајте наша правила о линковању других сајтова.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/homePage/serbianLat/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/homePage/serbianLat/__snapshots__/amp.test.js.snap
@@ -178,6 +178,13 @@ exports[`AMP Home Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Home Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Home Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Pročitajte naša pravila o linkovanju drugih sajtova.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/homePage/serbianLat/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/serbianLat/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Home Page Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Home Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Home Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Pročitajte naša pravila o linkovanju drugih sajtova.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/liveRadio/gahuza/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/gahuza/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Live Radio Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Live Radio Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Live Radio Footer Anchors should match text and url 9`] = `
+{
   "text": "Soma ibijanye n'aho duhagaze ku mihora ijana ahandi",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Korean Live Radio Page Footer Anchors should match text and u
 
 exports[`Canonical Korean Live Radio Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Korean Live Radio Page Footer Anchors should match text and url 9`] = `
+{
   "text": "외부 링크에 대한 본사 정책 보기",
   "url": "https://www.bbc.com/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/liveRadio/sinhala/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/sinhala/__snapshots__/canonical.test.js.snap
@@ -48,6 +48,13 @@ exports[`Canonical Sinhala Live Radio Page Footer Anchors should match text and 
 
 exports[`Canonical Sinhala Live Radio Page Footer Anchors should match text and url 7`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Sinhala Live Radio Page Footer Anchors should match text and url 8`] = `
+{
   "text": "බාහිර යොමු කෙරෙහි අපගේ ප්‍රවේශය ගැන කියවන්න.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/mediaArticlePage/pidgin/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaArticlePage/pidgin/__snapshots__/amp.test.js.snap
@@ -189,6 +189,13 @@ exports[`AMP Media Article Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Media Article Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Media Article Page Footer Anchors should match text and url 9`] = `
+{
   "text": "De way wey we de take go external link.",
   "url": "https://www.bbc.com/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/mediaArticlePage/pidgin/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaArticlePage/pidgin/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Media Article Page Footer Anchors should match text and url 7
 
 exports[`Canonical Media Article Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Media Article Page Footer Anchors should match text and url 9`] = `
+{
   "text": "De way wey we de take go external link.",
   "url": "https://www.bbc.com/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/amp.test.js.snap
@@ -189,6 +189,13 @@ exports[`AMP Media Asset Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Media Asset Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Media Asset Page Footer Anchors should match text and url 9`] = `
+{
   "text": "سياستنا بخصوص الروابط الخارجية.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Media Asset Page Footer Anchors should match text and url 7`]
 
 exports[`Canonical Media Asset Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Media Asset Page Footer Anchors should match text and url 9`] = `
+{
   "text": "سياستنا بخصوص الروابط الخارجية.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
@@ -196,13 +196,6 @@ exports[`AMP Media Asset Page Footer Anchors should match text and url 8`] = `
 
 exports[`AMP Media Asset Page Footer Anchors should match text and url 9`] = `
 {
-  "text": "Other Languages",
-  "url": "https://www.bbc.com/ws/languages",
-}
-`;
-
-exports[`AMP Media Asset Page Footer Anchors should match text and url 10`] = `
-{
   "text": "سیاست ما درباره لینک دادن به سایت های دیگر.",
   "url": "https://www.bbc.com/persian/institutional/2011/04/000001_links",
 }

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
@@ -189,6 +189,20 @@ exports[`AMP Media Asset Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Media Asset Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Media Asset Page Footer Anchors should match text and url 9`] = `
+{
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Media Asset Page Footer Anchors should match text and url 10`] = `
+{
   "text": "سیاست ما درباره لینک دادن به سایت های دیگر.",
   "url": "https://www.bbc.com/persian/institutional/2011/04/000001_links",
 }

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
@@ -62,13 +62,6 @@ exports[`Canonical Media Asset Page Footer Anchors should match text and url 8`]
 
 exports[`Canonical Media Asset Page Footer Anchors should match text and url 9`] = `
 {
-  "text": "Other Languages",
-  "url": "https://www.bbc.com/ws/languages",
-}
-`;
-
-exports[`Canonical Media Asset Page Footer Anchors should match text and url 10`] = `
-{
   "text": "سیاست ما درباره لینک دادن به سایت های دیگر.",
   "url": "https://www.bbc.com/persian/institutional/2011/04/000001_links",
 }

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,20 @@ exports[`Canonical Media Asset Page Footer Anchors should match text and url 7`]
 
 exports[`Canonical Media Asset Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Media Asset Page Footer Anchors should match text and url 9`] = `
+{
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Media Asset Page Footer Anchors should match text and url 10`] = `
+{
   "text": "سیاست ما درباره لینک دادن به سایت های دیگر.",
   "url": "https://www.bbc.com/persian/institutional/2011/04/000001_links",
 }

--- a/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/amp.test.js.snap
@@ -189,6 +189,13 @@ exports[`AMP Media Asset Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Media Asset Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Media Asset Page Footer Anchors should match text and url 9`] = `
+{
   "text": "De way wey we de take go external link.",
   "url": "https://www.bbc.com/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Media Asset Page Footer Anchors should match text and url 7`]
 
 exports[`Canonical Media Asset Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Media Asset Page Footer Anchors should match text and url 9`] = `
+{
   "text": "De way wey we de take go external link.",
   "url": "https://www.bbc.com/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
@@ -189,6 +189,13 @@ exports[`AMP Most Read Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Most Read Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Most Read Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Lee sobre nuestra postura acerca de enlaces externos.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Most Read Page Footer Anchors should match text and url 7`] =
 
 exports[`Canonical Most Read Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Most Read Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Lee sobre nuestra postura acerca de enlaces externos.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/mostReadPage/vietnamese/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/vietnamese/__snapshots__/amp.test.js.snap
@@ -189,6 +189,13 @@ exports[`AMP Most Read Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Most Read Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Most Read Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Tìm hiểu cách chúng tôi tiếp cận việc dẫn tới trang ngoài",
   "url": "https://www.bbc.com/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/mostReadPage/vietnamese/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/vietnamese/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Most Read Page Footer Anchors should match text and url 7`] =
 
 exports[`Canonical Most Read Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Most Read Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Tìm hiểu cách chúng tôi tiếp cận việc dẫn tới trang ngoài",
   "url": "https://www.bbc.com/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/onDemandAudioPage/gahuza.expired/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/gahuza.expired/__snapshots__/canonical.test.js.snap
@@ -67,6 +67,13 @@ exports[`Canonical On Demand Audio Page Footer Anchors should match text and url
 
 exports[`Canonical On Demand Audio Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical On Demand Audio Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Soma ibijanye n'aho duhagaze ku mihora ijana ahandi",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/onDemandAudioPage/indonesia.expired/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/indonesia.expired/__snapshots__/canonical.test.js.snap
@@ -67,6 +67,13 @@ exports[`Canonical On Demand Audio Page Footer Anchors should match text and url
 
 exports[`Canonical On Demand Audio Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical On Demand Audio Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Baca tentang peraturan baru terkait link eksternal.",
   "url": "https://www.bbc.com/indonesia/institutional/2011/02/000001_links",
 }

--- a/src/integration/pages/onDemandAudioPage/indonesia/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/indonesia/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical On Demand Audio Page Footer Anchors should match text and url
 
 exports[`Canonical On Demand Audio Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical On Demand Audio Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Baca tentang peraturan baru terkait link eksternal.",
   "url": "https://www.bbc.com/indonesia/institutional/2011/02/000001_links",
 }

--- a/src/integration/pages/onDemandAudioPage/pashto.expired/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/pashto.expired/__snapshots__/canonical.test.js.snap
@@ -67,6 +67,13 @@ exports[`Canonical On Demand Audio Page Footer Anchors should match text and url
 
 exports[`Canonical On Demand Audio Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical On Demand Audio Page Footer Anchors should match text and url 9`] = `
+{
   "text": "د نورو ویبپاڼو لینکولو په اړه زموږ تګلاره.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/onDemandAudioPage/pashto/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/pashto/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical On Demand Audio Page Footer Anchors should match text and url
 
 exports[`Canonical On Demand Audio Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical On Demand Audio Page Footer Anchors should match text and url 9`] = `
+{
   "text": "د نورو ویبپاڼو لینکولو په اړه زموږ تګلاره.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/onDemandAudioPage/pashtoBrand/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/pashtoBrand/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical On Demand Audio Page Footer Anchors should match text and url
 
 exports[`Canonical On Demand Audio Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical On Demand Audio Page Footer Anchors should match text and url 9`] = `
+{
   "text": "د نورو ویبپاڼو لینکولو په اړه زموږ تګلاره.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/onDemandTVPage/hausa/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/hausa/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical On Demand T V Page Footer Anchors should match text and url 7
 
 exports[`Canonical On Demand T V Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical On Demand T V Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Karanta hanyoyin da muke bi dangane da adireshin waje.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/onDemandTVPage/pashto.expired/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/pashto.expired/__snapshots__/canonical.test.js.snap
@@ -65,6 +65,13 @@ exports[`Canonical Pashto On Demand TV Page Footer Anchors should match text and
 
 exports[`Canonical Pashto On Demand TV Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Pashto On Demand TV Page Footer Anchors should match text and url 9`] = `
+{
   "text": "د نورو ویبپاڼو لینکولو په اړه زموږ تګلاره.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/onDemandTVPage/pashtoBrand/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/pashtoBrand/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical On Demand T V Page Footer Anchors should match text and url 7
 
 exports[`Canonical On Demand T V Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical On Demand T V Page Footer Anchors should match text and url 9`] = `
+{
   "text": "د نورو ویبپاڼو لینکولو په اړه زموږ تګلاره.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
@@ -189,6 +189,13 @@ exports[`AMP Photo Gallery Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Photo Gallery Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Photo Gallery Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Lee sobre nuestra postura acerca de enlaces externos.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Photo Gallery Page Footer Anchors should match text and url 7
 
 exports[`Canonical Photo Gallery Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Photo Gallery Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Lee sobre nuestra postura acerca de enlaces externos.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/photoGalleryPage/thai/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/thai/__snapshots__/amp.test.js.snap
@@ -189,6 +189,13 @@ exports[`AMP Photo Gallery Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Photo Gallery Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Photo Gallery Page Footer Anchors should match text and url 9`] = `
+{
   "text": "อ่านเกี่ยวกับแนวทางของเราในการติดต่อกับลิงก์ภายนอก",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/photoGalleryPage/thai/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/thai/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Photo Gallery Page Footer Anchors should match text and url 7
 
 exports[`Canonical Photo Gallery Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Photo Gallery Page Footer Anchors should match text and url 9`] = `
+{
   "text": "อ่านเกี่ยวกับแนวทางของเราในการติดต่อกับลิงก์ภายนอก",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/podcastPage/portugueseBrand/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/podcastPage/portugueseBrand/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Podcast Page Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Podcast Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Podcast Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Leia sobre nossa política em relação a links externos.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/podcastPage/portugueseEpisode/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/podcastPage/portugueseEpisode/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Podcast Page Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Podcast Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Podcast Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Leia sobre nossa política em relação a links externos.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/storyPage/hausa/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/hausa/__snapshots__/amp.test.js.snap
@@ -189,6 +189,13 @@ exports[`AMP Story Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Story Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Story Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Karanta hanyoyin da muke bi dangane da adireshin waje.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/storyPage/hausa/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/hausa/__snapshots__/canonical.test.js.snap
@@ -55,12 +55,19 @@ exports[`Canonical Story Page Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Story Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Story Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Do not share or sell my info",
   "url": "#",
 }
 `;
 
-exports[`Canonical Story Page Footer Anchors should match text and url 9`] = `
+exports[`Canonical Story Page Footer Anchors should match text and url 10`] = `
 {
   "text": "Karanta hanyoyin da muke bi dangane da adireshin waje.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",

--- a/src/integration/pages/storyPage/kyrgyz/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/kyrgyz/__snapshots__/amp.test.js.snap
@@ -189,6 +189,13 @@ exports[`AMP Story Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Story Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Story Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Башка интернет сайттардын мазмуну боюнча биздин позиция.",
   "url": "https://www.bbc.com/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Story Page Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Story Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Story Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Башка интернет сайттардын мазмуну боюнча биздин позиция.",
   "url": "https://www.bbc.com/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
@@ -189,6 +189,13 @@ exports[`AMP Story Page Footer Anchors should match text and url 7`] = `
 
 exports[`AMP Story Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`AMP Story Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Lee sobre nuestra postura acerca de enlaces externos.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -55,12 +55,19 @@ exports[`Canonical Story Page Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Story Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Story Page Footer Anchors should match text and url 9`] = `
+{
   "text": "Do not share or sell my info",
   "url": "#",
 }
 `;
 
-exports[`Canonical Story Page Footer Anchors should match text and url 9`] = `
+exports[`Canonical Story Page Footer Anchors should match text and url 10`] = `
 {
   "text": "Lee sobre nuestra postura acerca de enlaces externos.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",

--- a/src/integration/pages/topicPage/pidgin/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/topicPage/pidgin/__snapshots__/canonical.test.js.snap
@@ -55,6 +55,13 @@ exports[`Canonical Topic Page Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Topic Page Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Topic Page Footer Anchors should match text and url 9`] = `
+{
   "text": "De way wey we de take go external link.",
   "url": "https://www.bbc.com/editorialguidelines/guidance/feeds-and-links",
 }

--- a/ws-nextjs-app/integration/pages/live/serbian/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/live/serbian/__snapshots__/canonical.test.ts.snap
@@ -53,6 +53,13 @@ exports[`Canonical Live Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Live Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Live Footer Anchors should match text and url 9`] = `
+{
   "text": "Pročitajte naša pravila o linkovanju drugih sajtova.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/ws-nextjs-app/integration/pages/send/mundo/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/send/mundo/__snapshots__/canonical.test.ts.snap
@@ -53,6 +53,13 @@ exports[`Canonical Send Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Send Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Send Footer Anchors should match text and url 9`] = `
+{
   "text": "Lee sobre nuestra postura acerca de enlaces externos.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }

--- a/ws-nextjs-app/integration/pages/send/somaliFileUpload/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/send/somaliFileUpload/__snapshots__/canonical.test.ts.snap
@@ -53,6 +53,13 @@ exports[`Canonical Send Footer Anchors should match text and url 7`] = `
 
 exports[`Canonical Send Footer Anchors should match text and url 8`] = `
 {
+  "text": "Other Languages",
+  "url": "https://www.bbc.com/ws/languages",
+}
+`;
+
+exports[`Canonical Send Footer Anchors should match text and url 9`] = `
+{
   "text": "Akhri xogta ku saabsan sida aan u abaarno bogagga dibadda.",
   "url": "https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links",
 }


### PR DESCRIPTION
Resolves JIRA [[1429]](https://jira.dev.bbc.co.uk/browse/WSTEAMA-1429)

Overall changes
======

Added this 
```
{
          href: 'https://www.bbc.com/ws/languages',
          text: 'Other Languages',
        },
```

to the array of link objects in each of the services' config files, after the last one I see present on the current footer.

Code changes
======

- _A bullet point list of key code changes that have been made._

Testing
======

To test locally, check out this branch and visit a page from each service. Check that the 'Other Languages' link is there in the last position in that links section (before copyright at the bottom), and links to  https://www.bbc.com/ws/languages.

Do an a11y check on LTR and RTL that the links are announced correctly by screenreaders as a link that is the last in the list.

Same testing for test and live environments.

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
