### PR TITLE
JumpTo - Add custom metric name for view/click handlers

### DIFF
--- a/src/app/components/JumpTo/index.test.tsx
+++ b/src/app/components/JumpTo/index.test.tsx
@@ -51,7 +51,6 @@ describe('JumpTo Component', () => {
     const jumpToTrackerData = {
       componentName: 'jumpto',
       optimizely: null,
-      optimizelyEventName: 'jumpto',
     };
     describe('View tracking', () => {
       const viewTrackerSpy = jest.spyOn(viewTracking, 'default');

--- a/src/app/components/JumpTo/index.tsx
+++ b/src/app/components/JumpTo/index.tsx
@@ -22,7 +22,6 @@ const JumpTo = ({ jumpToHeadings }: JumpToProps) => {
   const eventTrackingData: EventTrackingMetadata = {
     componentName: 'jumpto',
     optimizely,
-    optimizelyEventName: 'jumpto',
   };
 
   // TODO: Remove for release

--- a/src/app/components/RelatedContentSection/index.tsx
+++ b/src/app/components/RelatedContentSection/index.tsx
@@ -112,7 +112,7 @@ const RelatedContentSection = ({ content, sendOptimizelyEvents }: Props) => {
       componentName: 'related-content',
       ...(sendOptimizelyEvents && {
         optimizely,
-        optimizelyEventName: 'related_content',
+        optimizelyMetricName: 'related_content',
       }),
     },
   };

--- a/src/app/components/RelatedContentSection/index.tsx
+++ b/src/app/components/RelatedContentSection/index.tsx
@@ -112,7 +112,7 @@ const RelatedContentSection = ({ content, sendOptimizelyEvents }: Props) => {
       componentName: 'related-content',
       ...(sendOptimizelyEvents && {
         optimizely,
-        optimizelyMetricName: 'related_content',
+        optimizelyMetricNameOverride: 'related_content',
       }),
     },
   };

--- a/src/app/hooks/useClickTrackerHandler/index.jsx
+++ b/src/app/hooks/useClickTrackerHandler/index.jsx
@@ -19,7 +19,7 @@ const useClickTrackerHandler = (props = {}) => {
   const advertiserID = path(['advertiserID'], props);
   const format = path(['format'], props);
   const optimizely = path(['optimizely'], props);
-  const optimizelyMetricName = props?.optimizelyMetricName;
+  const optimizelyMetricNameOverride = props?.optimizelyMetricNameOverride;
   const detailedPlacement = props?.detailedPlacement;
 
   const { trackingIsEnabled } = useTrackingToggle(componentName);
@@ -68,8 +68,8 @@ const useClickTrackerHandler = (props = {}) => {
             };
 
             optimizely.track(
-              optimizelyMetricName
-                ? `${optimizelyMetricName}_clicks`
+              optimizelyMetricNameOverride
+                ? `${optimizelyMetricNameOverride}_clicks`
                 : 'component_clicks',
               optimizely.user.id,
               overrideAttributes,
@@ -117,7 +117,7 @@ const useClickTrackerHandler = (props = {}) => {
       advertiserID,
       format,
       optimizely,
-      optimizelyMetricName,
+      optimizelyMetricNameOverride,
       detailedPlacement,
     ],
   );

--- a/src/app/hooks/useClickTrackerHandler/index.jsx
+++ b/src/app/hooks/useClickTrackerHandler/index.jsx
@@ -19,7 +19,7 @@ const useClickTrackerHandler = (props = {}) => {
   const advertiserID = path(['advertiserID'], props);
   const format = path(['format'], props);
   const optimizely = path(['optimizely'], props);
-  const optimizelyEventName = props?.optimizelyEventName;
+  const optimizelyMetricName = props?.optimizelyMetricName;
   const detailedPlacement = props?.detailedPlacement;
 
   const { trackingIsEnabled } = useTrackingToggle(componentName);
@@ -60,8 +60,7 @@ const useClickTrackerHandler = (props = {}) => {
           event.preventDefault();
 
           if (optimizely) {
-            const eventName =
-              optimizelyEventName || OPTIMIZELY_CONFIG.viewClickAttributeId;
+            const eventName = OPTIMIZELY_CONFIG.viewClickAttributeId;
 
             const overrideAttributes = {
               ...optimizely.user.attributes,
@@ -69,7 +68,9 @@ const useClickTrackerHandler = (props = {}) => {
             };
 
             optimizely.track(
-              'component_clicks',
+              optimizelyMetricName
+                ? `${optimizelyMetricName}_clicks`
+                : 'component_clicks',
               optimizely.user.id,
               overrideAttributes,
             );
@@ -116,7 +117,7 @@ const useClickTrackerHandler = (props = {}) => {
       advertiserID,
       format,
       optimizely,
-      optimizelyEventName,
+      optimizelyMetricName,
       detailedPlacement,
     ],
   );

--- a/src/app/hooks/useClickTrackerHandler/index.test.jsx
+++ b/src/app/hooks/useClickTrackerHandler/index.test.jsx
@@ -371,7 +371,7 @@ describe('Click tracking', () => {
     );
   });
 
-  it('should use "eventName" property if provided in optimizely object', async () => {
+  it('should use "optimizelyMetricNameOverride" property if provided in eventTrackingData object', async () => {
     const mockOptimizelyTrack = jest.fn();
     const mockUserId = 'test';
     const mockAttributes = { foo: 'bar' };
@@ -381,7 +381,7 @@ describe('Click tracking', () => {
         track: mockOptimizelyTrack,
         user: { attributes: mockAttributes, id: mockUserId },
       },
-      optimizelyEventName: 'myEvent',
+      optimizelyMetricNameOverride: 'myEvent',
     };
     const {
       metadata: { atiAnalytics },
@@ -403,10 +403,10 @@ describe('Click tracking', () => {
 
     expect(mockOptimizelyTrack).toHaveBeenCalledTimes(1);
     expect(mockOptimizelyTrack).toHaveBeenCalledWith(
-      'component_clicks',
+      'myEvent_clicks',
       mockUserId,
       {
-        clicked_myEvent: true,
+        clicked_wsoj: true,
         foo: 'bar',
       },
     );

--- a/src/app/hooks/useViewTracker/index.jsx
+++ b/src/app/hooks/useViewTracker/index.jsx
@@ -19,7 +19,7 @@ const useViewTracker = (props = {}) => {
   const advertiserID = path(['advertiserID'], props);
   const url = path(['url'], props);
   const optimizely = path(['optimizely'], props);
-  const optimizelyEventName = props?.optimizelyEventName;
+  const optimizelyMetricName = props?.optimizelyMetricName;
   const detailedPlacement = props?.detailedPlacement;
 
   const observer = useRef();
@@ -75,8 +75,7 @@ const useViewTracker = (props = {}) => {
 
         if (shouldSendEvent) {
           if (optimizely) {
-            const eventName =
-              optimizelyEventName || OPTIMIZELY_CONFIG.viewClickAttributeId;
+            const eventName = OPTIMIZELY_CONFIG.viewClickAttributeId;
 
             const overrideAttributes = {
               ...optimizely.user.attributes,
@@ -84,7 +83,9 @@ const useViewTracker = (props = {}) => {
             };
 
             optimizely.track(
-              'component_views',
+              optimizelyMetricName
+                ? `${optimizelyMetricName}_views`
+                : 'component_views',
               optimizely.user.id,
               overrideAttributes,
             );
@@ -133,7 +134,7 @@ const useViewTracker = (props = {}) => {
     advertiserID,
     url,
     optimizely,
-    optimizelyEventName,
+    optimizelyMetricName,
     detailedPlacement,
   ]);
 

--- a/src/app/hooks/useViewTracker/index.jsx
+++ b/src/app/hooks/useViewTracker/index.jsx
@@ -19,7 +19,7 @@ const useViewTracker = (props = {}) => {
   const advertiserID = path(['advertiserID'], props);
   const url = path(['url'], props);
   const optimizely = path(['optimizely'], props);
-  const optimizelyMetricName = props?.optimizelyMetricName;
+  const optimizelyMetricNameOverride = props?.optimizelyMetricNameOverride;
   const detailedPlacement = props?.detailedPlacement;
 
   const observer = useRef();
@@ -83,8 +83,8 @@ const useViewTracker = (props = {}) => {
             };
 
             optimizely.track(
-              optimizelyMetricName
-                ? `${optimizelyMetricName}_views`
+              optimizelyMetricNameOverride
+                ? `${optimizelyMetricNameOverride}_views`
                 : 'component_views',
               optimizely.user.id,
               overrideAttributes,
@@ -134,7 +134,7 @@ const useViewTracker = (props = {}) => {
     advertiserID,
     url,
     optimizely,
-    optimizelyMetricName,
+    optimizelyMetricNameOverride,
     detailedPlacement,
   ]);
 

--- a/src/app/hooks/useViewTracker/index.test.jsx
+++ b/src/app/hooks/useViewTracker/index.test.jsx
@@ -199,7 +199,7 @@ describe('Expected use', () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it('should use "eventName" property if provided in optimizely object', async () => {
+  it('should use "optimizelyMetricNameOverride" property if provided in eventTrackingData object', async () => {
     const mockOptimizelyTrack = jest.fn();
     const mockUserId = 'test';
     const mockAttributes = { foo: 'bar' };
@@ -209,7 +209,7 @@ describe('Expected use', () => {
         track: mockOptimizelyTrack,
         user: { attributes: mockAttributes, id: mockUserId },
       },
-      optimizelyEventName: 'myEvent',
+      optimizelyMetricNameOverride: 'myEvent',
     };
 
     const {
@@ -246,11 +246,11 @@ describe('Expected use', () => {
     expect(options).toEqual({ threshold: [0.5] });
     expect(mockOptimizelyTrack).toHaveBeenCalledTimes(1);
     expect(mockOptimizelyTrack).toHaveBeenCalledWith(
-      'component_views',
+      'myEvent_views',
       mockUserId,
       {
         foo: 'bar',
-        viewed_myEvent: true,
+        viewed_wsoj: true,
       },
     );
   });

--- a/src/app/models/types/eventTracking.ts
+++ b/src/app/models/types/eventTracking.ts
@@ -6,7 +6,7 @@ export type EventTrackingMetadata = {
   campaignID?: string;
   advertiserID?: number | string;
   optimizely?: ReactSDKClient | null;
-  optimizelyMetricName?: string;
+  optimizelyMetricNameOverride?: string;
 };
 
 export type EventTrackingBlock = {

--- a/src/app/models/types/eventTracking.ts
+++ b/src/app/models/types/eventTracking.ts
@@ -6,7 +6,7 @@ export type EventTrackingMetadata = {
   campaignID?: string;
   advertiserID?: number | string;
   optimizely?: ReactSDKClient | null;
-  optimizelyEventName?: string;
+  optimizelyMetricName?: string;
 };
 
 export type EventTrackingBlock = {


### PR DESCRIPTION
Overall changes
======
- Adds `optimizelyMetricName` prop that is passed into the view/click handlers. When passed in, it will override the Optimizely metric name for view/click handlers, or default to the existing `component_views` and `component_clicks` metric name if not overridden

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
