### PR TITLE
Remove US election topic link from Bangla, Russian and Swahili navs

### DIFF
--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -332,10 +332,6 @@ export const service: DefaultServiceConfig = {
         url: '/bengali',
       },
       {
-        title: 'যুক্তরাষ্ট্র নির্বাচন ২০২৪',
-        url: '/bengali/topics/cjlgjr0d2d2t',
-      },
-      {
         title: 'রাজনীতি',
         url: '/bengali/topics/cqywj91rkg6t',
       },

--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -445,10 +445,6 @@ export const service: DefaultServiceConfig = {
         url: '/russian/topics/cez0n29ggrdt',
       },
       {
-        title: 'Выборы в США',
-        url: '/russian/topics/ce802g1vrdgt',
-      },
-      {
         title: 'Истории',
         url: '/russian/topics/cv27xky1pppt',
       },

--- a/src/app/lib/config/services/swahili.ts
+++ b/src/app/lib/config/services/swahili.ts
@@ -332,10 +332,6 @@ export const service: DefaultServiceConfig = {
         url: '/swahili',
       },
       {
-        title: 'Uchaguzi wa Marekani 2024',
-        url: '/swahili/topics/c3v8qp1qz4xt',
-      },
-      {
         title: 'Michezo',
         url: '/swahili/topics/ckdxndddjkxt',
       },


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Removed links to US election topic pages from the nav bars of Bengali, Russian and Swahili

Code changes
======

- Edited Navigation section of src/app/lib/config/services/bengali.ts to remove election topic
- Edited Navigation section of src/app/lib/config/services/russian.ts to remove election topic
- Edited Navigation section of src/app/lib/config/services/swahili.ts to remove election topic


Testing
======
1. Open Russian front page  Выборы в США should not appear as third link in the navigation
2. Open Bengali front page যুক্তরাষ্ট্র নির্বাচন ২০২৪ shoulld not appear as second link in the navigation
3. Open Swahli front page Uchaguzi wa Marekani 2024  shoulld not appear as second link in the navigation


<img width="656" alt="swahili_nav" src="https://github.com/user-attachments/assets/d359f2b4-6d87-4cd8-9f93-e188c39150c3">
<img width="607" alt="russian_nav" src="https://github.com/user-attachments/assets/156ffe40-8897-4c50-8418-52fbd18b8576">
<img width="716" alt="bangal_nav" src="https://github.com/user-attachments/assets/8426d039-2a23-49d4-a31a-6b2cbc9ee1f7">




Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

