### PR TITLE
Mundo and Turkce navs: remove US election

### DIFF
--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -416,10 +416,6 @@ export const service: DefaultServiceConfig = {
         url: '/mundo/topics/c2lej05epw5t',
       },
       {
-        title: 'Elecciones EE.UU. 2024',
-        url: '/mundo/topics/c1v8en6r2qgt',
-      },
-      {
         title: 'Hay Festival',
         url: '/mundo/topics/cr50y7p7qyqt',
       },
@@ -442,10 +438,6 @@ export const service: DefaultServiceConfig = {
       {
         title: 'Tecnología',
         url: '/mundo/topics/cyx5krnw38vt',
-      },
-      {
-        title: 'Centroamérica Cuenta',
-        url: '/mundo/topics/c404v5z1k8wt',
       },
     ],
   },

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -333,10 +333,6 @@ export const service: DefaultServiceConfig = {
         url: '/turkce/topics/cg726y2qxg1t',
       },
       {
-        title: 'ABD Seçimleri',
-        url: '/turkce/topics/c3gyjy0vy91t',
-      },
-      {
         title: 'Rusya-Ukrayna Savaşı',
         url: '/turkce/topics/cy0ryl4pvx6t',
       },

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
@@ -237,57 +237,43 @@ exports[`AMP Most Read Page Header Navigation link should match text and url 3`]
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 4`] = `
 {
-  "text": "Elecciones EE.UU. 2024",
-  "url": "/mundo/topics/c1v8en6r2qgt",
-}
-`;
-
-exports[`AMP Most Read Page Header Navigation link should match text and url 5`] = `
-{
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
-}
-`;
-
-exports[`AMP Most Read Page Header Navigation link should match text and url 11`] = `
-{
-  "text": "Centroamérica Cuenta",
-  "url": "/mundo/topics/c404v5z1k8wt",
 }
 `;
 

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
@@ -143,57 +143,43 @@ exports[`Canonical Most Read Page Header Navigation link should match text and u
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 4`] = `
 {
-  "text": "Elecciones EE.UU. 2024",
-  "url": "/mundo/topics/c1v8en6r2qgt",
-}
-`;
-
-exports[`Canonical Most Read Page Header Navigation link should match text and url 5`] = `
-{
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
-}
-`;
-
-exports[`Canonical Most Read Page Header Navigation link should match text and url 11`] = `
-{
-  "text": "Centroamérica Cuenta",
-  "url": "/mundo/topics/c404v5z1k8wt",
 }
 `;
 

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
@@ -237,57 +237,43 @@ exports[`AMP Photo Gallery Page Header Navigation link should match text and url
 
 exports[`AMP Photo Gallery Page Header Navigation link should match text and url 4`] = `
 {
-  "text": "Elecciones EE.UU. 2024",
-  "url": "/mundo/topics/c1v8en6r2qgt",
-}
-`;
-
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 5`] = `
-{
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
-}
-`;
-
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 11`] = `
-{
-  "text": "Centroamérica Cuenta",
-  "url": "/mundo/topics/c404v5z1k8wt",
 }
 `;
 

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
@@ -146,57 +146,43 @@ exports[`Canonical Photo Gallery Page Header Navigation link should match text a
 
 exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 4`] = `
 {
-  "text": "Elecciones EE.UU. 2024",
-  "url": "/mundo/topics/c1v8en6r2qgt",
-}
-`;
-
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 5`] = `
-{
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
-}
-`;
-
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 11`] = `
-{
-  "text": "Centroamérica Cuenta",
-  "url": "/mundo/topics/c404v5z1k8wt",
 }
 `;
 

--- a/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
@@ -237,57 +237,43 @@ exports[`AMP Story Page Header Navigation link should match text and url 3`] = `
 
 exports[`AMP Story Page Header Navigation link should match text and url 4`] = `
 {
-  "text": "Elecciones EE.UU. 2024",
-  "url": "/mundo/topics/c1v8en6r2qgt",
-}
-`;
-
-exports[`AMP Story Page Header Navigation link should match text and url 5`] = `
-{
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
-}
-`;
-
-exports[`AMP Story Page Header Navigation link should match text and url 11`] = `
-{
-  "text": "Centroamérica Cuenta",
-  "url": "/mundo/topics/c404v5z1k8wt",
 }
 `;
 

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -159,57 +159,43 @@ exports[`Canonical Story Page Header Navigation link should match text and url 3
 
 exports[`Canonical Story Page Header Navigation link should match text and url 4`] = `
 {
-  "text": "Elecciones EE.UU. 2024",
-  "url": "/mundo/topics/c1v8en6r2qgt",
-}
-`;
-
-exports[`Canonical Story Page Header Navigation link should match text and url 5`] = `
-{
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
-}
-`;
-
-exports[`Canonical Story Page Header Navigation link should match text and url 11`] = `
-{
-  "text": "Centroamérica Cuenta",
-  "url": "/mundo/topics/c404v5z1k8wt",
 }
 `;
 

--- a/ws-nextjs-app/integration/pages/send/mundo/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/send/mundo/__snapshots__/canonical.test.ts.snap
@@ -94,57 +94,43 @@ exports[`Canonical Send Header Navigation link should match text and url 3`] = `
 
 exports[`Canonical Send Header Navigation link should match text and url 4`] = `
 {
-  "text": "Elecciones EE.UU. 2024",
-  "url": "/mundo/topics/c1v8en6r2qgt",
-}
-`;
-
-exports[`Canonical Send Header Navigation link should match text and url 5`] = `
-{
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 6`] = `
+exports[`Canonical Send Header Navigation link should match text and url 5`] = `
 {
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 7`] = `
+exports[`Canonical Send Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 8`] = `
+exports[`Canonical Send Header Navigation link should match text and url 7`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 9`] = `
+exports[`Canonical Send Header Navigation link should match text and url 8`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 10`] = `
+exports[`Canonical Send Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
-}
-`;
-
-exports[`Canonical Send Header Navigation link should match text and url 11`] = `
-{
-  "text": "Centroamérica Cuenta",
-  "url": "/mundo/topics/c404v5z1k8wt",
 }
 `;
 


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Remove US election topic link and CentroAmerica cuenta from Mundo's navigation bar 
- Remove US election topic link from Turkce's navigation bar 



Code changes
======

- Edited Navigation section of src/app/lib/config/services/mundo.ts
- Edited Navigation section of src/app/lib/config/services/turkce.ts
- Updqted snapshots


Testing
======
1. Open Mundo front page, Elecciones EE.UU. 2024 should no longer appear as fourth link in the nav and Centroamerica Cuenta should not appear as the last item
2. Open Turkce's front page, ABD Seçimleri should no longer appear as fourth link in the nav

<img width="898" alt="mundo_nav" src="https://github.com/user-attachments/assets/1a27f66c-c714-43e6-8313-cf97c87570ad">
<img width="812" alt="turkce-nav" src="https://github.com/user-attachments/assets/fa874559-d12d-47d6-91f1-5d8ef9f82ace">

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
