### PR TITLE
Next.js `.lite` extension fix

### DIFF
--- a/src/server/Document/Renderers/LiteRenderer.tsx
+++ b/src/server/Document/Renderers/LiteRenderer.tsx
@@ -11,6 +11,7 @@ export default function LitePageRenderer({
   helmetMetaTags,
   helmetLinkTags,
   helmetScriptTags,
+  helmetStyleTags,
   htmlAttrs,
   title,
   styles,
@@ -23,6 +24,7 @@ export default function LitePageRenderer({
         {helmetMetaTags}
         {helmetLinkTags}
         {helmetScriptTags}
+        {helmetStyleTags}
         <style dangerouslySetInnerHTML={{ __html: styles }} />
       </head>
       <body>{bodyContent}</body>

--- a/src/server/Document/Renderers/types.ts
+++ b/src/server/Document/Renderers/types.ts
@@ -4,6 +4,7 @@ export type BaseRendererProps = {
   helmetMetaTags: ReactElement;
   helmetLinkTags: ReactElement;
   helmetScriptTags: ReactElement;
+  helmetStyleTags?: ReactElement;
   htmlAttrs: HTMLAttributes<HTMLHtmlElement>;
   html?: string;
   ids?: string[];

--- a/ws-nextjs-app/middleware.page.ts
+++ b/ws-nextjs-app/middleware.page.ts
@@ -6,14 +6,6 @@ import cspHeaderResponse from './utilities/cspHeaderResponse';
 const LOCALHOST_DOMAINS = ['localhost', '127.0.0.1'];
 
 export function middleware(request: NextRequest) {
-  const url = request.nextUrl;
-
-  // Remove '.lite' from the end of the pathname to allow for the correct page to be rendered
-  if (url.pathname.endsWith('.lite')) {
-    url.pathname = url.pathname.replace('.lite', '');
-    return NextResponse.rewrite(url);
-  }
-
   const hostname = request.headers.get('host') ?? request.nextUrl.hostname;
 
   // Service worker is registered at the root (e.g. /pidgin) so will work as is on Test/Live

--- a/ws-nextjs-app/middleware.page.ts
+++ b/ws-nextjs-app/middleware.page.ts
@@ -1,12 +1,19 @@
 /* eslint-disable import/prefer-default-export */
-import { NextResponse } from 'next/server';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 import cspHeaderResponse from './utilities/cspHeaderResponse';
 
 const LOCALHOST_DOMAINS = ['localhost', '127.0.0.1'];
 
 export function middleware(request: NextRequest) {
+  const url = request.nextUrl;
+
+  // Remove '.lite' from the end of the pathname to allow for the correct page to be rendered
+  if (url.pathname.endsWith('.lite')) {
+    url.pathname = url.pathname.replace('.lite', '');
+    return NextResponse.rewrite(url);
+  }
+
   const hostname = request.headers.get('host') ?? request.nextUrl.hostname;
 
   // Service worker is registered at the root (e.g. /pidgin) so will work as is on Test/Live

--- a/ws-nextjs-app/next.config.js
+++ b/ws-nextjs-app/next.config.js
@@ -27,6 +27,14 @@ module.exports = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      {
+        source: '/:path*.lite',
+        destination: '/:path*',
+      },
+    ];
+  },
   reactStrictMode: true,
   distDir: 'build',
   output: 'standalone',

--- a/ws-nextjs-app/pages/[service]/[[...]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/[[...]].page.tsx
@@ -5,13 +5,12 @@ import isLitePath from '#app/routes/utils/isLitePath';
 import extractHeaders from '#server/utilities/extractHeaders';
 // AV Embeds
 import { AV_EMBEDS } from '#app/routes/utils/pageTypes';
+import { PageTypes } from '#app/models/types/global';
 import AvEmbedsPageLayout from './av-embeds/AvEmbedsPageLayout';
 import handleAvRoute from './av-embeds/handleAvRoute';
 import { AvEmbedsPageProps } from './av-embeds/types';
 
-type PageProps = {
-  pageType?: typeof AV_EMBEDS | null;
-} & AvEmbedsPageProps;
+type PageProps = { pageType?: PageTypes } & AvEmbedsPageProps;
 
 export default function Page({ pageType, ...rest }: PageProps) {
   switch (pageType) {

--- a/ws-nextjs-app/pages/[service]/[[...]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/[[...]].page.tsx
@@ -24,18 +24,19 @@ export default function Page({ pageType, ...rest }: PageProps) {
 }
 
 export const getServerSideProps: GetServerSideProps = async context => {
+  const url = context.req.url || context.resolvedUrl;
+
   const {
-    resolvedUrl,
     query: { service, variant },
     req: { headers: reqHeaders },
   } = context;
 
   // Route to AV Embeds
-  if (resolvedUrl?.includes('av-embeds')) {
+  if (url?.includes('av-embeds')) {
     return handleAvRoute(context);
   }
 
-  const isLite = isLitePath(resolvedUrl);
+  const isLite = isLitePath(url);
 
   logResponseTime(
     {

--- a/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.ts
+++ b/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.ts
@@ -19,9 +19,10 @@ const logger = nodeLogger(__filename);
 
 export default async (context: GetServerSidePropsContext) => {
   const {
-    resolvedUrl,
     req: { headers: reqHeaders },
   } = context;
+
+  const url = context.req.url || context.resolvedUrl;
 
   let pageStatus;
   let pageJson;
@@ -29,7 +30,7 @@ export default async (context: GetServerSidePropsContext) => {
   // Remove x-frame-options header to allow embedding
   context.res.removeHeader('x-frame-options');
 
-  const parsedRoute = parseAvRoute(resolvedUrl);
+  const parsedRoute = parseAvRoute(url);
 
   context.res.setHeader(
     'Cache-Control',
@@ -38,13 +39,13 @@ export default async (context: GetServerSidePropsContext) => {
 
   const avEmbedsUrl = constructPageFetchUrl({
     pageType: AV_EMBEDS,
-    pathname: resolvedUrl,
+    pathname: url,
     mediaId: parsedRoute.mediaId,
     lang: parsedRoute.lang,
   });
 
-  const env = getEnvironment(resolvedUrl);
-  const agent = certsRequired(resolvedUrl) ? await getAgent() : null;
+  const env = getEnvironment(url);
+  const agent = certsRequired(url) ? await getAgent() : null;
 
   const path = avEmbedsUrl.toString();
 
@@ -66,7 +67,7 @@ export default async (context: GetServerSidePropsContext) => {
       metricName: NON_200_RESPONSE,
       statusCode: status,
       pageType: AV_EMBEDS,
-      requestUrl: resolvedUrl,
+      requestUrl: url,
     });
 
     logger.error(BFF_FETCH_ERROR, {
@@ -124,7 +125,7 @@ export default async (context: GetServerSidePropsContext) => {
 
   return {
     props: {
-      id: resolvedUrl,
+      id: url,
       isNextJs: true,
       isAvEmbeds: true,
       pageData: avEmbed
@@ -143,7 +144,7 @@ export default async (context: GetServerSidePropsContext) => {
           }
         : null,
       pageType: AV_EMBEDS,
-      pathname: resolvedUrl,
+      pathname: url,
       service,
       status: pageStatus,
       variant,

--- a/ws-nextjs-app/pages/[service]/downloads/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/downloads/[[...variant]].page.tsx
@@ -25,13 +25,10 @@ const atiData = {
 };
 
 export const getServerSideProps: GetServerSideProps = async context => {
-  logResponseTime(
-    {
-      path: context.resolvedUrl,
-    },
-    context.res,
-    () => null,
-  );
+  const url = context.req.url || context.resolvedUrl;
+
+  logResponseTime({ path: url }, context.res, () => null);
+
   context.res.setHeader(
     'Cache-Control',
     'public, stale-if-error=600, stale-while-revalidate=240, max-age=60',

--- a/ws-nextjs-app/pages/[service]/live/[id]/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/[[...variant]].page.tsx
@@ -24,13 +24,9 @@ export const getServerSideProps: GetServerSideProps = async context => {
     'public, stale-if-error=300, stale-while-revalidate=120, max-age=30',
   );
 
-  logResponseTime(
-    {
-      path: context.resolvedUrl,
-    },
-    context.res,
-    () => null,
-  );
+  const url = context.req.url || context.resolvedUrl;
+
+  logResponseTime({ path: url }, context.res, () => null);
 
   const {
     id,
@@ -42,8 +38,8 @@ export const getServerSideProps: GetServerSideProps = async context => {
 
   const { headers: reqHeaders } = context.req;
 
-  const isApp = isAppPath(context.resolvedUrl);
-  const isLite = isLitePath(context.resolvedUrl);
+  const isApp = isAppPath(url);
+  const isLite = isLitePath(url);
 
   if (!isValidPageNumber(page)) {
     context.res.statusCode = 404;
@@ -52,7 +48,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
       metricName: NON_200_RESPONSE,
       statusCode: context.res.statusCode,
       pageType: LIVE_PAGE,
-      requestUrl: context.resolvedUrl,
+      requestUrl: url,
     });
 
     return {
@@ -75,17 +71,18 @@ export const getServerSideProps: GetServerSideProps = async context => {
     service,
     variant,
     rendererEnv,
-    resolvedUrl: context.resolvedUrl,
+    resolvedUrl: url,
     pageType: LIVE_PAGE,
   });
 
   let routingInfoLogger = logger.debug;
+
   if (data.status !== OK) {
     routingInfoLogger = logger.error;
   }
 
   routingInfoLogger(ROUTING_INFORMATION, {
-    url: context.resolvedUrl,
+    url,
     status: data.status,
     pageType: LIVE_PAGE,
   });
@@ -111,7 +108,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
           }
         : null,
       pageType: LIVE_PAGE,
-      pathname: context.resolvedUrl,
+      pathname: url,
       service,
       status: data.status,
       timeOnServer: Date.now(), // TODO: check if needed?

--- a/ws-nextjs-app/pages/[service]/send/[id]/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/send/[id]/[[...variant]].page.tsx
@@ -8,14 +8,16 @@ import UGCPageLayout from './UGCPageLayout';
 import extractHeaders from '../../../../../src/server/utilities/extractHeaders';
 
 export const getServerSideProps: GetServerSideProps = async context => {
+  const url = context.req.url || context.resolvedUrl;
+
   context.res.setHeader(
     'Cache-Control',
     'public, stale-if-error=300, stale-while-revalidate=120, max-age=30',
   );
 
   const { headers: reqHeaders } = context.req;
-  const isLite = isLitePath(context.resolvedUrl);
-  const isApp = isAppPath(context.resolvedUrl);
+  const isLite = isLitePath(url);
+  const isApp = isAppPath(url);
 
   const {
     id,
@@ -29,7 +31,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
     service,
     variant,
     rendererEnv,
-    resolvedUrl: context.resolvedUrl,
+    resolvedUrl: url,
     pageType: UGC_PAGE,
   });
 
@@ -53,7 +55,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
           }
         : null,
       pageType: UGC_PAGE,
-      pathname: context.resolvedUrl,
+      pathname: url,
       service,
       status: status ?? 500,
       toggles,

--- a/ws-nextjs-app/pages/_document.page.tsx
+++ b/ws-nextjs-app/pages/_document.page.tsx
@@ -137,6 +137,7 @@ export default class AppDocument extends Document<DocProps> {
     const helmetMetaTags = helmet.meta.toComponent();
     const helmetLinkTags = helmet.link.toComponent();
     const helmetScriptTags = helmet.script.toComponent();
+    const helmetStyleTags = helmet.style.toComponent();
 
     switch (true) {
       case isLite:
@@ -146,6 +147,7 @@ export default class AppDocument extends Document<DocProps> {
             helmetLinkTags={helmetLinkTags}
             helmetMetaTags={helmetMetaTags}
             helmetScriptTags={helmetScriptTags}
+            helmetStyleTags={helmetStyleTags}
             htmlAttrs={htmlAttrs}
             styles={css}
             title={title}
@@ -169,6 +171,7 @@ export default class AppDocument extends Document<DocProps> {
               {helmetMetaTags}
               {helmetLinkTags}
               {helmetScriptTags}
+              {helmetStyleTags}
               <style
                 data-emotion={ids.join(' ')}
                 dangerouslySetInnerHTML={{ __html: css }}

--- a/ws-nextjs-app/pages/ws/languages.page.tsx
+++ b/ws-nextjs-app/pages/ws/languages.page.tsx
@@ -1,12 +1,15 @@
-import Head from 'next/head';
 import * as React from 'react';
 import { GetServerSideProps } from 'next';
 import { STATIC_PAGE } from '#app/routes/utils/pageTypes';
 import ChartbeatAnalytics from '#app/components/ChartbeatAnalytics';
 import ATIAnalytics from '#app/components/ATIAnalytics';
 import MetadataContainer from '#app/components/Metadata';
+import isLitePath from '#app/routes/utils/isLitePath';
+import { Helmet } from 'react-helmet';
 
 export const getServerSideProps: GetServerSideProps = async context => {
+  const isLite = isLitePath(context.resolvedUrl);
+
   context.res.setHeader(
     'Cache-Control',
     'public, stale-if-error=300, stale-while-revalidate=120, max-age=30',
@@ -16,6 +19,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
     props: {
       error: null,
       isAmp: false,
+      isLite,
       isNextJs: true,
       page: null,
       pageData: {
@@ -36,20 +40,25 @@ const morphCSS1 = `@charset "CP850";@font-face{font-family:ReithSans;font-weight
 
 const morphCSS2 = `body{color:#404040;font-family:ReithSans,Arial,Helvetica,sans-serif}ol,ul{list-style:none}a:link{-webkit-tap-highlight-color:rgba(17,103,168,.3)}#core-navigation{display:none}.column-clearfix::after,.column-clearfix::before{content:"";display:block;height:0;overflow:hidden}.column-clearfix::after,.column-clearfix::before{clear:both}.units-list .unit+.unit{padding-top:9px}.units-list--separators .unit+.unit{padding-top:8px;border-top:1px solid #dcdcdc}.units-list--columning .unit+.unit{padding-top:0}.units-list .unit+.unit{padding-top:17px}#page{position:relative;z-index:10;background:#fff}.c-open{font-size:14px;padding-left:0;margin:0 auto;box-sizing:border-box;-webkit-box-sizing:border-box;-moz-box-sizing:border-box}.container{padding-bottom:42px}.container ul{margin:0;padding:0}.story-body__h1{font-family:ReithSerif,Arial,Helvetica,sans-serif;font-size:1.5rem;line-height:1.125;color:#1e1e1e;font-weight:700;margin:0;}.column--primary{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;padding-right:16px;padding-top:12px}.group__title{font-family:ReithSerif,Arial,Helvetica,sans-serif;font-size:24px;font-size:1.5rem;line-height:1;text-rendering:optimizeLegibility;letter-spacing:-.0425em;font-weight:700;margin-bottom:.5em}.group-title-component{margin-top:40px}.unit{clear:both;margin-bottom:8px}.container{padding-left:8px;padding-right:8px}.hide{display:none}.atlas-languages-page a{text-decoration:none;color:inherit}.atlas-languages-page a:focus,.atlas-languages-page a:hover{color:#1167a8}.language-switcher{padding:8px 0; margin:0;}@media (max-width:600px){.group-title-component{float:none}.group-title-component:nth-child(2){clear:both}}@media (min-width:480px){.container{padding-left:16px;padding-right:16px}.unit{margin-bottom:16px}}@media (min-width:600px){.group-title-component{float:left;width:50%}.group-title-component:nth-child(3),.group-title-component:nth-child(5),.group-title-component:nth-child(7){clear:both}.story-body__h1{font-size:2.25rem}.column--primary{padding-top:24px}}@media (min-width:976px){.container{margin:0 auto;max-width:1008px}.group-title-component{float:left;width:25%}.group-title-component:nth-child(3),.group-title-component:nth-child(5),.group-title-component:nth-child(7){clear:none}.story-body__h1{font-size:2rem}.column--primary{padding-top:20px;float:left;width:976px}}@media (min-width:1280px){.container{margin:0 auto;max-width:63.4rem; padding:0}}`;
 
-const languageToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
-  e.stopPropagation();
-  const elements = document.querySelectorAll('.panel, .toggle');
-  for (let i = 0; i < elements.length; i += 1) {
-    const classNames = elements[i].className.split(' ');
-    const indexOfHide = classNames.indexOf('hide');
-    if (indexOfHide !== -1) {
-      classNames.splice(indexOfHide, 1);
-    } else {
-      classNames.push('hide');
+const languageToggleFunc = `
+ window.addEventListener('load', function() {
+  var switcher = document.getElementById('switcher');
+  switcher.addEventListener('click', function(e) {
+    e.stopPropagation();
+    const elements = document.querySelectorAll('.panel, .toggle');
+    for (let i = 0; i < elements.length; i += 1) {
+      const classNames = elements[i].className.split(' ');
+      const indexOfHide = classNames.indexOf('hide');
+      if (indexOfHide !== -1) {
+        classNames.splice(indexOfHide, 1);
+      } else {
+        classNames.push('hide');
+      }
+      elements[i].className = classNames.join(' ');
     }
-    elements[i].className = classNames.join(' ');
-  }
-};
+  });
+ });
+`;
 
 const pageTitle = 'News in your language - BBC World Service';
 const pageDescription = 'A list of BBC World Service language services';
@@ -80,10 +89,11 @@ const pageLayout = () => {
         openGraphType="website"
         hasAmpPage={false}
       />
-      <Head>
-        <style>{morphCSS1}</style>
-        <style>{morphCSS2}</style>
-      </Head>
+      <Helmet>
+        <style type="text/css">{morphCSS1}</style>
+        <style type="text/css">{morphCSS2}</style>
+        <script type="text/javascript">{languageToggleFunc}</script>
+      </Helmet>
       <main>
         <div id="page" className="atlas-languages-page">
           <div className="container c-open" role="main">
@@ -93,12 +103,7 @@ const pageLayout = () => {
                   Get the news in your language
                 </h1>
                 <p className="language-switcher">
-                  <button
-                    className="switcher"
-                    id="switcher"
-                    onClick={languageToggle}
-                    type="button"
-                  >
+                  <button className="switcher" id="switcher" type="button">
                     <span className="toggle">Switch list to English</span>
                     <span className="toggle hide">
                       Switch list to localised scripts


### PR DESCRIPTION
Overall changes
======
Adds in URL rewrite for `.lite` URL paths to remove the `.lite` extension under-the-hood so that the correct page component can be rendered. **The URL does not change for the user, `.lite` is retained in the URL**.

Without this, a url like `/ws/languages.lite` will 404 as `.lite` isn't a valid route to Next.js. Similarly down the line, pages that don't have an optional parameter at the end would also 404, but these are rare.

Pages like Live work with `.lite` currently because the final part of the route is an 'optional catch-all', e.g. `[[...variant]]`, so the `.lite` extension gets caught in that as well

Changes using the `context.resolvedUrl` to using `context.req.url`. `resolvedUrl` has `.lite` removed from the URL rewrite, whereas `context.req.url` retains the fully requested URL. These appear to be functionally the same for us.

Testing this with the `/ws/languages` page, so I have made some minor changes to the code to test it works in Lite

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
