### PR TITLE
Subheadline padding adjustment

### DIFF
--- a/src/app/legacy/containers/Headings/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/Headings/__snapshots__/index.test.jsx.snap
@@ -570,6 +570,7 @@ exports[`Headings with plain text subheadline should render h2 containing correc
   color: #141414;
   padding: 0.5rem 0;
   margin: calc(1.5rem - 0.5rem) 0;
+  scroll-margin-top: 1rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -1550,6 +1551,7 @@ exports[`Headings with subheadline data should render correctly 1`] = `
   color: #141414;
   padding: 0.5rem 0;
   margin: calc(1.5rem - 0.5rem) 0;
+  scroll-margin-top: 1rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {

--- a/src/app/legacy/containers/Headings/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/Headings/__snapshots__/index.test.jsx.snap
@@ -568,7 +568,8 @@ exports[`Headings with plain text subheadline should render h2 containing correc
   font-weight: 700;
   font-style: normal;
   color: #141414;
-  margin: 1.5rem 0;
+  padding: 0.5rem 0;
+  margin: calc(1.5rem - 0.5rem) 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -587,7 +588,7 @@ exports[`Headings with plain text subheadline should render h2 containing correc
 
 @media (min-width: 37.5rem) {
   .emotion-2 {
-    margin-top: 2rem;
+    margin-top: calc(2rem - 0.5rem);
   }
 }
 
@@ -1547,7 +1548,8 @@ exports[`Headings with subheadline data should render correctly 1`] = `
   font-weight: 700;
   font-style: normal;
   color: #141414;
-  margin: 1.5rem 0;
+  padding: 0.5rem 0;
+  margin: calc(1.5rem - 0.5rem) 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -1566,7 +1568,7 @@ exports[`Headings with subheadline data should render correctly 1`] = `
 
 @media (min-width: 37.5rem) {
   .emotion-2 {
-    margin-top: 2rem;
+    margin-top: calc(2rem - 0.5rem);
   }
 }
 

--- a/src/app/legacy/psammead/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -134,7 +134,8 @@ exports[`SubHeading component should render correctly 1`] = `
   font-weight: 700;
   font-style: normal;
   color: #141414;
-  margin: 1.5rem 0;
+  padding: 0.5rem 0;
+  margin: calc(1.5rem - 0.5rem) 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -153,7 +154,7 @@ exports[`SubHeading component should render correctly 1`] = `
 
 @media (min-width: 37.5rem) {
   .emotion-0 {
-    margin-top: 2rem;
+    margin-top: calc(2rem - 0.5rem);
   }
 }
 
@@ -181,7 +182,8 @@ exports[`SubHeading component should render correctly on page types that support
   font-weight: 700;
   font-style: normal;
   color: #F6F6F6;
-  margin: 1.5rem 0;
+  padding: 0.5rem 0;
+  margin: calc(1.5rem - 0.5rem) 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -200,7 +202,7 @@ exports[`SubHeading component should render correctly on page types that support
 
 @media (min-width: 37.5rem) {
   .emotion-0 {
-    margin-top: 2rem;
+    margin-top: calc(2rem - 0.5rem);
   }
 }
 
@@ -228,7 +230,8 @@ exports[`SubHeading component should render correctly with an ID 1`] = `
   font-weight: 700;
   font-style: normal;
   color: #141414;
-  margin: 1.5rem 0;
+  padding: 0.5rem 0;
+  margin: calc(1.5rem - 0.5rem) 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -247,7 +250,7 @@ exports[`SubHeading component should render correctly with an ID 1`] = `
 
 @media (min-width: 37.5rem) {
   .emotion-0 {
-    margin-top: 2rem;
+    margin-top: calc(2rem - 0.5rem);
   }
 }
 
@@ -276,7 +279,8 @@ exports[`SubHeading component should render correctly with arabic script typogra
   font-weight: 700;
   font-style: normal;
   color: #141414;
-  margin: 1.5rem 0;
+  padding: 0.5rem 0;
+  margin: calc(1.5rem - 0.5rem) 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -295,7 +299,7 @@ exports[`SubHeading component should render correctly with arabic script typogra
 
 @media (min-width: 37.5rem) {
   .emotion-0 {
-    margin-top: 2rem;
+    margin-top: calc(2rem - 0.5rem);
   }
 }
 

--- a/src/app/legacy/psammead/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -136,6 +136,7 @@ exports[`SubHeading component should render correctly 1`] = `
   color: #141414;
   padding: 0.5rem 0;
   margin: calc(1.5rem - 0.5rem) 0;
+  scroll-margin-top: 1rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -184,6 +185,7 @@ exports[`SubHeading component should render correctly on page types that support
   color: #F6F6F6;
   padding: 0.5rem 0;
   margin: calc(1.5rem - 0.5rem) 0;
+  scroll-margin-top: 1rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -232,6 +234,7 @@ exports[`SubHeading component should render correctly with an ID 1`] = `
   color: #141414;
   padding: 0.5rem 0;
   margin: calc(1.5rem - 0.5rem) 0;
+  scroll-margin-top: 1rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -281,6 +284,7 @@ exports[`SubHeading component should render correctly with arabic script typogra
   color: #141414;
   padding: 0.5rem 0;
   margin: calc(1.5rem - 0.5rem) 0;
+  scroll-margin-top: 1rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {

--- a/src/app/legacy/psammead/psammead-headings/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-headings/src/index.jsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import {
+  GEL_SPACING_DBL,
   GEL_SPACING_TRPL,
   GEL_SPACING_QUAD,
   GEL_SPACING_QUIN,
@@ -38,6 +39,7 @@ export const SubHeading = styled.h2`
 
   padding: ${SUBHEADING_PADDING} 0;
   margin: calc(${GEL_SPACING_TRPL} - ${SUBHEADING_PADDING}) 0;
+  scroll-margin-top: ${GEL_SPACING_DBL};
 
   ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {
     padding-top ${SUBHEADING_PADDING};

--- a/src/app/legacy/psammead/psammead-headings/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-headings/src/index.jsx
@@ -28,14 +28,20 @@ export const Headline = styled.h1`
   }
 `;
 
+const SUBHEADING_PADDING = '0.5rem';
+
 export const SubHeading = styled.h2`
   ${({ script }) => script && getTrafalgar(script)};
   ${({ service }) => getSansBold(service)}
   color: ${({ theme }) =>
     theme.isDarkUi ? theme.palette.GREY_2 : theme.palette.GREY_10};
-  margin: ${GEL_SPACING_TRPL} 0;
+
+  padding: ${SUBHEADING_PADDING} 0;
+  margin: calc(${GEL_SPACING_TRPL} - ${SUBHEADING_PADDING}) 0;
+
   ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {
-    margin-top: ${GEL_SPACING_QUAD};
+    padding-top ${SUBHEADING_PADDING};
+    margin-top: calc(${GEL_SPACING_QUAD} - ${SUBHEADING_PADDING});
   }
 
   :focus-visible {

--- a/src/app/pages/MediaArticlePage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/MediaArticlePage/__snapshots__/index.test.tsx.snap
@@ -637,6 +637,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   color: #141414;
   padding: 0.5rem 0;
   margin: calc(1.5rem - 0.5rem) 0;
+  scroll-margin-top: 1rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {

--- a/src/app/pages/MediaArticlePage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/MediaArticlePage/__snapshots__/index.test.tsx.snap
@@ -635,7 +635,8 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   font-weight: 700;
   font-style: normal;
   color: #141414;
-  margin: 1.5rem 0;
+  padding: 0.5rem 0;
+  margin: calc(1.5rem - 0.5rem) 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -654,7 +655,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 
 @media (min-width: 37.5rem) {
   .emotion-31 {
-    margin-top: 2rem;
+    margin-top: calc(2rem - 0.5rem);
   }
 }
 


### PR DESCRIPTION
Overall changes
======
- Adds `0.5rem` padding to top and bottom of subheadline, which is then subtracted off the margin top and bottom to give more visual space to the subheadlines
- Adds `1rem` `scroll-margin-top` to create a bit of space between the browser elements and the focused header

|Before|After|
|---|---|
|![Screenshot 2024-11-12 at 12 24 46](https://github.com/user-attachments/assets/6059b51f-9a85-46c8-af3f-92f12fa83c6d)|![Screenshot 2024-11-12 at 12 24 22](https://github.com/user-attachments/assets/b6a8090c-1d44-47e9-a56b-82aeb9ae667e)|


Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
