### PR TITLE
WSTEAMA-1454 - Related Content focus indicator

### DIFF
--- a/src/app/components/MostRead/Label/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/MostRead/Label/__snapshots__/index.test.tsx.snap
@@ -127,6 +127,7 @@ exports[`MostReadSectionLabel assertion should render most-read section label wi
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-Most-Read"
+      tabindex="-1"
     >
       <span
         class="emotion-4 emotion-5"

--- a/src/app/components/MostRead/Label/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/MostRead/Label/__snapshots__/index.test.tsx.snap
@@ -31,6 +31,12 @@ exports[`MostReadSectionLabel assertion should render most-read section label wi
   padding: 0;
 }
 
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -120,6 +126,7 @@ exports[`MostReadSectionLabel assertion should render most-read section label wi
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-Most-Read"
     >
       <span
         class="emotion-4 emotion-5"

--- a/src/app/legacy/containers/CpsOnwardJourney/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/CpsOnwardJourney/__snapshots__/index.test.jsx.snap
@@ -1201,6 +1201,7 @@ exports[`CpsOnwardJourney renders section label with with alternative background
         <h2
           class="emotion-9 emotion-10"
           id="section-label-heading-heading-label"
+          tabindex="-1"
         >
           <span
             class="emotion-11 emotion-12"
@@ -1582,6 +1583,7 @@ exports[`CpsOnwardJourney renders section label with without bar under section l
         <h2
           class="emotion-9 emotion-10"
           id="section-label-heading-heading-label"
+          tabindex="-1"
         >
           <span
             class="emotion-11 emotion-12"
@@ -2030,6 +2032,7 @@ exports[`CpsOnwardJourney renders skip link with multiple promos 1`] = `
           <h2
             class="emotion-13 emotion-14"
             id="section-label-heading-heading-label"
+            tabindex="-1"
           >
             <span
               class="emotion-15 emotion-16"
@@ -2502,6 +2505,7 @@ exports[`CpsOnwardJourney renders skip link with single promo 1`] = `
           <h2
             class="emotion-13 emotion-14"
             id="section-label-heading-heading-label"
+            tabindex="-1"
           >
             <span
               class="emotion-15 emotion-16"

--- a/src/app/legacy/containers/CpsOnwardJourney/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/CpsOnwardJourney/__snapshots__/index.test.jsx.snap
@@ -714,6 +714,12 @@ exports[`CpsOnwardJourney renders section label with element as strong 1`] = `
   padding: 0;
 }
 
+.emotion-9:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-11 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1088,6 +1094,12 @@ exports[`CpsOnwardJourney renders section label with with alternative background
   padding: 0;
 }
 
+.emotion-9:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-11 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1188,6 +1200,7 @@ exports[`CpsOnwardJourney renders section label with with alternative background
       >
         <h2
           class="emotion-9 emotion-10"
+          id="section-label-heading-heading-label"
         >
           <span
             class="emotion-11 emotion-12"
@@ -1462,6 +1475,12 @@ exports[`CpsOnwardJourney renders section label with without bar under section l
   padding: 0;
 }
 
+.emotion-9:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-11 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1562,6 +1581,7 @@ exports[`CpsOnwardJourney renders section label with without bar under section l
       >
         <h2
           class="emotion-9 emotion-10"
+          id="section-label-heading-heading-label"
         >
           <span
             class="emotion-11 emotion-12"
@@ -1883,6 +1903,12 @@ exports[`CpsOnwardJourney renders skip link with multiple promos 1`] = `
   padding: 0;
 }
 
+.emotion-13:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-15 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2003,6 +2029,7 @@ exports[`CpsOnwardJourney renders skip link with multiple promos 1`] = `
         >
           <h2
             class="emotion-13 emotion-14"
+            id="section-label-heading-heading-label"
           >
             <span
               class="emotion-15 emotion-16"
@@ -2348,6 +2375,12 @@ exports[`CpsOnwardJourney renders skip link with single promo 1`] = `
   padding: 0;
 }
 
+.emotion-13:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-15 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2468,6 +2501,7 @@ exports[`CpsOnwardJourney renders skip link with single promo 1`] = `
         >
           <h2
             class="emotion-13 emotion-14"
+            id="section-label-heading-heading-label"
           >
             <span
               class="emotion-15 emotion-16"

--- a/src/app/legacy/containers/CpsRecommendations/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/CpsRecommendations/__snapshots__/index.test.jsx.snap
@@ -198,6 +198,12 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
   padding: 0;
 }
 
+.emotion-11:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-13 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -773,6 +779,12 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
 .emotion-11 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-11:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-13 {
@@ -1620,6 +1632,12 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
 .emotion-11 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-11:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-13 {

--- a/src/app/legacy/containers/EpisodeList/RecentAudioEpisodes/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/EpisodeList/RecentAudioEpisodes/__snapshots__/index.test.jsx.snap
@@ -43,6 +43,12 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
   padding: 0;
 }
 
+.emotion-5:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -361,6 +367,7 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
     >
       <h2
         class="emotion-5 emotion-6"
+        id="section-label-heading-recent-episodes"
       >
         <span
           class="emotion-7 emotion-8"

--- a/src/app/legacy/containers/EpisodeList/RecentAudioEpisodes/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/EpisodeList/RecentAudioEpisodes/__snapshots__/index.test.jsx.snap
@@ -368,6 +368,7 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
       <h2
         class="emotion-5 emotion-6"
         id="section-label-heading-recent-episodes"
+        tabindex="-1"
       >
         <span
           class="emotion-7 emotion-8"

--- a/src/app/legacy/containers/EpisodeList/RecentVideoEpisodes/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/EpisodeList/RecentVideoEpisodes/__snapshots__/index.test.jsx.snap
@@ -458,6 +458,7 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
       <h2
         class="emotion-3 emotion-4"
         id="section-label-heading-recent-episodes"
+        tabindex="-1"
       >
         <span
           class="emotion-5 emotion-6"

--- a/src/app/legacy/containers/EpisodeList/RecentVideoEpisodes/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/EpisodeList/RecentVideoEpisodes/__snapshots__/index.test.jsx.snap
@@ -39,6 +39,12 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
   padding: 0;
 }
 
+.emotion-3:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-5 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -451,6 +457,7 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
     >
       <h2
         class="emotion-3 emotion-4"
+        id="section-label-heading-recent-episodes"
       >
         <span
           class="emotion-5 emotion-6"

--- a/src/app/legacy/containers/IndexPageSection/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/IndexPageSection/__snapshots__/index.test.jsx.snap
@@ -46,6 +46,12 @@ HTMLCollection [
   padding: 0;
 }
 
+.emotion-4:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -922,6 +928,7 @@ HTMLCollection [
     >
       <h2
         class="emotion-4 emotion-5"
+        id="section-label-heading-Top-Stories"
       >
         <span
           class="emotion-6 emotion-7"
@@ -1334,6 +1341,12 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
 .emotion-4 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-4:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-6 {
@@ -2213,6 +2226,7 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
     >
       <h2
         class="emotion-4 emotion-5"
+        id="section-label-heading-Top-Stories"
       >
         <span
           class="emotion-6 emotion-7"
@@ -2618,6 +2632,12 @@ exports[`IndexPageSection Container snapshots should render correctly with a lin
 .emotion-4 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-4:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-6 {
@@ -3468,6 +3488,7 @@ exports[`IndexPageSection Container snapshots should render correctly with a lin
     >
       <h2
         class="emotion-4 emotion-5"
+        id="section-label-heading-Top-Stories"
       >
         <span
           class="emotion-6 emotion-7"
@@ -3673,6 +3694,12 @@ exports[`IndexPageSection Container snapshots should render with only one item 1
 .emotion-4 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-4:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-6 {
@@ -4037,6 +4064,7 @@ exports[`IndexPageSection Container snapshots should render with only one item 1
     >
       <h2
         class="emotion-4 emotion-5"
+        id="section-label-heading-Top-Stories"
       >
         <span
           class="emotion-6 emotion-7"
@@ -4159,6 +4187,12 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 .emotion-4 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-4:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-6 {
@@ -5026,6 +5060,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
     >
       <h2
         class="emotion-4 emotion-5"
+        id="section-label-heading-Top-Stories"
       >
         <span
           class="emotion-6 emotion-7"

--- a/src/app/legacy/containers/IndexPageSection/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/IndexPageSection/__snapshots__/index.test.jsx.snap
@@ -929,6 +929,7 @@ HTMLCollection [
       <h2
         class="emotion-4 emotion-5"
         id="section-label-heading-Top-Stories"
+        tabindex="-1"
       >
         <span
           class="emotion-6 emotion-7"
@@ -2227,6 +2228,7 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
       <h2
         class="emotion-4 emotion-5"
         id="section-label-heading-Top-Stories"
+        tabindex="-1"
       >
         <span
           class="emotion-6 emotion-7"
@@ -3489,6 +3491,7 @@ exports[`IndexPageSection Container snapshots should render correctly with a lin
       <h2
         class="emotion-4 emotion-5"
         id="section-label-heading-Top-Stories"
+        tabindex="-1"
       >
         <span
           class="emotion-6 emotion-7"
@@ -4065,6 +4068,7 @@ exports[`IndexPageSection Container snapshots should render with only one item 1
       <h2
         class="emotion-4 emotion-5"
         id="section-label-heading-Top-Stories"
+        tabindex="-1"
       >
         <span
           class="emotion-6 emotion-7"
@@ -5061,6 +5065,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
       <h2
         class="emotion-4 emotion-5"
         id="section-label-heading-Top-Stories"
+        tabindex="-1"
       >
         <span
           class="emotion-6 emotion-7"

--- a/src/app/legacy/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
@@ -889,6 +889,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
       <h2
         class="emotion-5 emotion-6"
         id="section-label-heading-Radio-Schedule"
+        tabindex="-1"
       >
         <span
           class="emotion-7 emotion-8"
@@ -2338,6 +2339,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
       <h2
         class="emotion-5 emotion-6"
         id="section-label-heading-Radio-Schedule"
+        tabindex="-1"
       >
         <span
           class="emotion-7 emotion-8"

--- a/src/app/legacy/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
@@ -73,6 +73,12 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   padding: 0;
 }
 
+.emotion-5:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -882,6 +888,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
     >
       <h2
         class="emotion-5 emotion-6"
+        id="section-label-heading-Radio-Schedule"
       >
         <span
           class="emotion-7 emotion-8"
@@ -1515,6 +1522,12 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   padding: 0;
 }
 
+.emotion-5:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2324,6 +2337,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
     >
       <h2
         class="emotion-5 emotion-6"
+        id="section-label-heading-Radio-Schedule"
       >
         <span
           class="emotion-7 emotion-8"

--- a/src/app/legacy/containers/RelatedTopics/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/RelatedTopics/__snapshots__/index.test.jsx.snap
@@ -36,6 +36,12 @@ exports[`Expected use should render correctly with a single tag 1`] = `
   padding: 0;
 }
 
+.emotion-5:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -200,6 +206,7 @@ exports[`Expected use should render correctly with a single tag 1`] = `
     >
       <h2
         class="emotion-5 emotion-6"
+        id="section-label-heading-related-topics"
       >
         <span
           class="emotion-7 emotion-8"
@@ -269,6 +276,12 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
 .emotion-5 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-5:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-7 {
@@ -436,6 +449,7 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
     >
       <h2
         class="emotion-5 emotion-6"
+        id="section-label-heading-related-topics"
       >
         <span
           class="emotion-7 emotion-8"

--- a/src/app/legacy/containers/RelatedTopics/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/RelatedTopics/__snapshots__/index.test.jsx.snap
@@ -207,6 +207,7 @@ exports[`Expected use should render correctly with a single tag 1`] = `
       <h2
         class="emotion-5 emotion-6"
         id="section-label-heading-related-topics"
+        tabindex="-1"
       >
         <span
           class="emotion-7 emotion-8"
@@ -450,6 +451,7 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
       <h2
         class="emotion-5 emotion-6"
         id="section-label-heading-related-topics"
+        tabindex="-1"
       >
         <span
           class="emotion-7 emotion-8"

--- a/src/app/legacy/psammead/psammead-section-label/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-section-label/src/__snapshots__/index.test.jsx.snap
@@ -128,6 +128,7 @@ exports[`SectionLabel With bar When hideSectionHeader is true should add styling
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <span
         class="emotion-4 emotion-5"
@@ -464,6 +465,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <a
         class="focusIndicatorDisplayBlock emotion-4 emotion-5"
@@ -672,6 +674,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <a
         class="focusIndicatorDisplayBlock emotion-4 emotion-5"
@@ -880,6 +883,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <a
         class="focusIndicatorDisplayBlock emotion-4 emotion-5"
@@ -1088,6 +1092,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <a
         class="focusIndicatorDisplayBlock emotion-4 emotion-5"
@@ -1249,6 +1254,7 @@ exports[`SectionLabel With bar With plain title should render correctly with ara
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <span
         class="emotion-4 emotion-5"
@@ -1391,6 +1397,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <span
         class="emotion-4 emotion-5"
@@ -1533,6 +1540,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <span
         class="emotion-4 emotion-5"
@@ -1675,6 +1683,7 @@ exports[`SectionLabel With bar With plain title should render correctly with mob
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <span
         class="emotion-4 emotion-5"
@@ -1870,6 +1879,7 @@ exports[`SectionLabel With bar Without bar With linking title should render corr
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <a
         class="focusIndicatorDisplayBlock emotion-4 emotion-5"
@@ -2078,6 +2088,7 @@ exports[`SectionLabel With bar Without bar With linking title should render corr
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <a
         class="focusIndicatorDisplayBlock emotion-4 emotion-5"
@@ -2286,6 +2297,7 @@ exports[`SectionLabel With bar Without bar With linking title should render corr
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <a
         class="focusIndicatorDisplayBlock emotion-4 emotion-5"
@@ -2441,6 +2453,7 @@ exports[`SectionLabel With bar Without bar With plain title should render correc
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <span
         class="emotion-4 emotion-5"
@@ -2583,6 +2596,7 @@ exports[`SectionLabel With bar Without bar With plain title should render correc
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <span
         class="emotion-4 emotion-5"
@@ -2725,6 +2739,7 @@ exports[`SectionLabel With bar Without bar With plain title should render correc
     <h2
       class="emotion-2 emotion-3"
       id="section-label-heading-test-section-label"
+      tabindex="-1"
     >
       <span
         class="emotion-4 emotion-5"

--- a/src/app/legacy/psammead/psammead-section-label/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-section-label/src/__snapshots__/index.test.jsx.snap
@@ -32,6 +32,12 @@ exports[`SectionLabel With bar When hideSectionHeader is true should add styling
   padding: 0;
 }
 
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -121,6 +127,7 @@ exports[`SectionLabel With bar When hideSectionHeader is true should add styling
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <span
         class="emotion-4 emotion-5"
@@ -165,6 +172,12 @@ exports[`SectionLabel With bar With heading overriden should render a span eleme
 .emotion-2 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-4 {
@@ -302,6 +315,12 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
   padding: 0;
 }
 
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-4 {
   color: #222222;
   -webkit-text-decoration: none;
@@ -444,6 +463,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <a
         class="focusIndicatorDisplayBlock emotion-4 emotion-5"
@@ -501,6 +521,12 @@ exports[`SectionLabel With bar With linking title should render correctly with a
 .emotion-2 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-4 {
@@ -645,6 +671,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <a
         class="focusIndicatorDisplayBlock emotion-4 emotion-5"
@@ -704,6 +731,12 @@ exports[`SectionLabel With bar With linking title should render correctly with e
   padding: 0;
 }
 
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-4 {
   color: #222222;
   -webkit-text-decoration: none;
@@ -846,6 +879,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <a
         class="focusIndicatorDisplayBlock emotion-4 emotion-5"
@@ -905,6 +939,12 @@ exports[`SectionLabel With bar With linking title should render correctly with e
   padding: 0;
 }
 
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-4 {
   color: #222222;
   -webkit-text-decoration: none;
@@ -1047,6 +1087,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <a
         class="focusIndicatorDisplayBlock emotion-4 emotion-5"
@@ -1112,6 +1153,12 @@ exports[`SectionLabel With bar With plain title should render correctly with ara
   padding: 0;
 }
 
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1201,6 +1248,7 @@ exports[`SectionLabel With bar With plain title should render correctly with ara
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <span
         class="emotion-4 emotion-5"
@@ -1247,6 +1295,12 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
   padding: 0;
 }
 
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1336,6 +1390,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <span
         class="emotion-4 emotion-5"
@@ -1382,6 +1437,12 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
   padding: 0;
 }
 
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1471,6 +1532,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <span
         class="emotion-4 emotion-5"
@@ -1517,6 +1579,12 @@ exports[`SectionLabel With bar With plain title should render correctly with mob
   padding: 0;
 }
 
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1606,6 +1674,7 @@ exports[`SectionLabel With bar With plain title should render correctly with mob
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <span
         class="emotion-4 emotion-5"
@@ -1650,6 +1719,12 @@ exports[`SectionLabel With bar Without bar With linking title should render corr
 .emotion-2 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-4 {
@@ -1794,6 +1869,7 @@ exports[`SectionLabel With bar Without bar With linking title should render corr
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <a
         class="focusIndicatorDisplayBlock emotion-4 emotion-5"
@@ -1851,6 +1927,12 @@ exports[`SectionLabel With bar Without bar With linking title should render corr
 .emotion-2 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-4 {
@@ -1995,6 +2077,7 @@ exports[`SectionLabel With bar Without bar With linking title should render corr
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <a
         class="focusIndicatorDisplayBlock emotion-4 emotion-5"
@@ -2052,6 +2135,12 @@ exports[`SectionLabel With bar Without bar With linking title should render corr
 .emotion-2 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-4 {
@@ -2196,6 +2285,7 @@ exports[`SectionLabel With bar Without bar With linking title should render corr
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <a
         class="focusIndicatorDisplayBlock emotion-4 emotion-5"
@@ -2253,6 +2343,12 @@ exports[`SectionLabel With bar Without bar With plain title should render correc
 .emotion-2 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-4 {
@@ -2344,6 +2440,7 @@ exports[`SectionLabel With bar Without bar With plain title should render correc
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <span
         class="emotion-4 emotion-5"
@@ -2388,6 +2485,12 @@ exports[`SectionLabel With bar Without bar With plain title should render correc
 .emotion-2 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-4 {
@@ -2479,6 +2582,7 @@ exports[`SectionLabel With bar Without bar With plain title should render correc
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <span
         class="emotion-4 emotion-5"
@@ -2523,6 +2627,12 @@ exports[`SectionLabel With bar Without bar With plain title should render correc
 .emotion-2 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-2:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-4 {
@@ -2614,6 +2724,7 @@ exports[`SectionLabel With bar Without bar With plain title should render correc
   >
     <h2
       class="emotion-2 emotion-3"
+      id="section-label-heading-test-section-label"
     >
       <span
         class="emotion-4 emotion-5"

--- a/src/app/legacy/psammead/psammead-section-label/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-section-label/src/index.jsx
@@ -70,7 +70,10 @@ const SectionLabel = ({
     <Heading
       as={overrideHeadingAs}
       {...(labelId &&
-        !overrideHeadingAs && { id: `section-label-heading-${labelId}` })}
+        !overrideHeadingAs && {
+          id: `section-label-heading-${labelId}`,
+          tabIndex: -1,
+        })}
     >
       {linkText && href ? (
         <LinkTitle

--- a/src/app/legacy/psammead/psammead-section-label/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-section-label/src/index.jsx
@@ -9,6 +9,7 @@ import {
   GEL_SPACING_QUAD,
 } from '#psammead/gel-foundations/src/spacings';
 import { GHOST } from '#app/components/ThemeProvider/palette';
+import { focusIndicatorThickness } from '#app/components/ThemeProvider/focusIndicator';
 import { PlainTitle, LinkTitle } from './titles';
 
 const SectionLabelWrapper = styled.div`
@@ -42,6 +43,14 @@ export const Heading = styled.h2`
   /* reset default margins */
   margin: 0;
   padding: 0;
+
+  :focus-visible {
+    outline: ${({ theme: { palette } }) =>
+      `${focusIndicatorThickness} solid ${palette.BLACK}`};
+    box-shadow: ${({ theme: { palette } }) =>
+      `0 0 0 ${focusIndicatorThickness} ${palette.WHITE}`};
+    outline-offset: ${focusIndicatorThickness};
+  }
 `;
 
 const SectionLabel = ({
@@ -58,7 +67,11 @@ const SectionLabel = ({
   ...props
 }) => (
   <SectionLabelWrapper visuallyHidden={visuallyHidden} {...props}>
-    <Heading as={overrideHeadingAs}>
+    <Heading
+      as={overrideHeadingAs}
+      {...(labelId &&
+        !overrideHeadingAs && { id: `section-label-heading-${labelId}` })}
+    >
       {linkText && href ? (
         <LinkTitle
           dir={dir}

--- a/src/app/pages/ArticlePage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/ArticlePage/__snapshots__/index.test.tsx.snap
@@ -878,6 +878,7 @@ exports[`Article Page should render a ltr article (pidgin) with most read correc
         <h2
           class="emotion-15 emotion-16"
           id="section-label-heading-Most-Read"
+          tabindex="-1"
         >
           <span
             class="emotion-17 emotion-18"
@@ -2313,6 +2314,7 @@ exports[`Article Page should render a news article correctly 1`] = `
         <h2
           class="emotion-19 emotion-20"
           id="section-label-heading-Most-Read"
+          tabindex="-1"
         >
           <span
             class="emotion-21 emotion-22"
@@ -4448,6 +4450,7 @@ exports[`Article Page should render a rtl article (persian) with most read corre
         <h2
           class="emotion-15 emotion-16"
           id="section-label-heading-Most-Read"
+          tabindex="-1"
         >
           <span
             class="emotion-17 emotion-18"

--- a/src/app/pages/ArticlePage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/ArticlePage/__snapshots__/index.test.tsx.snap
@@ -364,6 +364,12 @@ exports[`Article Page should render a ltr article (pidgin) with most read correc
   padding: 0;
 }
 
+.emotion-15:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-17 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -871,6 +877,7 @@ exports[`Article Page should render a ltr article (pidgin) with most read correc
       >
         <h2
           class="emotion-15 emotion-16"
+          id="section-label-heading-Most-Read"
         >
           <span
             class="emotion-17 emotion-18"
@@ -1526,6 +1533,12 @@ exports[`Article Page should render a news article correctly 1`] = `
 .emotion-19 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-19:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
 }
 
 .emotion-21 {
@@ -2299,6 +2312,7 @@ exports[`Article Page should render a news article correctly 1`] = `
       >
         <h2
           class="emotion-19 emotion-20"
+          id="section-label-heading-Most-Read"
         >
           <span
             class="emotion-21 emotion-22"
@@ -3700,6 +3714,12 @@ exports[`Article Page should render a rtl article (persian) with most read corre
   padding: 0;
 }
 
+.emotion-15:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-17 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -4427,6 +4447,7 @@ exports[`Article Page should render a rtl article (persian) with most read corre
       >
         <h2
           class="emotion-15 emotion-16"
+          id="section-label-heading-Most-Read"
         >
           <span
             class="emotion-17 emotion-18"

--- a/src/app/pages/LiveRadioPage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/LiveRadioPage/__snapshots__/index.test.tsx.snap
@@ -305,6 +305,12 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   padding: 0;
 }
 
+.emotion-14:focus-visible {
+  outline: 0.1875rem solid #000000;
+  box-shadow: 0 0 0 0.1875rem #FFFFFF;
+  outline-offset: 0.1875rem;
+}
+
 .emotion-16 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1106,6 +1112,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
     >
       <h2
         class="emotion-14 emotion-15"
+        id="section-label-heading-Radio-Schedule"
       >
         <span
           class="emotion-16 emotion-17"

--- a/src/app/pages/LiveRadioPage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/LiveRadioPage/__snapshots__/index.test.tsx.snap
@@ -1113,6 +1113,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
       <h2
         class="emotion-14 emotion-15"
         id="section-label-heading-Radio-Schedule"
+        tabindex="-1"
       >
         <span
           class="emotion-16 emotion-17"


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAMA-1454

Overall changes
======
- Adds focus indicator styling to the Related Content `h2` element
- Adds `id` and `tabIndex` to the `h2` element in the `psammead-section-label` component so that it can be focused to. This `id` is different to the one that is used in the child `span` element to retain any previous functionality around that id.

<img width="790" alt="Screenshot 2024-11-14 at 15 44 51" src="https://github.com/user-attachments/assets/65f26620-02e4-4618-9072-34357ee79adf">


Testing
======
1. Visit http://localhost:7080/pidgin/articles/c7049l52l2go?renderer_env=live
2. Scroll down to the related content section
3. Open Chrome dev tools
4. Highlight the `h2` element of the related content header
5. Force `:focus-visible` state and observe the focus indicator styling

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
