### PR TITLE
JumpTo - Remove `aria-labelledby` and add `border`s

### DIFF
--- a/src/app/components/JumpTo/index.styles.ts
+++ b/src/app/components/JumpTo/index.styles.ts
@@ -78,7 +78,7 @@ export default {
       textDecoration: 'underline',
       textUnderlineOffset: `${spacings.HALF}rem`,
     }),
-  linkTextActive: ({ spacings, palette }: Theme) =>
+  linkTextActive: ({ palette }: Theme) =>
     css({
       color: palette.POSTBOX,
 
@@ -87,7 +87,6 @@ export default {
         content: '""',
         top: 0,
         insetInlineStart: 0,
-        width: `${spacings.HALF}rem`,
         height: '100%',
         border: `${pixelsToRem(2)}rem solid ${palette.POSTBOX}`,
       },

--- a/src/app/components/JumpTo/index.styles.ts
+++ b/src/app/components/JumpTo/index.styles.ts
@@ -89,7 +89,8 @@ export default {
         insetInlineStart: 0,
         width: `${spacings.HALF}rem`,
         height: '100%',
-        backgroundColor: palette.POSTBOX,
+        border: `${pixelsToRem(2)}rem solid ${palette.POSTBOX}`,
+        // backgroundColor: palette.POSTBOX,
       },
     }),
 };

--- a/src/app/components/JumpTo/index.styles.ts
+++ b/src/app/components/JumpTo/index.styles.ts
@@ -90,7 +90,6 @@ export default {
         width: `${spacings.HALF}rem`,
         height: '100%',
         border: `${pixelsToRem(2)}rem solid ${palette.POSTBOX}`,
-        // backgroundColor: palette.POSTBOX,
       },
     }),
 };

--- a/src/app/components/JumpTo/index.styles.ts
+++ b/src/app/components/JumpTo/index.styles.ts
@@ -1,16 +1,19 @@
 import pixelsToRem from '#app/utilities/pixelsToRem';
 import { css, Theme } from '@emotion/react';
 
+const TRANSPARENT_BORDER_SPACING = 0.1875;
+
 export default {
   wrapper: ({ palette, spacings, mq }: Theme) =>
     css({
       backgroundColor: palette.WHITE,
-      padding: `${spacings.FULL}rem`,
+      padding: `${spacings.FULL - TRANSPARENT_BORDER_SPACING}rem`,
       marginInline: `${spacings.FULL}rem`,
       marginBottom: `${spacings.DOUBLE}rem`,
+      border: `${TRANSPARENT_BORDER_SPACING}rem solid transparent`,
 
       [mq.GROUP_1_MIN_WIDTH]: {
-        padding: `${spacings.DOUBLE}rem`,
+        padding: `${spacings.DOUBLE - TRANSPARENT_BORDER_SPACING}rem`,
       },
 
       [mq.GROUP_2_MIN_WIDTH]: {

--- a/src/app/components/JumpTo/index.tsx
+++ b/src/app/components/JumpTo/index.tsx
@@ -73,11 +73,9 @@ const JumpTo = ({ jumpToHeadings }: JumpToProps) => {
                 href={idWithHash}
                 onClick={e => linkClickHandler(e, idWithHash)}
                 css={styles.link}
-                aria-labelledby={`jump-to-heading-${sanitisedId}`}
                 data-testid={`jump-to-link-${sanitisedId}`}
               >
                 <span
-                  id={`jump-to-heading-${sanitisedId}`}
                   css={[styles.linkText, isActiveId && styles.linkTextActive]}
                 >
                   {heading}


### PR DESCRIPTION
Overall changes
======
- Removes `aria-labelledby` attributes as these are not needed
- Adds `border` to create the red bar indicator, rather than `backgroundColor` so that this still appears with forced-colours
- Adds transparent border around wrapper so that the component is clearly visible on forced-colours

Testing
======
1. Visit http://localhost:7080/hindi/articles/c3vl5kzd744o?renderer_env=live in a browser with forced colours
2. Interact with a link on the JumpTo component
3. Confirm the bar indicator still appears
4. Confirm that there is a border around the component

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
