### PR TITLE
Update Brasil in-article podcast promo

### DIFF
--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -48,16 +48,16 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: true,
     showRelatedTopics: true,
     podcastPromo: {
-      title: 'Que História!',
-      brandTitle: 'Que História!',
-      brandDescription: 'A 3ª temporada com histórias reais incríveis',
+      title: 'A Raposa',
+      brandTitle: 'A Raposa',
+      brandDescription: 'O novo podcast investigativo da BBC News Brasil',
       image: {
-        src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0jfptnr.png',
-        alt: 'Logo: Que História!',
+        src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0jsx1gc.jpg',
+        alt: 'Logo: A Raposa',
       },
       linkLabel: {
         text: 'Episódios',
-        href: 'https://www.bbc.com/portuguese/podcasts/p07r3r3t',
+        href: 'https://www.bbc.com/portuguese/podcasts/p0cyhvny',
       },
       skipLink: {
         text: 'Pule %title% e continue lendo',


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Update Brasil's article podcast promo to promote their latest podcast

Code changes
======

- Edited podcastPromo section of src/app/lib/config/services/portuguese.ts 

Testing
======
1. Open an article on Brasils site: the podcat promo should show the A raposa image and open https://www.bbc.com/portuguese/podcasts/p0cyhvny

![image](https://github.com/user-attachments/assets/d4730f18-85ef-4dc9-acb8-01641302f034)



[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
