### PR TITLE
Sinhala nav: remove election link

### DIFF
--- a/src/app/lib/config/services/sinhala.ts
+++ b/src/app/lib/config/services/sinhala.ts
@@ -318,10 +318,6 @@ export const service: DefaultServiceConfig = {
         url: '/sinhala',
       },
       {
-        title: 'මහ මැතිවරණය 2024',
-        url: '/sinhala/topics/c5y3ve4z2lkt',
-      },
-      {
         title: 'ශ්‍රී ලංකා',
         url: '/sinhala/topics/cg7267dz901t',
       },

--- a/src/integration/pages/liveRadio/sinhala/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/sinhala/__snapshots__/canonical.test.js.snap
@@ -75,33 +75,26 @@ exports[`Canonical Sinhala Live Radio Page Header Navigation link should match t
 
 exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 2`] = `
 {
-  "text": "මහ මැතිවරණය 2024",
-  "url": "/sinhala/topics/c5y3ve4z2lkt",
-}
-`;
-
-exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 3`] = `
-{
   "text": "ශ්‍රී ලංකා",
   "url": "/sinhala/topics/cg7267dz901t",
 }
 `;
 
-exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 3`] = `
 {
   "text": "ලෝකය",
   "url": "/sinhala/topics/c83plvepnq1t",
 }
 `;
 
-exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 4`] = `
 {
   "text": "වීඩියෝ",
   "url": "/sinhala/topics/crldzm9n2lnt",
 }
 `;
 
-exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 5`] = `
 {
   "text": "කලා",
   "url": "/sinhala/topics/c7zp5zxk8jxt",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Remove election topic link from Sinhala navgation bar 

Code changes
======

- Edited Navigation section of src/app/lib/config/services/sinhala.ts to add election topic link in second position
- Updated snapshots



Testing
======
1. Open Sinhala's front page, මහ මැතිවරණය 2024 should no longer appear as second link in the nav 

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
