### PR TITLE
Uzbek: update Related content + Serbian nav: remove US election link

### DIFF
--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -115,10 +115,6 @@ export const service: SerbianConfig = {
         url: '/serbian/lat',
       },
       {
-        title: 'Američki izbori',
-        url: '/serbian/lat/topics/c1v8enng1npt',
-      },
-      {
         title: 'Srbija',
         url: '/serbian/lat/topics/cr50vdy9q6wt',
       },

--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -72,7 +72,7 @@ const defaultCyrillicConfig = {
     home: 'Бош саҳифа',
     currentPage: 'Жорий саҳифа',
     skipLinkText: 'Саҳифага ўтиш',
-    relatedContent: 'Бу мавзуда батафсилроқ',
+    relatedContent: 'Мавзуга алоқадор',
     relatedTopics: 'Алоқадор мавзулар',
     navMenuText: 'Бўлимлар',
     mediaAssetPage: {

--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -407,7 +407,7 @@ export const service: UzbekConfig = {
       home: 'Bosh sahifa',
       currentPage: 'Joriy sahifa',
       skipLinkText: 'Sahifaga o‘tish',
-      relatedContent: 'Bu mavzuda batafsilroq',
+      relatedContent: 'Mavzuga aloqador',
       relatedTopics: 'Aloqador mavzular',
       navMenuText: 'Bo‘limlar',
       mediaAssetPage: {

--- a/src/integration/pages/homePage/serbianLat/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/homePage/serbianLat/__snapshots__/amp.test.js.snap
@@ -212,40 +212,33 @@ exports[`AMP Home Page Header Navigation link should match text and url 1`] = `
 
 exports[`AMP Home Page Header Navigation link should match text and url 2`] = `
 {
-  "text": "Američki izbori",
-  "url": "/serbian/lat/topics/c1v8enng1npt",
-}
-`;
-
-exports[`AMP Home Page Header Navigation link should match text and url 3`] = `
-{
   "text": "Srbija",
   "url": "/serbian/lat/topics/cr50vdy9q6wt",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 4`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 3`] = `
 {
   "text": "Balkan",
   "url": "/serbian/lat/topics/c06g87137jgt",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Svet",
   "url": "/serbian/lat/topics/c2lej05e1eqt",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Video",
   "url": "/serbian/lat/topics/c44vyp5g049t",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Najpopularnije",
   "url": "/serbian/lat/popular/read",

--- a/src/integration/pages/homePage/serbianLat/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/serbianLat/__snapshots__/canonical.test.js.snap
@@ -126,40 +126,33 @@ exports[`Canonical Home Page Header Navigation link should match text and url 1`
 
 exports[`Canonical Home Page Header Navigation link should match text and url 2`] = `
 {
-  "text": "Američki izbori",
-  "url": "/serbian/lat/topics/c1v8enng1npt",
-}
-`;
-
-exports[`Canonical Home Page Header Navigation link should match text and url 3`] = `
-{
   "text": "Srbija",
   "url": "/serbian/lat/topics/cr50vdy9q6wt",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 3`] = `
 {
   "text": "Balkan",
   "url": "/serbian/lat/topics/c06g87137jgt",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Svet",
   "url": "/serbian/lat/topics/c2lej05e1eqt",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Video",
   "url": "/serbian/lat/topics/c44vyp5g049t",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Najpopularnije",
   "url": "/serbian/lat/popular/read",

--- a/ws-nextjs-app/integration/pages/live/serbian/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/live/serbian/__snapshots__/canonical.test.ts.snap
@@ -80,40 +80,33 @@ exports[`Canonical Live Header Navigation link should match text and url 1`] = `
 
 exports[`Canonical Live Header Navigation link should match text and url 2`] = `
 {
-  "text": "Američki izbori",
-  "url": "/serbian/lat/topics/c1v8enng1npt",
-}
-`;
-
-exports[`Canonical Live Header Navigation link should match text and url 3`] = `
-{
   "text": "Srbija",
   "url": "/serbian/lat/topics/cr50vdy9q6wt",
 }
 `;
 
-exports[`Canonical Live Header Navigation link should match text and url 4`] = `
+exports[`Canonical Live Header Navigation link should match text and url 3`] = `
 {
   "text": "Balkan",
   "url": "/serbian/lat/topics/c06g87137jgt",
 }
 `;
 
-exports[`Canonical Live Header Navigation link should match text and url 5`] = `
+exports[`Canonical Live Header Navigation link should match text and url 4`] = `
 {
   "text": "Svet",
   "url": "/serbian/lat/topics/c2lej05e1eqt",
 }
 `;
 
-exports[`Canonical Live Header Navigation link should match text and url 6`] = `
+exports[`Canonical Live Header Navigation link should match text and url 5`] = `
 {
   "text": "Video",
   "url": "/serbian/lat/topics/c44vyp5g049t",
 }
 `;
 
-exports[`Canonical Live Header Navigation link should match text and url 7`] = `
+exports[`Canonical Live Header Navigation link should match text and url 6`] = `
 {
   "text": "Najpopularnije",
   "url": "/serbian/lat/popular/read",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Update Related content string on Uzbek
- Remove US election topic links on Serbian navigaiton bar 

Code changes
======
- Updated the Cyrillic and Latin relatedContent strings on src/app/lib/config/services/uzbek.ts
- Edited Navigation section of src/app/lib/config/services/serbian.ts to remove election topic link 
- Updated snapshots
 

Testing
======
1. Open http://localhost:7080/uzbek/articles/c5yxzwg47lpo/cyr?renderer_env=live the Related content content component at the bottom of the article should have Мавзуга алоқадор as a heading on the Latin version http://localhost:7080/uzbek/articles/c5yxzwg47lpo/lat?renderer_env=live the heading should be Mavzuga aloqador
2 Open the Serbian Latin front page, Američki izbori should no longer appear as second item in the navigation bar


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
