### PR TITLE
WSTEAM1-1408: Populates 'x2' ATI value with 'lite' for .lite pages

### DIFF
--- a/src/app/contexts/RequestContext/index.test.tsx
+++ b/src/app/contexts/RequestContext/index.test.tsx
@@ -204,7 +204,7 @@ describe('RequestContext', () => {
         isAmp: false,
         isApp: false,
         isLite: true,
-        platform: 'canonical',
+        platform: 'lite',
       });
     });
 

--- a/src/app/contexts/RequestContext/index.tsx
+++ b/src/app/contexts/RequestContext/index.tsx
@@ -100,6 +100,8 @@ export const RequestContextProvider = ({
         return 'app';
       case isAmp:
         return 'amp';
+      case isLite:
+        return 'lite';
       default:
         return 'canonical';
     }

--- a/src/app/lib/analyticsUtils/index.js
+++ b/src/app/lib/analyticsUtils/index.js
@@ -78,6 +78,8 @@ export const getAppType = platform => {
       return 'amp';
     case 'app':
       return 'mobile-app';
+    case 'lite':
+      return 'lite';
     case 'canonical':
       return 'responsive';
     default:

--- a/src/app/lib/analyticsUtils/index.test.js
+++ b/src/app/lib/analyticsUtils/index.test.js
@@ -130,6 +130,11 @@ describe('getAppType', () => {
       summary: 'should return mobile-app for app',
     },
     {
+      platform: 'lite',
+      expected: 'lite',
+      summary: 'should return lite for lite',
+    },
+    {
       platform: 'canonical',
       expected: 'responsive',
       summary: 'should return responsive for amp',

--- a/src/app/models/types/global.ts
+++ b/src/app/models/types/global.ts
@@ -2,7 +2,7 @@ import * as PAGE_TYPES from '../../routes/utils/pageTypes';
 
 export type Environments = 'local' | 'test' | 'live';
 
-export type Platforms = 'amp' | 'canonical' | 'app';
+export type Platforms = 'amp' | 'canonical' | 'app' | 'lite';
 
 export type Direction = 'rtl' | 'ltr';
 

--- a/src/integration/integrationTestEnvironment.js
+++ b/src/integration/integrationTestEnvironment.js
@@ -18,7 +18,21 @@ class IntegrationTestEnvironment extends JsdomEnvironment {
     } = context.docblockPragmas;
     const pageType = getPageTypeFromTestPath(context.testPath);
 
-    const platformForPath = platform === 'canonical' ? '' : `.${platform}`;
+    let platformForPath = '';
+
+    switch (platform) {
+      case 'canonical':
+        platformForPath = '';
+        break;
+      case 'amp':
+        platformForPath = '.amp';
+        break;
+      case 'lite':
+        platformForPath = '.lite';
+        break;
+      default:
+        platformForPath = '';
+    }
 
     this.pageType = camelCaseToText(pageType);
     this.service = service;

--- a/src/integration/integrationTestEnvironment.js
+++ b/src/integration/integrationTestEnvironment.js
@@ -18,7 +18,9 @@ class IntegrationTestEnvironment extends JsdomEnvironment {
     } = context.docblockPragmas;
     const pageType = getPageTypeFromTestPath(context.testPath);
 
-    const platformForPath = ['amp', 'lite'].includes(platform) ? `.${platform}` : '';
+    const platformForPath = ['amp', 'lite'].includes(platform)
+      ? `.${platform}`
+      : '';
 
     this.pageType = camelCaseToText(pageType);
     this.service = service;

--- a/src/integration/integrationTestEnvironment.js
+++ b/src/integration/integrationTestEnvironment.js
@@ -18,21 +18,7 @@ class IntegrationTestEnvironment extends JsdomEnvironment {
     } = context.docblockPragmas;
     const pageType = getPageTypeFromTestPath(context.testPath);
 
-    let platformForPath = '';
-
-    switch (platform) {
-      case 'canonical':
-        platformForPath = '';
-        break;
-      case 'amp':
-        platformForPath = '.amp';
-        break;
-      case 'lite':
-        platformForPath = '.lite';
-        break;
-      default:
-        platformForPath = '';
-    }
+    const platformForPath = ['amp', 'lite'].includes(platform) ? `.${platform}` : '';
 
     this.pageType = camelCaseToText(pageType);
     this.service = service;


### PR DESCRIPTION
Resolves JIRA [[WSTEAM1-1408]](https://jira.dev.bbc.co.uk/browse/WSTEAM1-1408)

Overall changes
======
Populates 'x2' ATI value for Piano with 'lite' for .lite pages

Code changes
======
- Sets the Platform value to 'lite' for .lite pages. (Follows pattern already put in place by .app)
- Sets AppType value to 'lite' for .lite pages
- Refactors integrationTest to make the platform more explicit

Testing
======
1. Visit any .lite page on latest. E.g. https://www.bbc.com/afrique/articles/cn01kyjj230o.lite
2. Visit the same page locally E.g. http://localhost:7080/afrique/articles/cn01kyjj230o.lite?renderer_env=live
3. For each, go to the Network Tab and filter by 'Fetch/XHR'
4. Compare the analytics request. All values should match apart from 'x2:'. Locally this should be [lite] and not [responsive]

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
