### PR TITLE
Add focus-indicator to SubHeadline component

### DIFF
--- a/src/app/legacy/containers/Headings/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/Headings/__snapshots__/index.test.jsx.snap
@@ -568,8 +568,7 @@ exports[`Headings with plain text subheadline should render h2 containing correc
   font-weight: 700;
   font-style: normal;
   color: #141414;
-  margin: 0;
-  padding: 1.5rem 0;
+  margin: 1.5rem 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -588,8 +587,14 @@ exports[`Headings with plain text subheadline should render h2 containing correc
 
 @media (min-width: 37.5rem) {
   .emotion-2 {
-    padding-top: 2rem;
+    margin-top: 2rem;
   }
+}
+
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 <div>
@@ -1542,8 +1547,7 @@ exports[`Headings with subheadline data should render correctly 1`] = `
   font-weight: 700;
   font-style: normal;
   color: #141414;
-  margin: 0;
-  padding: 1.5rem 0;
+  margin: 1.5rem 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -1562,8 +1566,14 @@ exports[`Headings with subheadline data should render correctly 1`] = `
 
 @media (min-width: 37.5rem) {
   .emotion-2 {
-    padding-top: 2rem;
+    margin-top: 2rem;
   }
+}
+
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 <div>

--- a/src/app/legacy/psammead/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -134,8 +134,7 @@ exports[`SubHeading component should render correctly 1`] = `
   font-weight: 700;
   font-style: normal;
   color: #141414;
-  margin: 0;
-  padding: 1.5rem 0;
+  margin: 1.5rem 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -154,8 +153,14 @@ exports[`SubHeading component should render correctly 1`] = `
 
 @media (min-width: 37.5rem) {
   .emotion-0 {
-    padding-top: 2rem;
+    margin-top: 2rem;
   }
+}
+
+.emotion-0:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 <div>
@@ -176,8 +181,7 @@ exports[`SubHeading component should render correctly on page types that support
   font-weight: 700;
   font-style: normal;
   color: #F6F6F6;
-  margin: 0;
-  padding: 1.5rem 0;
+  margin: 1.5rem 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -196,8 +200,14 @@ exports[`SubHeading component should render correctly on page types that support
 
 @media (min-width: 37.5rem) {
   .emotion-0 {
-    padding-top: 2rem;
+    margin-top: 2rem;
   }
+}
+
+.emotion-0:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 <div>
@@ -218,8 +228,7 @@ exports[`SubHeading component should render correctly with an ID 1`] = `
   font-weight: 700;
   font-style: normal;
   color: #141414;
-  margin: 0;
-  padding: 1.5rem 0;
+  margin: 1.5rem 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -238,8 +247,14 @@ exports[`SubHeading component should render correctly with an ID 1`] = `
 
 @media (min-width: 37.5rem) {
   .emotion-0 {
-    padding-top: 2rem;
+    margin-top: 2rem;
   }
+}
+
+.emotion-0:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 <div>
@@ -261,8 +276,7 @@ exports[`SubHeading component should render correctly with arabic script typogra
   font-weight: 700;
   font-style: normal;
   color: #141414;
-  margin: 0;
-  padding: 1.5rem 0;
+  margin: 1.5rem 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -281,8 +295,14 @@ exports[`SubHeading component should render correctly with arabic script typogra
 
 @media (min-width: 37.5rem) {
   .emotion-0 {
-    padding-top: 2rem;
+    margin-top: 2rem;
   }
+}
+
+.emotion-0:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 <div>

--- a/src/app/legacy/psammead/psammead-headings/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-headings/src/index.jsx
@@ -13,6 +13,7 @@ import {
   getSansBold,
   getSerifMedium,
 } from '#psammead/psammead-styles/src/font-styles';
+import { focusIndicatorThickness } from '#app/components/ThemeProvider/focusIndicator';
 
 export const Headline = styled.h1`
   ${({ script }) => script && getCanon(script)};
@@ -32,10 +33,17 @@ export const SubHeading = styled.h2`
   ${({ service }) => getSansBold(service)}
   color: ${({ theme }) =>
     theme.isDarkUi ? theme.palette.GREY_2 : theme.palette.GREY_10};
-  margin: 0; /* Reset */
-  padding: ${GEL_SPACING_TRPL} 0;
+  margin: ${GEL_SPACING_TRPL} 0;
   ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {
-    padding-top: ${GEL_SPACING_QUAD};
+    margin-top: ${GEL_SPACING_QUAD};
+  }
+
+  :focus-visible {
+    outline: ${({ theme: { palette } }) =>
+      `${focusIndicatorThickness} solid ${palette.BLACK}`};
+    box-shadow: ${({ theme: { palette } }) =>
+      `0 0 0 ${focusIndicatorThickness} ${palette.WHITE}`};
+    outline-offset: ${focusIndicatorThickness};
   }
 `;
 

--- a/src/app/pages/MediaArticlePage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/MediaArticlePage/__snapshots__/index.test.tsx.snap
@@ -635,8 +635,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   font-weight: 700;
   font-style: normal;
   color: #141414;
-  margin: 0;
-  padding: 1.5rem 0;
+  margin: 1.5rem 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -655,8 +654,14 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 
 @media (min-width: 37.5rem) {
   .emotion-31 {
-    padding-top: 2rem;
+    margin-top: 2rem;
   }
+}
+
+.emotion-31:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-35 {


### PR DESCRIPTION
Overall changes
======
- Adds focus-indicator to subheadline component, which will be used mostly with the JumpTo component
- Changes spacing above and below subheadlines from `padding` to `margin` to allow focus-indicator to display correctly

|Before|After|
|---|---|
|<img width="883" alt="Screenshot 2024-11-12 at 09 34 59" src="https://github.com/user-attachments/assets/b39a0d06-06a7-42e3-918e-d0aad5088f3c">|<img width="753" alt="Screenshot 2024-11-12 at 09 42 38" src="https://github.com/user-attachments/assets/2c3fac8c-983d-4370-ac4b-eb293d212d82">|


Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
