### PR TITLE
WSTEAMA-1428 - Update README docs for JumpTo component

### DIFF
--- a/src/app/components/JumpTo/README.md
+++ b/src/app/components/JumpTo/README.md
@@ -8,5 +8,5 @@ This component is typically used in articles with multiple headings, enhancing c
 
 | Name              | type                  | Description                                     |
 | ----------------- | --------------------- | ----------------------------------------------- |
-| jumpToData        | object                | Contains article sections with titles and IDs   |
+| jumpToData        | object                | Contains article headings with titles and IDs   |
 | eventTrackingData | eventTrackingMetadata | Contains click and view tracking data for Piano |

--- a/src/app/components/JumpTo/README.md
+++ b/src/app/components/JumpTo/README.md
@@ -1,6 +1,6 @@
 ## Description
 
-The JumpTo component serves as an in-page navigation menu, similar to a table of contents, allowing users to quickly jump to specific headings within an article. This component renders an `H2` heading, a list of anchor titles as `anchor` links, and groups them within a `navigation` landmark. When a link is actioned, the page scrolls down to the relevant heading, identified by matching anchor `ids`.
+The JumpTo component serves as an in-page navigation menu, similar to a table of contents, allowing users to quickly jump to specific headings within an article. This component renders text as a `strong` element, a list of anchor titles as `anchor` links, and groups them within a `navigation` landmark. When a link is actioned, the page scrolls down to the relevant heading, identified by matching anchor `ids`.
 
 This component is typically used in articles with multiple headings, enhancing content findability by providing quick navigation options.
 

--- a/src/app/components/JumpTo/README.md
+++ b/src/app/components/JumpTo/README.md
@@ -1,6 +1,6 @@
 ## Description
 
-The JumpTo component serves as an in-page navigation menu, similar to a table of contents, allowing users to quickly jump to specific headings within an article. This component renders text as a `strong` element, a list of anchor titles as `anchor` links, and groups them within a `navigation` landmark. When a link is actioned, the page scrolls down to the relevant heading, identified by matching anchor `ids`.
+The JumpTo component serves as an in-page navigation menu, similar to a table of contents, allowing users to quickly jump to specific headings within an article. This component renders text as a `strong` element, a list of `anchor` links, and groups them within a `navigation` landmark. When a link is actioned, the page scrolls down to the relevant heading, identified by matching anchor `ids`.
 
 This component is typically used in articles with multiple headings, enhancing content findability by providing quick navigation options.
 

--- a/src/app/components/JumpTo/README.md
+++ b/src/app/components/JumpTo/README.md
@@ -1,8 +1,8 @@
 ## Description - WORK IN PROGRESS - COMPLETE IN SUBTASK
 
-The JumpTo component serves as an in-page navigation menu, similar to a table of contents, allowing users to quickly jump to specific headings within an article. This component renders an `H2`, a list of section titles as `anchor` links, and groups them within a `navigation` landmark. When a link is actioned, the page scrolls down to the relevant section, identified by matching anchor `ids`.
+The JumpTo component serves as an in-page navigation menu, similar to a table of contents, allowing users to quickly jump to specific headings within an article. This component renders an `H2` heading, a list of anchor titles as `anchor` links, and groups them within a `navigation` landmark. When a link is actioned, the page scrolls down to the relevant heading, identified by matching anchor `ids`.
 
-This component is typically used in articles with multiple headings, enhancing content accessibility by providing quick navigation options....
+This component is typically used in articles with multiple headings, enhancing content findability by providing quick navigation options.
 
 ## Props
 

--- a/src/app/components/JumpTo/README.md
+++ b/src/app/components/JumpTo/README.md
@@ -1,4 +1,4 @@
-## Description - WORK IN PROGRESS - COMPLETE IN SUBTASK
+## Description
 
 The JumpTo component serves as an in-page navigation menu, similar to a table of contents, allowing users to quickly jump to specific headings within an article. This component renders an `H2` heading, a list of anchor titles as `anchor` links, and groups them within a `navigation` landmark. When a link is actioned, the page scrolls down to the relevant heading, identified by matching anchor `ids`.
 


### PR DESCRIPTION
Resolves JIRA [[1428](https://jira.dev.bbc.co.uk/browse/WSTEAMA-1428)]

Overall changes
======

Updates to README documentation following input from other engineers and our Accessibility Lead.

Code changes
======

- README file updated.

Testing
======
Can be viewed here - https://wsteama-1428-update-readme-docs-for-j--5d28eb3fe163f6002046d6fa.chromatic.com/?path=/docs/components-jumpto--readme&globals=backgrounds.grid:!false
