### PR TITLE
update nextjs live page example

### DIFF
--- a/ws-nextjs-app/README.md
+++ b/ws-nextjs-app/README.md
@@ -14,7 +14,7 @@ For more information on Next.js and how to use the framework, see the [Next.js d
 
 - Run `yarn install` to install dependencies
 - Run `yarn dev` to start the development server on `http://localhost:7081`
-- Navigate to `http://localhost:7081/kyrgyz/live/cz74kjpyk07t` to see the page
+- Navigate to `http://localhost:7081/pidgin/live/c7p765ynk9qt` to see the page
 
 ## Running Unit and E2E tests
 


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
updates example of a live page in our `ws-nextjs-app` readme docs: `http://localhost:7081/pidgin/live/c7p765ynk9qt`. the current example no longer works and returns a 500 error.

Testing
======
1. run `ws-nextjs-app`
2. go to http://localhost:7081/pidgin/live/c7p765ynk9qt
3. see that this live page example is available

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
