### PR TITLE
Brasil navigation: remove US election link

### DIFF
--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -423,10 +423,6 @@ export const service: DefaultServiceConfig = {
         url: '/portuguese/topics/cz74k717pw5t',
       },
       {
-        title: 'Eleições EUA',
-        url: '/portuguese/topics/c30gn378n6kt',
-      },
-      {
         title: 'Internacional',
         url: '/portuguese/topics/cmdm4ynm24kt',
       },

--- a/src/integration/pages/podcastPage/portugueseBrand/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/podcastPage/portugueseBrand/__snapshots__/canonical.test.js.snap
@@ -89,54 +89,47 @@ exports[`Canonical Podcast Page Header Navigation link should match text and url
 
 exports[`Canonical Podcast Page Header Navigation link should match text and url 3`] = `
 {
-  "text": "Eleições EUA",
-  "url": "/portuguese/topics/c30gn378n6kt",
-}
-`;
-
-exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
-{
   "text": "Internacional",
   "url": "/portuguese/topics/cmdm4ynm24kt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Economia",
   "url": "/portuguese/topics/cvjp2jr0k9rt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Saúde",
   "url": "/portuguese/topics/c340q430z4vt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciência",
   "url": "/portuguese/topics/cr50y580rjxt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Tecnologia",
   "url": "/portuguese/topics/c404v027pd4t",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Vídeos",
   "url": "/portuguese/topics/c9y2j35dn2zt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
 {
   "text": "BBC Lê",
   "url": "/portuguese/topics/cxndrr1qgllt",

--- a/src/integration/pages/podcastPage/portugueseEpisode/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/podcastPage/portugueseEpisode/__snapshots__/canonical.test.js.snap
@@ -89,54 +89,47 @@ exports[`Canonical Podcast Page Header Navigation link should match text and url
 
 exports[`Canonical Podcast Page Header Navigation link should match text and url 3`] = `
 {
-  "text": "Eleições EUA",
-  "url": "/portuguese/topics/c30gn378n6kt",
-}
-`;
-
-exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
-{
   "text": "Internacional",
   "url": "/portuguese/topics/cmdm4ynm24kt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Economia",
   "url": "/portuguese/topics/cvjp2jr0k9rt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Saúde",
   "url": "/portuguese/topics/c340q430z4vt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciência",
   "url": "/portuguese/topics/cr50y580rjxt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Tecnologia",
   "url": "/portuguese/topics/c404v027pd4t",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Vídeos",
   "url": "/portuguese/topics/c9y2j35dn2zt",
 }
 `;
 
-exports[`Canonical Podcast Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Podcast Page Header Navigation link should match text and url 9`] = `
 {
   "text": "BBC Lê",
   "url": "/portuguese/topics/cxndrr1qgllt",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Remove election topic link from Brasil's navgation bar 

Code changes
======

- Edited Navigation section of src/app/lib/config/services/portuguese.ts to add election topic link in second position
- upadted snapshots



Testing
======
1. Open Brasil front page, Eleições EUA should no longer appear as third link in the nav 

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
