### PR TITLE
Arabic and Urdu podcast promo: update to promote WhatsApp

### DIFF
--- a/src/app/lib/config/services/arabic.ts
+++ b/src/app/lib/config/services/arabic.ts
@@ -48,16 +48,16 @@ export const service: DefaultServiceConfig = {
     googleSiteVerification: 'D-aEHUiyVaMoUJXjVRbDVkxS0dLTMUZLD3dLPTnWO4Q',
     podcastPromo: {
       title: 'يستحق الانتباه',
-      brandTitle: 'يستحق الانتباه',
+      brandTitle: 'حسابنا الرسمي على واتساب',
       brandDescription:
-        'شرح معمق لقصة بارزة من أخباراليوم، لمساعدتك على فهم أهم الأحداث حولك وأثرها على حياتك',
+        'تابعوا التغطية الشاملة من بي بي سي نيوز عربي على واتساب.',
       image: {
-        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0h6dt4s.jpg',
-        alt: 'يستحق الانتباه',
+        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0k7ksmj.png',
+        alt: 'حسابنا الرسمي على واتساب',
       },
       linkLabel: {
-        text: 'الحلقات',
-        href: 'https://www.bbc.com/arabic/podcasts/p0h6d6nm',
+        text: 'اضغط هنا',
+        href: 'https://www.whatsapp.com/channel/0029Val8KlE5a24BsTvuVd2e',
       },
       skipLink: {
         text: 'تخطى %title% وواصل القراءة',

--- a/src/app/lib/config/services/urdu.ts
+++ b/src/app/lib/config/services/urdu.ts
@@ -46,17 +46,17 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: true,
     showRelatedTopics: true,
     podcastPromo: {
-      title: 'پوڈکاسٹ',
-      brandTitle: 'ڈرامہ کوئین',
+      title: 'واٹس ایپ',
+      brandTitle: 'بی بی سی اردو اب واٹس ایپ پر',
       brandDescription:
-        '’ڈرامہ کوئین‘ پوڈکاسٹ میں سنیے وہ باتیں جنہیں کسی کے ساتھ بانٹنے نہیں دیا جاتا',
+        'بی بی سی اردو کی خبروں اور فیچرز کو اپنے فون پر حاصل کریں اور سب سے پہلے جانیں پاکستان اور دنیا بھر سے ان کہانیوں کے بارے میں جو آپ کے لیے معنی رکھتی ہیں',
       image: {
-        src: 'http://ichef.bbci.co.uk/images/ic/448xn/p0c04zy8.jpg',
-        alt: 'ڈرامہ کوئین',
+        src: 'http://ichef.bbci.co.uk/images/ic/448xn/p0k7ks07.png',
+        alt: 'بی بی سی اردو اب واٹس ایپ پر',
       },
       linkLabel: {
-        text: 'قسطیں',
-        href: 'https://www.bbc.com/urdu/podcasts/p0c04t7w',
+        text: 'سبسکرائب کرنے کے لیے کلک کریں',
+        href: 'https://whatsapp.com/channel/0029Vateujy3wtbGKtkkMD44',
       },
       skipLink: {
         text: 'مواد پر جائیں',


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Update the in-article podcast promo for Arabic and Urdu to promote their Whatsapp channel

Code changes
======

- Edited podcastPromo section of src/app/lib/config/services/arabic.ts 
- Edited podcastPromo section of src/app/lib/config/services/urdu.ts 

Testing
======
1. Open an article in BBC Arabic, the podcast promo should have the whatsapp promo graphic and point to: https://www.whatsapp.com/channel/0029Val8KlE5a24BsTvuVd2e e.g. http://localhost:7080/arabic/articles/c8j91j2ljppo?renderer_env=live
2. Open an article in BBC Urdu, the podcast promo should have the whatsapp promo graphic and point to: https://www.whatsapp.com/channel/0029Vateujy3wtbGKtkkMD44 e.g. http://localhost:7080/urdu/articles/ce31x340j2lo?renderer_env=live

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
