### PR TITLE
WSTEAM1-1347: Fetch live data on the test environment for on demand audio & podcasts

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -699,7 +699,7 @@ module.exports = () => ({
             enabled: true,
           },
         },
-        smoke: false,
+        smoke: true,
       },
       onDemandTV: { environments: undefined, smoke: false },
       topicPage: {
@@ -1588,7 +1588,7 @@ module.exports = () => ({
             enabled: true,
           },
         },
-        smoke: false,
+        smoke: true,
       },
       onDemandTV: { environments: undefined, smoke: false },
       topicPage: { environments: undefined, smoke: false },

--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -1588,7 +1588,7 @@ module.exports = () => ({
             enabled: true,
           },
         },
-        smoke: true,
+        smoke: false,
       },
       onDemandTV: { environments: undefined, smoke: false },
       topicPage: { environments: undefined, smoke: false },

--- a/data/arabic/bbc_arabic_radio/w3ct01yb.json
+++ b/data/arabic/bbc_arabic_radio/w3ct01yb.json
@@ -1,515 +1,104 @@
 {
-  "metadata": {
-    "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct01yb",
-    "locators": { "pid": "w3ct01yb", "brandPid": "p030vh39" },
-    "type": "WSRADIO",
-    "createdBy": "bbc_arabic_radio",
+  "data": {
+    "metadata": {
+      "type": "On Demand Radio",
+      "atiAnalytics": {
+        "pageIdentifier": "arabic.bbc_arabic_radio.w3ct01yb.page",
+        "contentType": "player-episode",
+        "pageTitle": "نقطة حوار - BBC News Arabic",
+        "language": "ar",
+        "contentId": "urn:bbc:pips:w3ct01yb"
+      }
+    },
     "language": "ar",
-    "lastUpdated": 1608292285998,
-    "firstPublished": 1582584617000,
-    "lastPublished": 1582584617000,
-    "timestamp": 1582584617000,
-    "options": {},
-    "analyticsLabels": {
-      "pageTitle": "نقطة حوار - BBC News Arabic",
-      "pageIdentifier": "arabic.bbc_arabic_radio.w3ct01yb.page",
-      "producerId": "5",
-      "contentType": "player-episode",
-      "producer": "ARABIC"
-    },
-    "tags": {},
-    "version": "v1.3.11",
-    "blockTypes": ["media"],
-    "title": "نقطة حوار",
-    "releaseDateTimeStamp": 1583452800000,
-    "atiAnalytics": {}
-  },
-  "content": {
-    "blocks": [
-      {
-        "id": "w3ct01yb",
-        "subType": "episode",
-        "format": "Audio",
-        "title": "06/03/2020 GMT",
-        "synopses": {
-          "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
-          "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
-        },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-        "embedding": false,
-        "advertising": false,
-        "versions": [],
-        "availability": "notAvailable",
-        "smpKind": "radioProgramme",
-        "type": "media"
-      }
-    ]
-  },
-  "promo": {
-    "headlines": { "headline": "نقطة حوار" },
-    "locators": { "pid": "w3ct01yb", "brandPid": "p030vh39" },
-    "media": {
-      "id": "w3ct01yb",
-      "subType": "episode",
-      "format": "Audio",
-      "title": "06/03/2020 GMT",
-      "synopses": {
-        "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
-        "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
-      },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-      "embedding": false,
-      "advertising": false,
-      "versions": [],
-      "availability": "notAvailable",
-      "smpKind": "radioProgramme",
-      "type": "media"
-    },
-    "indexImage": {
-      "id": "",
-      "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-      "height": 0,
-      "width": 0,
-      "altText": null,
-      "copyrightHolder": null,
-      "type": "image"
-    },
-    "releaseDateTimestamp": 1583452800000,
-    "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
+    "brandTitle": "نقطة حوار",
+    "episodeTitle": "نقطة حوار",
+    "headline": "نقطة حوار",
+    "shortSynopsis": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
+    "mediumSynopsis": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
     "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct01yb",
-    "type": "ws_radio"
-  },
-  "relatedContent": {
-    "site": {
-      "subType": "site",
-      "name": "Arabic",
-      "uri": "/arabic",
-      "type": "simple"
-    },
-    "groups": [
+    "brandId": "p030vh39",
+    "episodeId": "w3ct01yb",
+    "masterBrand": "bbc_arabic_radio",
+    "releaseDateTimeStamp": "2020-03-06T00:00:00.000Z",
+    "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
+    "imageAltText": null,
+    "promoBrandTitle": "نقطة حوار",
+    "durationISO8601": null,
+    "thumbnailImageUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p08b23t4.png",
+    "episodeAvailability": "expired",
+    "recentEpisodes": [],
+    "mediaBlocks": [
       {
-        "type": "other-episode",
-        "promos": [
-          {
-            "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct197f", "brandPid": "p030vh39" },
-            "media": {
-              "id": "w3ct197f",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "17/12/2020 GMT",
-              "synopses": {
-                "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
-                "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w4hqwzrn",
-                  "types": ["Original"],
-                  "duration": 1440,
-                  "durationISO8601": "PT24M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1610883000000,
-                  "availableFrom": 1608172200000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1608163200000,
-            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct197f",
-            "type": "ws_radio"
+        "type": "audio",
+        "model": {
+          "id": "w3ct01yb",
+          "subType": "episode",
+          "format": "Audio",
+          "title": "نقطة حوار",
+          "synopses": {
+            "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
+            "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
           },
-          {
-            "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct1969", "brandPid": "p030vh39" },
-            "media": {
-              "id": "w3ct1969",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "15/12/2020 GMT",
-              "synopses": {
-                "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
-                "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w4hqwzqj",
-                  "types": ["Original"],
-                  "duration": 1440,
-                  "durationISO8601": "PT24M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1610710200000,
-                  "availableFrom": 1607999400000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1607990400000,
-            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct1969",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct1940", "brandPid": "p030vh39" },
-            "media": {
-              "id": "w3ct1940",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "12/12/2020 GMT",
-              "synopses": {
-                "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
-                "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w4hqwzn7",
-                  "types": ["Original"],
-                  "duration": 1440,
-                  "durationISO8601": "PT24M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1610537400000,
-                  "availableFrom": 1607740200000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1607731200000,
-            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct1940",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct197d", "brandPid": "p030vh39" },
-            "media": {
-              "id": "w3ct197d",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "10/12/2020 GMT",
-              "synopses": {
-                "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
-                "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w4hqwzrm",
-                  "types": ["Original"],
-                  "duration": 1440,
-                  "durationISO8601": "PT24M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1610418600000,
-                  "availableFrom": 1607567400000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1607558400000,
-            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct197d",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct1968", "brandPid": "p030vh39" },
-            "media": {
-              "id": "w3ct1968",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "08/12/2020 GMT",
-              "synopses": {
-                "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
-                "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w4hqwzqh",
-                  "types": ["Original"],
-                  "duration": 1440,
-                  "durationISO8601": "PT24M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1610105400000,
-                  "availableFrom": 1607394600000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1607385600000,
-            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct1968",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct193z", "brandPid": "p030vh39" },
-            "media": {
-              "id": "w3ct193z",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "05/12/2020 GMT",
-              "synopses": {
-                "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
-                "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w4hqwzn6",
-                  "types": ["Original"],
-                  "duration": 1440,
-                  "durationISO8601": "PT24M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1609932600000,
-                  "availableFrom": 1607135400000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1607126400000,
-            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct193z",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct197c", "brandPid": "p030vh39" },
-            "media": {
-              "id": "w3ct197c",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "03/12/2020 GMT",
-              "synopses": {
-                "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
-                "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w4hqwzrl",
-                  "types": ["Original"],
-                  "duration": 1440,
-                  "durationISO8601": "PT24M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1609813800000,
-                  "availableFrom": 1606962600000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1606953600000,
-            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct197c",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct1967", "brandPid": "p030vh39" },
-            "media": {
-              "id": "w3ct1967",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "01/12/2020 GMT",
-              "synopses": {
-                "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
-                "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w4hqwzqg",
-                  "types": ["Original"],
-                  "duration": 1440,
-                  "durationISO8601": "PT24M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1609500600000,
-                  "availableFrom": 1606789800000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1606780800000,
-            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct1967",
-            "type": "ws_radio"
-          }
-        ]
+          "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
+          "embedding": false,
+          "advertising": false,
+          "versions": [],
+          "availability": "notAvailable",
+          "smpKind": "radioProgramme",
+          "episodeTitle": "نقطة حوار",
+          "type": "media"
+        }
+      },
+      {
+        "type": "mediaOverrides",
+        "model": {
+          "language": "ar",
+          "pageIdentifierOverride": "arabic.bbc_arabic_radio.w3ct01yb.page"
+        }
       }
-    ]
-  }
+    ],
+    "isPodcast": false,
+    "summary": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
+    "radioScheduleData": [
+      {
+        "id": "p0k1cpty",
+        "state": "next",
+        "startTime": "2024-12-05T05:59:30.000Z",
+        "link": "/arabic/bbc_arabic_radio/w17300sfc9c0zjt",
+        "brandTitle": "غزة اليوم ",
+        "summary": "البرنامج يقدم خدمة اخبارية  ومعلومات   تهدف الى توعية  الجمهور في غزة  بما يحدث على الأرض ",
+        "duration": "PT30M"
+      },
+      {
+        "id": "p0k16srk",
+        "state": "onDemand",
+        "startTime": "2024-12-04T14:59:30.000Z",
+        "link": "/arabic/bbc_arabic_radio/w17300sv2nn9tkj",
+        "brandTitle": "غزة اليوم ",
+        "summary": "البرنامج يقدم خدمة اخبارية  ومعلومات   تهدف الى توعية  الجمهور في غزة  بما يحدث على الأرض ",
+        "duration": "PT30M"
+      },
+      {
+        "id": "p0k12xxz",
+        "state": "onDemand",
+        "startTime": "2024-12-04T05:59:30.000Z",
+        "link": "/arabic/bbc_arabic_radio/w17300sfc9by2mq",
+        "brandTitle": "غزة اليوم ",
+        "summary": "البرنامج يقدم خدمة اخبارية  ومعلومات   تهدف الى توعية  الجمهور في غزة  بما يحدث على الأرض ",
+        "duration": "PT30M"
+      },
+      {
+        "id": "p0k0y0sl",
+        "state": "onDemand",
+        "startTime": "2024-12-03T14:59:30.000Z",
+        "link": "/arabic/bbc_arabic_radio/w17300sv2nn6xnf",
+        "brandTitle": "غزة اليوم ",
+        "summary": "البرنامج يقدم خدمة اخبارية  ومعلومات   تهدف الى توعية  الجمهور في غزة  بما يحدث على الأرض ",
+        "duration": "PT30M"
+      }
+    ],
+    "externalLinkVersionId": null
+  },
+  "contentType": "application/json; charset=utf-8"
 }

--- a/data/arabic/podcasts/p02pc9qc.json
+++ b/data/arabic/podcasts/p02pc9qc.json
@@ -1,553 +1,202 @@
 {
-  "metadata": {
-    "id": "urn:bbc:ares:ws_media:brand:bbc_arabic_radio/p02pc9qc",
-    "locators": { "pid": "p08wtg4d", "brandPid": "p02pc9qc" },
-    "type": "WSRADIO",
-    "createdBy": "bbc_arabic_radio",
+  "data": {
+    "metadata": {
+      "type": "Podcast",
+      "atiAnalytics": {
+        "pageIdentifier": "arabic.bbc_arabic_radio.podcasts.programmes.p02pc9qc.page",
+        "contentType": "player-episode",
+        "pageTitle": "بي بي سي إكسترا - BBC News Arabic",
+        "language": "ar",
+        "contentId": "urn:bbc:pips:p02pc9qc"
+      }
+    },
     "language": "ar",
-    "lastUpdated": 1604309876295,
-    "firstPublished": 1603983776000,
-    "lastPublished": 1603983776000,
-    "timestamp": 1603983776000,
-    "options": {},
-    "analyticsLabels": {
-      "pageTitle": "BBC Xtra - BBC News Arabic",
-      "pageIdentifier": "arabic.bbc_arabic_radio.programmes.p02pc9qc.page",
-      "producerId": "5",
-      "contentType": "player-episode",
-      "producer": "ARABIC"
-    },
-    "tags": {},
-    "version": "v1.3.8",
-    "blockTypes": ["media"],
-    "title": "BBC Xtra",
-    "releaseDateTimeStamp": 1603929600000,
-    "atiAnalytics": {}
-  },
-  "content": {
-    "blocks": [
+    "brandTitle": "بي بي سي إكسترا",
+    "episodeTitle": "زلزال تركيا و سوريا: ناجون من أنطاكيا يتحدثون عن مرارة الهجرة",
+    "headline": "بي بي سي إكسترا",
+    "shortSynopsis": "زلزال تركيا و سوريا: ناجون من أنطاكيا يتحدثون عن مرارة الهجرة",
+    "mediumSynopsis": "",
+    "id": "urn:bbc:ares:ws_media:brand:bbc_arabic_radio/p02pc9qc",
+    "brandId": "p02pc9qc",
+    "episodeId": "p0fk8gw9",
+    "masterBrand": "bbc_arabic_radio",
+    "releaseDateTimeStamp": "2023-04-28T00:00:00.000Z",
+    "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0fk8gx6.jpg",
+    "imageAltText": "",
+    "promoBrandTitle": "بي بي سي إكسترا",
+    "durationISO8601": "PT18M28S",
+    "thumbnailImageUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p0fk8gx6.jpg",
+    "episodeAvailability": "available",
+    "recentEpisodes": [
       {
-        "id": "p08wtg4d",
-        "subType": "episode",
-        "format": "Audio",
-        "title": "",
-        "synopses": {
-          "short": "التصويت عبر البريد في الانتخابات الرئاسية الأميركية",
-          "long": "التصويت الانتخابي عبر البريد خيار يلجأ إليه البعض\nمتى وكيف بدأ توتر العلاقات بين الدولة العثمانية وفرنسا؟\nونتابع احتفالات المغاربة بالمولد النبوي\nبي بي سي إكسترا بصحبة محمد مطر"
-        },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-        "embedding": false,
-        "advertising": false,
-        "versions": [
-          {
-            "versionId": "p08wsxz2",
-            "types": ["Podcast"],
-            "duration": 410,
-            "durationISO8601": "PT6M50S",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": true,
-              "nonUk": true,
-              "world": false
-            },
-            "availableUntil": 1606575660000,
-            "availableFrom": 1603983660000,
-            "availabilityStatus": "available"
-          }
-        ],
-        "availability": "available",
-        "smpKind": "radioProgramme",
-        "episodeTitle": "التصويت عبر البريد في الانتخابات الرئاسية الأميركية",
-        "type": "media"
-      }
-    ]
-  },
-  "promo": {
-    "headlines": { "headline": "BBC Xtra" },
-    "locators": { "pid": "p08wtg4d", "brandPid": "p02pc9qc" },
-    "media": {
-      "id": "p08wtg4d",
-      "subType": "episode",
-      "format": "Audio",
-      "title": "",
-      "synopses": {
-        "short": "التصويت عبر البريد في الانتخابات الرئاسية الأميركية",
-        "long": "التصويت الانتخابي عبر البريد خيار يلجأ إليه البعض\nمتى وكيف بدأ توتر العلاقات بين الدولة العثمانية وفرنسا؟\nونتابع احتفالات المغاربة بالمولد النبوي\nبي بي سي إكسترا بصحبة محمد مطر"
+        "id": "p0fgnwjn",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "إكسترا رمضان: ما قصة زواج محمد المصري مع يوكو اليابانية؟",
+        "timestamp": "2023-04-14T00:00:00.000Z",
+        "duration": "PT13M21S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0fgnwl6.jpg",
+        "altText": "بي بي سي إكسترا"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-      "embedding": false,
-      "advertising": false,
-      "versions": [
-        {
-          "versionId": "p08wsxz2",
-          "types": ["Podcast"],
-          "duration": 410,
-          "durationISO8601": "PT6M50S",
-          "warnings": {},
-          "availableTerritories": { "uk": true, "nonUk": true, "world": false },
-          "availableUntil": 1606575660000,
-          "availableFrom": 1603983660000,
-          "availabilityStatus": "available"
-        }
-      ],
-      "availability": "available",
-      "smpKind": "radioProgramme",
-      "episodeTitle": "التصويت عبر البريد في الانتخابات الرئاسية الأميركية",
-      "type": "media"
-    },
-    "indexImage": {
-      "id": "",
-      "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-      "height": 0,
-      "width": 0,
-      "altText": null,
-      "copyrightHolder": null,
-      "type": "image"
-    },
-    "releaseDateTimestamp": 1603929600000,
-    "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-    "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08wtg4d",
-    "type": "ws_radio"
-  },
-  "relatedContent": {
-    "site": {
-      "subType": "site",
-      "name": "Arabic",
-      "uri": "/arabic",
-      "type": "simple"
-    },
-    "groups": [
       {
-        "type": "other-episode",
-        "promos": [
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08wkzvd", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08wkzvd",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "كيف نضمن حق الاعتقاد والتعبد للأقليات الدينية؟",
-                "long": "في هذه الحلقة من بي بي سي إكسترا:\n-\tهل تقبل الجزائر على تحسن لواقع الحريات الدينية؟\n-\tانقسام في بولندا بشأن قوانين الإجهاض.\n-\tتفاؤل بين أصحاب الشركات الكبرى في السودان بعد شطبه من قائمة الدول الراعية للإرهاب.\n-\tومحلات كويتية تقاطع المنتجات الفرنسية.\nإكسترا اليوم مع هالة صالح."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08wknst",
-                  "types": ["Podcast"],
-                  "duration": 2667,
-                  "durationISO8601": "PT44M27S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1606404480000,
-                  "availableFrom": 1603812480000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "كيف نضمن حق الاعتقاد والتعبد للأقليات الدينية؟",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1603756800000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08wkzvd",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08wg9ff", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08wg9ff",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "لماذا يكون العمر عائقا لتألق المرأة كمذيعة ؟",
-                "long": "في هذه الحلقة من بي بي سي إكسترا نسأل ما هي فرص المذيعات للحضور الإعلامي مع التقدم في العمر؟ وهل هناك أسباب لغياب المساواة بين المذيعين والمذيعات؟\nكما نتعرف على أطفال القمر الذين لا يتحملون الشمس.. ونتابع ردود الفعل في أستراليا حيال قضية فحص تعرضت له مسافرات أستراليات من الدوحة ووصفنه بالمهين.\nالحلقة بصحبة محمد مطر."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08wfn0f",
-                  "types": ["Podcast"],
-                  "duration": 2667,
-                  "durationISO8601": "PT44M27S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1606317780000,
-                  "availableFrom": 1603725780000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "لماذا يكون العمر عائقا لتألق المرأة كمذيعة ؟",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1603670400000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08wg9ff",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08w1lmp", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08w1lmp",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "فرنسا: تهديدات لمسلمين بعد ذبح مدرس",
-                "long": "اليوم في بي بي سي إكسترا: \nتهديدات لمسلمين بعد حادث ذبح مدرس في فرنسا.\nوهجوم على قطع أثرية في جزيرة المتاحف في برلين. \nوأخيراً في السودان، مقتل شخص في تظاهرات الأربعاء بعد وقوع اشتباكات. \nبي بي سي إكسترا بصحبة ياسمين أبو خضرا"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08w14mh",
-                  "types": ["Podcast"],
-                  "duration": 2660,
-                  "durationISO8601": "PT44M20S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1605971340000,
-                  "availableFrom": 1603379340000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "فرنسا: تهديدات لمسلمين بعد ذبح مدرس",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1603324800000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08w1lmp",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08vtncm", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08vtncm",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "الحوار .. اللجوء لطرف ثالث .. ما الحل لخلافات زوجية متجذرة ؟",
-                "long": "في حلقة اليوم من بي بي سي إكسترا .. نسأل هل المشكلة الأكبر بين الأزواج أحيانا هي الخلاف حول حل المشكلة؟ وهل تدخل العائلة نافع دائما؟\nفي اكسترا أيضا نناقش الآثار النفسية لكورونا التي تعقدها أحيانا تعامل الآخرين معها.. ونتعرف على جريمة الآداب العامة التي بسببها رُحلت مذيعة لبنانية من الكويت \nهذه الحلقة بصحبة بسمة كراشة"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08vt825",
-                  "types": ["Podcast"],
-                  "duration": 2688,
-                  "durationISO8601": "PT44M48S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1605798600000,
-                  "availableFrom": 1603206600000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "الحوار .. اللجوء لطرف ثالث .. ما الحل لخلافات زوجية متجذرة ؟",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1603152000000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08vtncm",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08vqk5t", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08vqk5t",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "من جيل \"أعطني الآن بندقية إلى فلسطين خذوني\" إلى جيل \"خذني زيارة لتل آبيب\"",
-                "long": "في هذه الحلقة من بي بي سي إكسترا نسأل هل الشعوب العربية كالحكومات اختلفت حول التطبيع مع إسرائيل؟  ونتعرف على وثائقي جديد لبي بي سي حول تعذيب طلبة في الخلوات السودانية ونستمع لشهادة  مهندسةُ آبار نفط عمانية عن المشاكل التي و اجهتها  \nهذه الحلقة بصحبة بسمة كراشة"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08vq2fm",
-                  "types": ["Podcast"],
-                  "duration": 2621,
-                  "durationISO8601": "PT43M41S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1605713280000,
-                  "availableFrom": 1603121280000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "من جيل \"أعطني الآن بندقية إلى فلسطين خذوني\" إلى جيل \"خذني زيارة لتل آبيب\"",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1603065600000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08vqk5t",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08vdb7x", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08vdb7x",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "جيل محمود ياسين هل مازال حيا في الذاكرة؟",
-                "long": "في هذه الحلقة من بي بي سي اكسترا: \nمحمود ياسين بعيون ابنته رانيا\nوماذا يقوله مخرج شاب عن العمل مع النجم الراحل\nهذه أسباب النزاع على الحدود البحرية بين لبنان وإسرائيل\nوماهي شبكة الجيل الخامس؟"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08vd1w1",
-                  "types": ["Podcast"],
-                  "duration": 2635,
-                  "durationISO8601": "PT43M55S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1605367560000,
-                  "availableFrom": 1602775560000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "جيل محمود ياسين هل مازال حيا في الذاكرة؟",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1602720000000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08vdb7x",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08v5gf3", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08v5gf3",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "الحنين إلى لقاء الطبيب وجها لوجه وليس عبر الهاتف",
-                "long": "في هذه الحلقة نسأل كيف ينظر المرضى للاستشارات عن بعد؟ وهل التشخيص عبر الإنترنت دقيق؟ كما نحاول التعرف على شكل كليوباترا الحقيقي وما إذا كانت تشبه نجمات هوليوود اللواتي قدمنها؟ ونتعرف على الجدل الحاصل في الجزائر بسبب درجات الثانوية العامة\n\nإكسترا اليوم مع منال جوهر"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08v56x2",
-                  "types": ["Podcast"],
-                  "duration": 403,
-                  "durationISO8601": "PT6M43S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1605194880000,
-                  "availableFrom": 1602602880000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "الحنين إلى لقاء الطبيب وجها لوجه وليس عبر الهاتف",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1602547200000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08v5gf3",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08v2mmd", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08v2mmd",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "ما الحلول البديلة إذا لم تتوفر المراحيض العامة؟",
-                "long": "في حلقة اليوم من بي بي سي إكسترا: \n•\tفي غياب المراحيض العامة، البعض يضطر إلى البدائل. \n•\tلماذا قرر فيسبوك منع الإعلانات السياسية بعد الانتخابات الأمريكية؟\n•\tنتعرف على مبادرة في موريتانيا للتوعية بأخطار سرطان الثدي. \n•\tنستمع إلى حالات كانت تعانى من الاكتئاب في السودان. \nحلقة إكسترا من تقديم محمد قطب"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08v28v4",
-                  "types": ["Podcast"],
-                  "duration": 2653,
-                  "durationISO8601": "PT44M13S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1605108180000,
-                  "availableFrom": 1602516180000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "ما الحلول البديلة إذا لم تتوفر المراحيض العامة؟",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1602460800000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08v2mmd",
-            "type": "ws_radio"
-          }
-        ]
+        "id": "p0fffqlh",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "إكسترا رمضان: زواجي المختلط",
+        "timestamp": "2023-04-07T00:00:00.000Z",
+        "duration": "PT13M44S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0fffqnf.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0fcyrx8",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "إكسترا بودكاست: بلا وظيفة... ما العمل؟",
+        "timestamp": "2023-03-31T00:00:00.000Z",
+        "duration": "PT17M29S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0fcys0c.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0fbqvst",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "أكسترا بودكاست : ما بعد الزلزال ...",
+        "timestamp": "2023-03-24T00:00:00.000Z",
+        "duration": "PT29M39S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0fbqvv7.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0f99zjf",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "إكسترا بودكاست: بلا وظيفة... ما العمل؟",
+        "timestamp": "2023-03-17T00:00:00.000Z",
+        "duration": "PT20M28S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0f9vxs0.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0f8nc0z",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "بي بي سي إكسترا الإذاعي يودع مستمعيه في حلقة استثنائية على الهواء",
+        "timestamp": "2023-03-14T00:00:00.000Z",
+        "duration": "PT50M45S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p09t98w8.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0f8n8yz",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "أسرار بدايات بي بي سي إكسترا",
+        "timestamp": "2023-03-14T00:00:00.000Z",
+        "duration": "PT50M32S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p09t98w8.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0f7yvl7",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "إكسترا بودكاست: ما بعد الزلزال",
+        "timestamp": "2023-03-10T00:00:00.000Z",
+        "duration": "PT18M48S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0f7yvmb.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0dz2633",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "بي بي سي إكسترا",
+        "timestamp": "2023-01-26T00:00:00.000Z",
+        "duration": "PT50M30S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0dz264z.jpg",
+        "altText": "بي بي سي إكسترا"
       }
-    ]
-  }
+    ],
+    "mediaBlocks": [
+      {
+        "type": "audio",
+        "model": {
+          "id": "p0fk8gw9",
+          "subType": "episode",
+          "format": "Audio",
+          "title": "بي بي سي إكسترا",
+          "synopses": {
+            "short": "زلزال تركيا و سوريا: ناجون من أنطاكيا يتحدثون عن مرارة الهجرة",
+            "long": "بعد حوالي ثلاثة أشهرعلى الزلزال، هل استعاد الناجون من الزلزال في أنطاكيا الأمل اثر فقدان بيوتهم في المدينة التي طالتها أضرار بالغة؟\nنتحدث إلى سامية وعائلتها وهم أتراك من أصول عربية و إلى أحمد دحو صانع محتوى سوري شاب، هاجر إلى أنطاكيا قبل سبع سنوات لكن الزلزال دفعه إلى الهجرة مرة أخرى. الحلقة أعدتها وقدمتها بسمة كراشة بمساعدة بناني الخنشي و كريم إمام، و بإشراف رئيسة التحرير كريمة كواح.\n\nيمكنكم الاستماع إلى حلقات إكسترا بودكاست على صفحة بي بي سي عربي بودكاست، ساوند كلاود، وسبوتيفاي و أبل بودكاست."
+          },
+          "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0fk8gx6.jpg",
+          "embedding": true,
+          "advertising": false,
+          "versions": [
+            {
+              "versionId": "p0fk8fw4",
+              "types": ["Podcast"],
+              "duration": 1108,
+              "durationISO8601": "PT18M28S",
+              "warnings": {},
+              "availableTerritories": {
+                "uk": true,
+                "nonUk": true,
+                "world": false
+              },
+              "availableFrom": "2023-04-28T07:30:00.000Z",
+              "availabilityStatus": "available",
+              "availableUntil": null
+            }
+          ],
+          "availability": "available",
+          "smpKind": "radioProgramme",
+          "episodeTitle": "زلزال تركيا و سوريا: ناجون من أنطاكيا يتحدثون عن مرارة الهجرة",
+          "type": "media"
+        }
+      },
+      {
+        "type": "mediaOverrides",
+        "model": {
+          "language": "ar",
+          "pageIdentifierOverride": "arabic.bbc_arabic_radio.podcasts.p0fk8gw9.page"
+        }
+      }
+    ],
+    "isPodcast": true,
+    "summary": "زلزال تركيا و سوريا: ناجون من أنطاكيا يتحدثون عن مرارة الهجرة",
+    "radioScheduleData": [
+      {
+        "id": "p0k1cpty",
+        "state": "next",
+        "startTime": "2024-12-05T05:59:30.000Z",
+        "link": "/arabic/bbc_arabic_radio/w17300sfc9c0zjt",
+        "brandTitle": "غزة اليوم ",
+        "summary": "البرنامج يقدم خدمة اخبارية  ومعلومات   تهدف الى توعية  الجمهور في غزة  بما يحدث على الأرض ",
+        "duration": "PT30M"
+      },
+      {
+        "id": "p0k16srk",
+        "state": "onDemand",
+        "startTime": "2024-12-04T14:59:30.000Z",
+        "link": "/arabic/bbc_arabic_radio/w17300sv2nn9tkj",
+        "brandTitle": "غزة اليوم ",
+        "summary": "البرنامج يقدم خدمة اخبارية  ومعلومات   تهدف الى توعية  الجمهور في غزة  بما يحدث على الأرض ",
+        "duration": "PT30M"
+      },
+      {
+        "id": "p0k12xxz",
+        "state": "onDemand",
+        "startTime": "2024-12-04T05:59:30.000Z",
+        "link": "/arabic/bbc_arabic_radio/w17300sfc9by2mq",
+        "brandTitle": "غزة اليوم ",
+        "summary": "البرنامج يقدم خدمة اخبارية  ومعلومات   تهدف الى توعية  الجمهور في غزة  بما يحدث على الأرض ",
+        "duration": "PT30M"
+      },
+      {
+        "id": "p0k0y0sl",
+        "state": "onDemand",
+        "startTime": "2024-12-03T14:59:30.000Z",
+        "link": "/arabic/bbc_arabic_radio/w17300sv2nn6xnf",
+        "brandTitle": "غزة اليوم ",
+        "summary": "البرنامج يقدم خدمة اخبارية  ومعلومات   تهدف الى توعية  الجمهور في غزة  بما يحدث على الأرض ",
+        "duration": "PT30M"
+      }
+    ],
+    "externalLinkVersionId": "p0fk8fw4"
+  },
+  "contentType": "application/json; charset=utf-8"
 }

--- a/data/arabic/podcasts/p02pc9qc/p08wtg4d.json
+++ b/data/arabic/podcasts/p02pc9qc/p08wtg4d.json
@@ -1,553 +1,194 @@
 {
-  "metadata": {
-    "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08wtg4d",
-    "locators": { "pid": "p08wtg4d", "brandPid": "p02pc9qc" },
-    "type": "WSRADIO",
-    "createdBy": "bbc_arabic_radio",
+  "data": {
+    "metadata": {
+      "type": "Podcast",
+      "atiAnalytics": {
+        "pageIdentifier": "arabic.bbc_arabic_radio.podcasts.p08wtg4d.page",
+        "contentType": "player-episode",
+        "pageTitle": "بي بي سي إكسترا - BBC News Arabic",
+        "language": "ar",
+        "contentId": "urn:bbc:pips:p08wtg4d"
+      }
+    },
     "language": "ar",
-    "lastUpdated": 1604309877147,
-    "firstPublished": 1603983776000,
-    "lastPublished": 1603983776000,
-    "timestamp": 1603983776000,
-    "options": {},
-    "analyticsLabels": {
-      "pageTitle": "BBC Xtra - BBC News Arabic",
-      "pageIdentifier": "arabic.bbc_arabic_radio.p08wtg4d.page",
-      "producerId": "5",
-      "contentType": "player-episode",
-      "producer": "ARABIC"
-    },
-    "tags": {},
-    "version": "v1.3.8",
-    "blockTypes": ["media"],
-    "title": "BBC Xtra",
-    "releaseDateTimeStamp": 1603929600000,
-    "atiAnalytics": {}
-  },
-  "content": {
-    "blocks": [
-      {
-        "id": "p08wtg4d",
-        "subType": "episode",
-        "format": "Audio",
-        "title": "",
-        "synopses": {
-          "short": "التصويت عبر البريد في الانتخابات الرئاسية الأميركية",
-          "medium": "التصويت الانتخابي عبر البريد خيار يلجأ إليه البعض\nمتى وكيف بدأ توتر العلاقات بين الدولة العثمانية وفرنسا؟\nونتابع احتفالات المغاربة بالمولد النبوي\nبي بي سي إكسترا بصحبة محمد مطر"
-        },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-        "embedding": true,
-        "advertising": false,
-        "versions": [
-          {
-            "versionId": "p08wsxz2",
-            "types": ["Podcast"],
-            "duration": 410,
-            "durationISO8601": "PT6M50S",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": true,
-              "nonUk": true,
-              "world": false
-            },
-            "availableUntil": 1606575660000,
-            "availableFrom": 1603983660000,
-            "availabilityStatus": "available"
-          }
-        ],
-        "availability": "available",
-        "smpKind": "radioProgramme",
-        "episodeTitle": "التصويت عبر البريد في الانتخابات الرئاسية الأميركية",
-        "type": "media"
-      }
-    ]
-  },
-  "promo": {
-    "headlines": { "headline": "BBC Xtra" },
-    "locators": { "pid": "p08wtg4d", "brandPid": "p02pc9qc" },
-    "media": {
-      "id": "p08wtg4d",
-      "subType": "episode",
-      "format": "Audio",
-      "title": "",
-      "synopses": {
-        "short": "التصويت عبر البريد في الانتخابات الرئاسية الأميركية",
-        "long": "التصويت الانتخابي عبر البريد خيار يلجأ إليه البعض\nمتى وكيف بدأ توتر العلاقات بين الدولة العثمانية وفرنسا؟\nونتابع احتفالات المغاربة بالمولد النبوي\nبي بي سي إكسترا بصحبة محمد مطر"
-      },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-      "embedding": true,
-      "advertising": false,
-      "versions": [
-        {
-          "versionId": "p08wsxz2",
-          "types": ["Podcast"],
-          "duration": 410,
-          "durationISO8601": "PT6M50S",
-          "warnings": {},
-          "availableTerritories": { "uk": true, "nonUk": true, "world": false },
-          "availableUntil": 1606575660000,
-          "availableFrom": 1603983660000,
-          "availabilityStatus": "available"
-        }
-      ],
-      "availability": "available",
-      "smpKind": "radioProgramme",
-      "episodeTitle": "التصويت عبر البريد في الانتخابات الرئاسية الأميركية",
-      "type": "media"
-    },
-    "indexImage": {
-      "id": "",
-      "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-      "height": 0,
-      "width": 0,
-      "altText": null,
-      "copyrightHolder": null,
-      "type": "image"
-    },
-    "releaseDateTimestamp": 1603929600000,
-    "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
+    "brandTitle": "بي بي سي إكسترا",
+    "episodeTitle": "التصويت عبر البريد في الانتخابات الرئاسية الأميركية",
+    "headline": "بي بي سي إكسترا",
+    "shortSynopsis": "التصويت عبر البريد في الانتخابات الرئاسية الأميركية",
+    "mediumSynopsis": "",
     "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08wtg4d",
-    "type": "ws_radio"
-  },
-  "relatedContent": {
-    "site": {
-      "subType": "site",
-      "name": "Arabic",
-      "uri": "/arabic",
-      "type": "simple"
-    },
-    "groups": [
+    "brandId": "p02pc9qc",
+    "episodeId": "p08wtg4d",
+    "masterBrand": "bbc_arabic_radio",
+    "releaseDateTimeStamp": "2020-10-29T00:00:00.000Z",
+    "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09t98w8.jpg",
+    "imageAltText": "",
+    "promoBrandTitle": "بي بي سي إكسترا",
+    "durationISO8601": null,
+    "thumbnailImageUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p09t98w8.jpg",
+    "episodeAvailability": "expired",
+    "recentEpisodes": [
       {
-        "type": "other-episode",
-        "promos": [
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08wkzvd", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08wkzvd",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "كيف نضمن حق الاعتقاد والتعبد للأقليات الدينية؟",
-                "long": "في هذه الحلقة من بي بي سي إكسترا:\n-\tهل تقبل الجزائر على تحسن لواقع الحريات الدينية؟\n-\tانقسام في بولندا بشأن قوانين الإجهاض.\n-\tتفاؤل بين أصحاب الشركات الكبرى في السودان بعد شطبه من قائمة الدول الراعية للإرهاب.\n-\tومحلات كويتية تقاطع المنتجات الفرنسية.\nإكسترا اليوم مع هالة صالح."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08wknst",
-                  "types": ["Podcast"],
-                  "duration": 2667,
-                  "durationISO8601": "PT44M27S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1606404480000,
-                  "availableFrom": 1603812480000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "كيف نضمن حق الاعتقاد والتعبد للأقليات الدينية؟",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1603756800000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08wkzvd",
-            "type": "ws_radio"
+        "id": "p0fk8gw9",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "زلزال تركيا و سوريا: ناجون من أنطاكيا يتحدثون عن مرارة الهجرة",
+        "timestamp": "2023-04-28T00:00:00.000Z",
+        "duration": "PT18M28S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0fk8gx6.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0fgnwjn",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "إكسترا رمضان: ما قصة زواج محمد المصري مع يوكو اليابانية؟",
+        "timestamp": "2023-04-14T00:00:00.000Z",
+        "duration": "PT13M21S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0fgnwl6.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0fffqlh",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "إكسترا رمضان: زواجي المختلط",
+        "timestamp": "2023-04-07T00:00:00.000Z",
+        "duration": "PT13M44S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0fffqnf.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0fcyrx8",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "إكسترا بودكاست: بلا وظيفة... ما العمل؟",
+        "timestamp": "2023-03-31T00:00:00.000Z",
+        "duration": "PT17M29S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0fcys0c.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0fbqvst",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "أكسترا بودكاست : ما بعد الزلزال ...",
+        "timestamp": "2023-03-24T00:00:00.000Z",
+        "duration": "PT29M39S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0fbqvv7.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0f99zjf",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "إكسترا بودكاست: بلا وظيفة... ما العمل؟",
+        "timestamp": "2023-03-17T00:00:00.000Z",
+        "duration": "PT20M28S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0f9vxs0.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0f8nc0z",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "بي بي سي إكسترا الإذاعي يودع مستمعيه في حلقة استثنائية على الهواء",
+        "timestamp": "2023-03-14T00:00:00.000Z",
+        "duration": "PT50M45S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p09t98w8.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0f8n8yz",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "أسرار بدايات بي بي سي إكسترا",
+        "timestamp": "2023-03-14T00:00:00.000Z",
+        "duration": "PT50M32S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p09t98w8.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0f7yvl7",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "إكسترا بودكاست: ما بعد الزلزال",
+        "timestamp": "2023-03-10T00:00:00.000Z",
+        "duration": "PT18M48S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0f7yvmb.jpg",
+        "altText": "بي بي سي إكسترا"
+      },
+      {
+        "id": "p0dz2633",
+        "brandTitle": "بي بي سي إكسترا",
+        "episodeTitle": "بي بي سي إكسترا",
+        "timestamp": "2023-01-26T00:00:00.000Z",
+        "duration": "PT50M30S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p0dz264z.jpg",
+        "altText": "بي بي سي إكسترا"
+      }
+    ],
+    "mediaBlocks": [
+      {
+        "type": "audio",
+        "model": {
+          "id": "p08wtg4d",
+          "subType": "episode",
+          "format": "Audio",
+          "title": "بي بي سي إكسترا",
+          "synopses": {
+            "short": "التصويت عبر البريد في الانتخابات الرئاسية الأميركية",
+            "long": "التصويت الانتخابي عبر البريد خيار يلجأ إليه البعض\nمتى وكيف بدأ توتر العلاقات بين الدولة العثمانية وفرنسا؟\nونتابع احتفالات المغاربة بالمولد النبوي\nبي بي سي إكسترا بصحبة محمد مطر"
           },
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08wg9ff", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08wg9ff",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "لماذا يكون العمر عائقا لتألق المرأة كمذيعة ؟",
-                "long": "في هذه الحلقة من بي بي سي إكسترا نسأل ما هي فرص المذيعات للحضور الإعلامي مع التقدم في العمر؟ وهل هناك أسباب لغياب المساواة بين المذيعين والمذيعات؟\nكما نتعرف على أطفال القمر الذين لا يتحملون الشمس.. ونتابع ردود الفعل في أستراليا حيال قضية فحص تعرضت له مسافرات أستراليات من الدوحة ووصفنه بالمهين.\nالحلقة بصحبة محمد مطر."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08wfn0f",
-                  "types": ["Podcast"],
-                  "duration": 2667,
-                  "durationISO8601": "PT44M27S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1606317780000,
-                  "availableFrom": 1603725780000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "لماذا يكون العمر عائقا لتألق المرأة كمذيعة ؟",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1603670400000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08wg9ff",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08w1lmp", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08w1lmp",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "فرنسا: تهديدات لمسلمين بعد ذبح مدرس",
-                "long": "اليوم في بي بي سي إكسترا: \nتهديدات لمسلمين بعد حادث ذبح مدرس في فرنسا.\nوهجوم على قطع أثرية في جزيرة المتاحف في برلين. \nوأخيراً في السودان، مقتل شخص في تظاهرات الأربعاء بعد وقوع اشتباكات. \nبي بي سي إكسترا بصحبة ياسمين أبو خضرا"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08w14mh",
-                  "types": ["Podcast"],
-                  "duration": 2660,
-                  "durationISO8601": "PT44M20S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1605971340000,
-                  "availableFrom": 1603379340000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "فرنسا: تهديدات لمسلمين بعد ذبح مدرس",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1603324800000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08w1lmp",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08vtncm", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08vtncm",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "الحوار .. اللجوء لطرف ثالث .. ما الحل لخلافات زوجية متجذرة ؟",
-                "long": "في حلقة اليوم من بي بي سي إكسترا .. نسأل هل المشكلة الأكبر بين الأزواج أحيانا هي الخلاف حول حل المشكلة؟ وهل تدخل العائلة نافع دائما؟\nفي اكسترا أيضا نناقش الآثار النفسية لكورونا التي تعقدها أحيانا تعامل الآخرين معها.. ونتعرف على جريمة الآداب العامة التي بسببها رُحلت مذيعة لبنانية من الكويت \nهذه الحلقة بصحبة بسمة كراشة"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08vt825",
-                  "types": ["Podcast"],
-                  "duration": 2688,
-                  "durationISO8601": "PT44M48S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1605798600000,
-                  "availableFrom": 1603206600000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "الحوار .. اللجوء لطرف ثالث .. ما الحل لخلافات زوجية متجذرة ؟",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1603152000000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08vtncm",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08vqk5t", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08vqk5t",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "من جيل \"أعطني الآن بندقية إلى فلسطين خذوني\" إلى جيل \"خذني زيارة لتل آبيب\"",
-                "long": "في هذه الحلقة من بي بي سي إكسترا نسأل هل الشعوب العربية كالحكومات اختلفت حول التطبيع مع إسرائيل؟  ونتعرف على وثائقي جديد لبي بي سي حول تعذيب طلبة في الخلوات السودانية ونستمع لشهادة  مهندسةُ آبار نفط عمانية عن المشاكل التي و اجهتها  \nهذه الحلقة بصحبة بسمة كراشة"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08vq2fm",
-                  "types": ["Podcast"],
-                  "duration": 2621,
-                  "durationISO8601": "PT43M41S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1605713280000,
-                  "availableFrom": 1603121280000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "من جيل \"أعطني الآن بندقية إلى فلسطين خذوني\" إلى جيل \"خذني زيارة لتل آبيب\"",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1603065600000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08vqk5t",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08vdb7x", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08vdb7x",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "جيل محمود ياسين هل مازال حيا في الذاكرة؟",
-                "long": "في هذه الحلقة من بي بي سي اكسترا: \nمحمود ياسين بعيون ابنته رانيا\nوماذا يقوله مخرج شاب عن العمل مع النجم الراحل\nهذه أسباب النزاع على الحدود البحرية بين لبنان وإسرائيل\nوماهي شبكة الجيل الخامس؟"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08vd1w1",
-                  "types": ["Podcast"],
-                  "duration": 2635,
-                  "durationISO8601": "PT43M55S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1605367560000,
-                  "availableFrom": 1602775560000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "جيل محمود ياسين هل مازال حيا في الذاكرة؟",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1602720000000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08vdb7x",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08v5gf3", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08v5gf3",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "الحنين إلى لقاء الطبيب وجها لوجه وليس عبر الهاتف",
-                "long": "في هذه الحلقة نسأل كيف ينظر المرضى للاستشارات عن بعد؟ وهل التشخيص عبر الإنترنت دقيق؟ كما نحاول التعرف على شكل كليوباترا الحقيقي وما إذا كانت تشبه نجمات هوليوود اللواتي قدمنها؟ ونتعرف على الجدل الحاصل في الجزائر بسبب درجات الثانوية العامة\n\nإكسترا اليوم مع منال جوهر"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08v56x2",
-                  "types": ["Podcast"],
-                  "duration": 403,
-                  "durationISO8601": "PT6M43S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1605194880000,
-                  "availableFrom": 1602602880000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "الحنين إلى لقاء الطبيب وجها لوجه وليس عبر الهاتف",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1602547200000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08v5gf3",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "BBC Xtra" },
-            "locators": { "pid": "p08v2mmd", "brandPid": "p02pc9qc" },
-            "media": {
-              "id": "p08v2mmd",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "ما الحلول البديلة إذا لم تتوفر المراحيض العامة؟",
-                "long": "في حلقة اليوم من بي بي سي إكسترا: \n•\tفي غياب المراحيض العامة، البعض يضطر إلى البدائل. \n•\tلماذا قرر فيسبوك منع الإعلانات السياسية بعد الانتخابات الأمريكية؟\n•\tنتعرف على مبادرة في موريتانيا للتوعية بأخطار سرطان الثدي. \n•\tنستمع إلى حالات كانت تعانى من الاكتئاب في السودان. \nحلقة إكسترا من تقديم محمد قطب"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p08v28v4",
-                  "types": ["Podcast"],
-                  "duration": 2653,
-                  "durationISO8601": "PT44M13S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1605108180000,
-                  "availableFrom": 1602516180000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "ما الحلول البديلة إذا لم تتوفر المراحيض العامة؟",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02rt7vj.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1602460800000,
-            "brand": { "pid": "p02pc9qc", "title": "BBC Xtra" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/p08v2mmd",
-            "type": "ws_radio"
-          }
-        ]
+          "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09t98w8.jpg",
+          "embedding": true,
+          "advertising": false,
+          "versions": [],
+          "availability": "notAvailable",
+          "smpKind": "radioProgramme",
+          "episodeTitle": "التصويت عبر البريد في الانتخابات الرئاسية الأميركية",
+          "type": "media"
+        }
+      },
+      {
+        "type": "mediaOverrides",
+        "model": {
+          "language": "ar",
+          "pageIdentifierOverride": "arabic.bbc_arabic_radio.p08wtg4d.page"
+        }
+      }
+    ],
+    "isPodcast": true,
+    "summary": "التصويت عبر البريد في الانتخابات الرئاسية الأميركية",
+    "radioScheduleData": [
+      {
+        "id": "p0k1cpty",
+        "state": "next",
+        "startTime": "2024-12-05T05:59:30.000Z",
+        "link": "/arabic/bbc_arabic_radio/w17300sfc9c0zjt",
+        "brandTitle": "غزة اليوم ",
+        "summary": "البرنامج يقدم خدمة اخبارية  ومعلومات   تهدف الى توعية  الجمهور في غزة  بما يحدث على الأرض ",
+        "duration": "PT30M"
+      },
+      {
+        "id": "p0k16srk",
+        "state": "onDemand",
+        "startTime": "2024-12-04T14:59:30.000Z",
+        "link": "/arabic/bbc_arabic_radio/w17300sv2nn9tkj",
+        "brandTitle": "غزة اليوم ",
+        "summary": "البرنامج يقدم خدمة اخبارية  ومعلومات   تهدف الى توعية  الجمهور في غزة  بما يحدث على الأرض ",
+        "duration": "PT30M"
+      },
+      {
+        "id": "p0k12xxz",
+        "state": "onDemand",
+        "startTime": "2024-12-04T05:59:30.000Z",
+        "link": "/arabic/bbc_arabic_radio/w17300sfc9by2mq",
+        "brandTitle": "غزة اليوم ",
+        "summary": "البرنامج يقدم خدمة اخبارية  ومعلومات   تهدف الى توعية  الجمهور في غزة  بما يحدث على الأرض ",
+        "duration": "PT30M"
+      },
+      {
+        "id": "p0k0y0sl",
+        "state": "onDemand",
+        "startTime": "2024-12-03T14:59:30.000Z",
+        "link": "/arabic/bbc_arabic_radio/w17300sv2nn6xnf",
+        "brandTitle": "غزة اليوم ",
+        "summary": "البرنامج يقدم خدمة اخبارية  ومعلومات   تهدف الى توعية  الجمهور في غزة  بما يحدث على الأرض ",
+        "duration": "PT30M"
       }
     ]
-  }
+  },
+  "contentType": "application/json; charset=utf-8"
 }

--- a/data/gahuza/podcasts/p07yh8hb.json
+++ b/data/gahuza/podcasts/p07yh8hb.json
@@ -1,330 +1,137 @@
 {
-  "metadata": {
-    "id": "urn:bbc:ares:ws_media:brand:bbc_gahuza_radio/p07yh8hb",
-    "locators": { "pid": "p096621h", "brandPid": "p07yh8hb" },
-    "type": "WSRADIO",
-    "createdBy": "bbc_gahuza_radio",
+  "data": {
+    "metadata": {
+      "type": "Podcast",
+      "atiAnalytics": {
+        "pageIdentifier": "gahuza.bbc_gahuza_radio.podcasts.programmes.p07yh8hb.page",
+        "contentType": "player-episode",
+        "pageTitle": "Baza Muganga - BBC News Gahuza",
+        "language": "rw",
+        "contentId": "urn:bbc:pips:p07yh8hb"
+      }
+    },
     "language": "rw",
-    "lastUpdated": 1612889474546,
-    "firstPublished": 1612548597000,
-    "lastPublished": 1612548597000,
-    "timestamp": 1612548597000,
-    "options": {},
-    "analyticsLabels": {
-      "pageTitle": "Baza Muganga - BBC News Gahuza",
-      "pageIdentifier": "gahuza.bbc_gahuza_radio.programmes.p07yh8hb.page",
-      "producerId": "40",
-      "contentType": "player-episode",
-      "producer": "GAHUZA"
-    },
-    "tags": {},
-    "version": "v1.3.11",
-    "blockTypes": ["media"],
-    "title": "Baza Muganga",
-    "releaseDateTimeStamp": 1612483200000,
-    "atiAnalytics": {}
-  },
-  "content": {
-    "blocks": [
+    "brandTitle": "Baza Muganga",
+    "episodeTitle": "Ikiganiro cyo kuwa 29/11/2024",
+    "headline": "Baza Muganga",
+    "shortSynopsis": "Kurikira ikiganiro Bazamuganga kuri BBC Gahuzamiryango",
+    "mediumSynopsis": "",
+    "id": "urn:bbc:ares:ws_media:brand:bbc_gahuza_radio/p07yh8hb",
+    "brandId": "p07yh8hb",
+    "episodeId": "p0k7t82p",
+    "masterBrand": "bbc_gahuza_radio",
+    "releaseDateTimeStamp": "2024-11-29T00:00:00.000Z",
+    "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
+    "imageAltText": "",
+    "promoBrandTitle": "Baza Muganga",
+    "durationISO8601": "PT5M45S",
+    "thumbnailImageUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p082wk67.jpg",
+    "episodeAvailability": "available",
+    "recentEpisodes": [
       {
-        "id": "p096621h",
-        "subType": "episode",
-        "format": "Audio",
-        "title": "",
-        "synopses": {
-          "short": "Kurikira ikiganiro Bazamuganga kuri BBC Gahuzamiryango."
-        },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-        "embedding": false,
-        "advertising": false,
-        "versions": [
-          {
-            "versionId": "p09661q9",
-            "types": ["Podcast"],
-            "duration": 357,
-            "durationISO8601": "PT5M57S",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": true,
-              "nonUk": true,
-              "world": false
-            },
-            "availableUntil": 1615140480000,
-            "availableFrom": 1612548480000,
-            "availabilityStatus": "available"
-          }
-        ],
-        "availability": "available",
-        "smpKind": "radioProgramme",
-        "episodeTitle": "Ikiganiro cyo kuwa 05/02/2021",
-        "type": "media"
-      }
-    ]
-  },
-  "promo": {
-    "headlines": { "headline": "Baza Muganga" },
-    "locators": { "pid": "p096621h", "brandPid": "p07yh8hb" },
-    "media": {
-      "id": "p096621h",
-      "subType": "episode",
-      "format": "Audio",
-      "title": "",
-      "synopses": {
-        "short": "Kurikira ikiganiro Bazamuganga kuri BBC Gahuzamiryango."
+        "id": "p0k6cby1",
+        "brandTitle": "Baza Muganga",
+        "episodeTitle": "BBC Gahuzamiryango/ Baza Muganga",
+        "timestamp": "2024-11-22T00:00:00.000Z",
+        "duration": "PT6M2S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p082wk67.jpg",
+        "altText": "Baza Muganga"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-      "embedding": false,
-      "advertising": false,
-      "versions": [
-        {
-          "versionId": "p09661q9",
-          "types": ["Podcast"],
-          "duration": 357,
-          "durationISO8601": "PT5M57S",
-          "warnings": {},
-          "availableTerritories": { "uk": true, "nonUk": true, "world": false },
-          "availableUntil": 1615140480000,
-          "availableFrom": 1612548480000,
-          "availabilityStatus": "available"
-        }
-      ],
-      "availability": "available",
-      "smpKind": "radioProgramme",
-      "episodeTitle": "Ikiganiro cyo kuwa 05/02/2021",
-      "type": "media"
-    },
-    "indexImage": {
-      "id": "",
-      "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-      "height": 0,
-      "width": 0,
-      "altText": null,
-      "copyrightHolder": null,
-      "type": "image"
-    },
-    "releaseDateTimestamp": 1612483200000,
-    "brand": { "pid": "p07yh8hb", "title": "Baza Muganga" },
-    "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/p096621h",
-    "type": "ws_radio"
-  },
-  "relatedContent": {
-    "site": {
-      "subType": "site",
-      "name": "Gahuza",
-      "uri": "/gahuza",
-      "type": "simple"
-    },
-    "groups": [
       {
-        "type": "other-episode",
-        "promos": [
-          {
-            "headlines": { "headline": "Baza Muganga" },
-            "locators": { "pid": "p095jtct", "brandPid": "p07yh8hb" },
-            "media": {
-              "id": "p095jtct",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": { "short": "Baza muganga kuri BBC gahuzamiryango" },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p095jt1q",
-                  "types": ["Podcast"],
-                  "duration": 345,
-                  "durationISO8601": "PT5M45S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1614533280000,
-                  "availableFrom": 1611941280000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "Baza muganga 29/01/2021",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1611878400000,
-            "brand": { "pid": "p07yh8hb", "title": "Baza Muganga" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/p095jtct",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "Baza Muganga" },
-            "locators": { "pid": "p094vs2n", "brandPid": "p07yh8hb" },
-            "media": {
-              "id": "p094vs2n",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": { "short": "Baza Muganga 22/01/2021" },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p094vrh5",
-                  "types": ["Podcast"],
-                  "duration": 345,
-                  "durationISO8601": "PT5M45S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1613928780000,
-                  "availableFrom": 1611336780000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "Baza Muganga 22/01/2021",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1611273600000,
-            "brand": { "pid": "p07yh8hb", "title": "Baza Muganga" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/p094vs2n",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "Baza Muganga" },
-            "locators": { "pid": "p0944r77", "brandPid": "p07yh8hb" },
-            "media": {
-              "id": "p0944r77",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "Ikiganiro ku guca imvyaro ku bagore kandi igihe kitaragera"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p0944qzd",
-                  "types": ["Podcast"],
-                  "duration": 370,
-                  "durationISO8601": "PT6M10S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1613323380000,
-                  "availableFrom": 1610731380000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "Ikiganiro Bazamuganga co kuri uno wa gatanu itariki 15/01/2021",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1610668800000,
-            "brand": { "pid": "p07yh8hb", "title": "Baza Muganga" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/p0944r77",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "Baza Muganga" },
-            "locators": { "pid": "p07yh9qm", "brandPid": "p07yh8hb" },
-            "media": {
-              "id": "p07yh9qm",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "Ikiganiro Baza Muganga gitegurwa na BBC Gahuzamiryango."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p07yh6z4",
-                  "types": ["Podcast"],
-                  "duration": 8,
-                  "durationISO8601": "PT8S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableFrom": 1576840260000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "Welcome to Baza Muganga",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1576800000000,
-            "brand": { "pid": "p07yh8hb", "title": "Baza Muganga" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/p07yh9qm",
-            "type": "ws_radio"
-          }
-        ]
+        "id": "p0k4x0jm",
+        "brandTitle": "Baza Muganga",
+        "episodeTitle": "Baza Muganga 15/11/2024",
+        "timestamp": "2024-11-15T00:00:00.000Z",
+        "duration": "PT5M58S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p082wk67.jpg",
+        "altText": "Baza Muganga"
+      },
+      {
+        "id": "p0k396c8",
+        "brandTitle": "Baza Muganga",
+        "episodeTitle": "Ikiganiro cyo kuwa 08/11/2024",
+        "timestamp": "2024-11-08T00:00:00.000Z",
+        "duration": "PT6M2S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p082wk67.jpg",
+        "altText": "Baza Muganga"
+      },
+      {
+        "id": "p0f0xlq5",
+        "brandTitle": "Baza Muganga",
+        "episodeTitle": "Bazamuganga 03/02/2023",
+        "timestamp": "2023-02-03T00:00:00.000Z",
+        "duration": "PT5M29S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p082wk67.jpg",
+        "altText": "Baza Muganga"
+      },
+      {
+        "id": "p0b99rb5",
+        "brandTitle": "Baza Muganga",
+        "episodeTitle": "Bazamuganga 10/12/2021: Ikiganiro ku ndwara ya Otite cyangwa Umuhaha",
+        "timestamp": "2021-12-10T00:00:00.000Z",
+        "duration": "PT4M20S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p082wk67.jpg",
+        "altText": "Baza Muganga"
+      },
+      {
+        "id": "p07yh9qm",
+        "brandTitle": "Baza Muganga",
+        "episodeTitle": "Welcome to Baza Muganga",
+        "timestamp": "2019-12-20T00:00:00.000Z",
+        "duration": "PT8S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p082wk67.jpg",
+        "altText": "Baza Muganga"
       }
-    ]
-  }
+    ],
+    "mediaBlocks": [
+      {
+        "type": "audio",
+        "model": {
+          "id": "p0k7t82p",
+          "subType": "episode",
+          "format": "Audio",
+          "title": "Baza Muganga",
+          "synopses": {
+            "short": "Kurikira ikiganiro Bazamuganga kuri BBC Gahuzamiryango"
+          },
+          "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
+          "embedding": true,
+          "advertising": false,
+          "versions": [
+            {
+              "versionId": "p0k7t7vq",
+              "types": ["Podcast"],
+              "duration": 345,
+              "durationISO8601": "PT5M45S",
+              "warnings": {},
+              "availableTerritories": {
+                "uk": true,
+                "nonUk": true,
+                "world": false
+              },
+              "availableUntil": "2024-12-29T17:04:00.000Z",
+              "availableFrom": "2024-11-29T17:04:00.000Z",
+              "availabilityStatus": "available"
+            }
+          ],
+          "availability": "available",
+          "smpKind": "radioProgramme",
+          "episodeTitle": "Ikiganiro cyo kuwa 29/11/2024",
+          "type": "media"
+        }
+      },
+      {
+        "type": "mediaOverrides",
+        "model": {
+          "language": "rw",
+          "pageIdentifierOverride": "gahuza.bbc_gahuza_radio.podcasts.p0k7t82p.page"
+        }
+      }
+    ],
+    "isPodcast": true,
+    "summary": "Kurikira ikiganiro Bazamuganga kuri BBC Gahuzamiryango",
+    "radioScheduleData": null,
+    "externalLinkVersionId": "p0k7t7vq"
+  },
+  "contentType": "application/json; charset=utf-8"
 }

--- a/data/gahuza/podcasts/p07yh8hb/p094vs2n.json
+++ b/data/gahuza/podcasts/p07yh8hb/p094vs2n.json
@@ -1,328 +1,127 @@
 {
-  "metadata": {
-    "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/p094vs2n",
-    "locators": { "pid": "p094vs2n", "brandPid": "p07yh8hb" },
-    "type": "WSRADIO",
-    "createdBy": "bbc_gahuza_radio",
+  "data": {
+    "metadata": {
+      "type": "Podcast",
+      "atiAnalytics": {
+        "pageIdentifier": "gahuza.bbc_gahuza_radio.podcasts.p094vs2n.page",
+        "contentType": "player-episode",
+        "pageTitle": "Baza Muganga - BBC News Gahuza",
+        "language": "rw",
+        "contentId": "urn:bbc:pips:p094vs2n"
+      }
+    },
     "language": "rw",
-    "lastUpdated": 1612889570769,
-    "firstPublished": 1611336969000,
-    "lastPublished": 1611336969000,
-    "timestamp": 1611336969000,
-    "options": {},
-    "analyticsLabels": {
-      "pageTitle": "Baza Muganga - BBC News Gahuza",
-      "pageIdentifier": "gahuza.bbc_gahuza_radio.p094vs2n.page",
-      "producerId": "40",
-      "contentType": "player-episode",
-      "producer": "GAHUZA"
-    },
-    "tags": {},
-    "version": "v1.3.11",
-    "blockTypes": ["media"],
-    "title": "Baza Muganga",
-    "releaseDateTimeStamp": 1611273600000,
-    "atiAnalytics": {}
-  },
-  "content": {
-    "blocks": [
-      {
-        "id": "p094vs2n",
-        "subType": "episode",
-        "format": "Audio",
-        "title": "",
-        "synopses": { "short": "Baza Muganga 22/01/2021" },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-        "embedding": true,
-        "advertising": false,
-        "versions": [
-          {
-            "versionId": "p094vrh5",
-            "types": ["Podcast"],
-            "duration": 345,
-            "durationISO8601": "PT5M45S",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": true,
-              "nonUk": true,
-              "world": false
-            },
-            "availableUntil": 1613928780000,
-            "availableFrom": 1611336780000,
-            "availabilityStatus": "available"
-          }
-        ],
-        "availability": "available",
-        "smpKind": "radioProgramme",
-        "episodeTitle": "Baza Muganga 22/01/2021",
-        "type": "media"
-      }
-    ]
-  },
-  "promo": {
-    "headlines": { "headline": "Baza Muganga" },
-    "locators": { "pid": "p094vs2n", "brandPid": "p07yh8hb" },
-    "media": {
-      "id": "p094vs2n",
-      "subType": "episode",
-      "format": "Audio",
-      "title": "",
-      "synopses": { "short": "Baza Muganga 22/01/2021" },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-      "embedding": true,
-      "advertising": false,
-      "versions": [
-        {
-          "versionId": "p094vrh5",
-          "types": ["Podcast"],
-          "duration": 345,
-          "durationISO8601": "PT5M45S",
-          "warnings": {},
-          "availableTerritories": { "uk": true, "nonUk": true, "world": false },
-          "availableUntil": 1613928780000,
-          "availableFrom": 1611336780000,
-          "availabilityStatus": "available"
-        }
-      ],
-      "availability": "available",
-      "smpKind": "radioProgramme",
-      "episodeTitle": "Baza Muganga 22/01/2021",
-      "type": "media"
-    },
-    "indexImage": {
-      "id": "",
-      "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-      "height": 0,
-      "width": 0,
-      "altText": null,
-      "copyrightHolder": null,
-      "type": "image"
-    },
-    "releaseDateTimestamp": 1611273600000,
-    "brand": { "pid": "p07yh8hb", "title": "Baza Muganga" },
+    "brandTitle": "Baza Muganga",
+    "episodeTitle": "Baza Muganga 22/01/2021",
+    "headline": "Baza Muganga",
+    "shortSynopsis": "Baza Muganga 22/01/2021",
+    "mediumSynopsis": "",
     "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/p094vs2n",
-    "type": "ws_radio"
-  },
-  "relatedContent": {
-    "site": {
-      "subType": "site",
-      "name": "Gahuza",
-      "uri": "/gahuza",
-      "type": "simple"
-    },
-    "groups": [
+    "brandId": "p07yh8hb",
+    "episodeId": "p094vs2n",
+    "masterBrand": "bbc_gahuza_radio",
+    "releaseDateTimeStamp": "2021-01-22T00:00:00.000Z",
+    "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
+    "imageAltText": "",
+    "promoBrandTitle": "Baza Muganga",
+    "durationISO8601": null,
+    "thumbnailImageUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p082wk67.jpg",
+    "episodeAvailability": "expired",
+    "recentEpisodes": [
       {
-        "type": "other-episode",
-        "promos": [
-          {
-            "headlines": { "headline": "Baza Muganga" },
-            "locators": { "pid": "p096621h", "brandPid": "p07yh8hb" },
-            "media": {
-              "id": "p096621h",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "Kurikira ikiganiro Bazamuganga kuri BBC Gahuzamiryango."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p09661q9",
-                  "types": ["Podcast"],
-                  "duration": 357,
-                  "durationISO8601": "PT5M57S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1615140480000,
-                  "availableFrom": 1612548480000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "Ikiganiro cyo kuwa 05/02/2021",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1612483200000,
-            "brand": { "pid": "p07yh8hb", "title": "Baza Muganga" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/p096621h",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "Baza Muganga" },
-            "locators": { "pid": "p095jtct", "brandPid": "p07yh8hb" },
-            "media": {
-              "id": "p095jtct",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": { "short": "Baza muganga kuri BBC gahuzamiryango" },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p095jt1q",
-                  "types": ["Podcast"],
-                  "duration": 345,
-                  "durationISO8601": "PT5M45S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1614533280000,
-                  "availableFrom": 1611941280000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "Baza muganga 29/01/2021",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1611878400000,
-            "brand": { "pid": "p07yh8hb", "title": "Baza Muganga" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/p095jtct",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "Baza Muganga" },
-            "locators": { "pid": "p0944r77", "brandPid": "p07yh8hb" },
-            "media": {
-              "id": "p0944r77",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "Ikiganiro ku guca imvyaro ku bagore kandi igihe kitaragera"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p0944qzd",
-                  "types": ["Podcast"],
-                  "duration": 370,
-                  "durationISO8601": "PT6M10S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1613323380000,
-                  "availableFrom": 1610731380000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "Ikiganiro Bazamuganga co kuri uno wa gatanu itariki 15/01/2021",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1610668800000,
-            "brand": { "pid": "p07yh8hb", "title": "Baza Muganga" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/p0944r77",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "Baza Muganga" },
-            "locators": { "pid": "p07yh9qm", "brandPid": "p07yh8hb" },
-            "media": {
-              "id": "p07yh9qm",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "Ikiganiro Baza Muganga gitegurwa na BBC Gahuzamiryango."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p07yh6z4",
-                  "types": ["Podcast"],
-                  "duration": 8,
-                  "durationISO8601": "PT8S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableFrom": 1576840260000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "Welcome to Baza Muganga",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1576800000000,
-            "brand": { "pid": "p07yh8hb", "title": "Baza Muganga" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/p07yh9qm",
-            "type": "ws_radio"
-          }
-        ]
+        "id": "p0k7t82p",
+        "brandTitle": "Baza Muganga",
+        "episodeTitle": "Ikiganiro cyo kuwa 29/11/2024",
+        "timestamp": "2024-11-29T00:00:00.000Z",
+        "duration": "PT5M45S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p082wk67.jpg",
+        "altText": "Baza Muganga"
+      },
+      {
+        "id": "p0k6cby1",
+        "brandTitle": "Baza Muganga",
+        "episodeTitle": "BBC Gahuzamiryango/ Baza Muganga",
+        "timestamp": "2024-11-22T00:00:00.000Z",
+        "duration": "PT6M2S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p082wk67.jpg",
+        "altText": "Baza Muganga"
+      },
+      {
+        "id": "p0k4x0jm",
+        "brandTitle": "Baza Muganga",
+        "episodeTitle": "Baza Muganga 15/11/2024",
+        "timestamp": "2024-11-15T00:00:00.000Z",
+        "duration": "PT5M58S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p082wk67.jpg",
+        "altText": "Baza Muganga"
+      },
+      {
+        "id": "p0k396c8",
+        "brandTitle": "Baza Muganga",
+        "episodeTitle": "Ikiganiro cyo kuwa 08/11/2024",
+        "timestamp": "2024-11-08T00:00:00.000Z",
+        "duration": "PT6M2S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p082wk67.jpg",
+        "altText": "Baza Muganga"
+      },
+      {
+        "id": "p0f0xlq5",
+        "brandTitle": "Baza Muganga",
+        "episodeTitle": "Bazamuganga 03/02/2023",
+        "timestamp": "2023-02-03T00:00:00.000Z",
+        "duration": "PT5M29S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p082wk67.jpg",
+        "altText": "Baza Muganga"
+      },
+      {
+        "id": "p0b99rb5",
+        "brandTitle": "Baza Muganga",
+        "episodeTitle": "Bazamuganga 10/12/2021: Ikiganiro ku ndwara ya Otite cyangwa Umuhaha",
+        "timestamp": "2021-12-10T00:00:00.000Z",
+        "duration": "PT4M20S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p082wk67.jpg",
+        "altText": "Baza Muganga"
+      },
+      {
+        "id": "p07yh9qm",
+        "brandTitle": "Baza Muganga",
+        "episodeTitle": "Welcome to Baza Muganga",
+        "timestamp": "2019-12-20T00:00:00.000Z",
+        "duration": "PT8S",
+        "image": "//ichef.bbci.co.uk/images/ic/768x432/p082wk67.jpg",
+        "altText": "Baza Muganga"
       }
-    ]
-  }
+    ],
+    "mediaBlocks": [
+      {
+        "type": "audio",
+        "model": {
+          "id": "p094vs2n",
+          "subType": "episode",
+          "format": "Audio",
+          "title": "Baza Muganga",
+          "synopses": { "short": "Baza Muganga 22/01/2021" },
+          "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wk67.jpg",
+          "embedding": true,
+          "advertising": false,
+          "versions": [],
+          "availability": "notAvailable",
+          "smpKind": "radioProgramme",
+          "episodeTitle": "Baza Muganga 22/01/2021",
+          "type": "media"
+        }
+      },
+      {
+        "type": "mediaOverrides",
+        "model": {
+          "language": "rw",
+          "pageIdentifierOverride": "gahuza.bbc_gahuza_radio.p094vs2n.page"
+        }
+      }
+    ],
+    "isPodcast": true,
+    "summary": "Baza Muganga 22/01/2021",
+    "radioScheduleData": null
+  },
+  "contentType": "application/json; charset=utf-8"
 }

--- a/src/app/routes/onDemandAudio/getInitialData/index.ts
+++ b/src/app/routes/onDemandAudio/getInitialData/index.ts
@@ -3,6 +3,7 @@ import pathOr from 'ramda/src/pathOr';
 import { BFF_FETCH_ERROR } from '#lib/logger.const';
 import { InitialDataProps } from '#app/models/types/initialData';
 import fetchDataFromBFF from '#app/routes/utils/fetchDataFromBFF';
+import overrideRendererOnTest from '#app/routes/utils/overrideRendererOnTest';
 import getErrorStatusCode from '../../utils/fetchPageData/utils/getErrorStatusCode';
 import { getPodcastExternalLinks } from '../tempData/podcastExternalLinks';
 import nodeLogger from '../../../lib/logger.node';
@@ -38,7 +39,7 @@ export default async ({
     const { isPodcast, getRecentEpisodesToggle } = getConfig(pathname);
 
     const { json, status } = await fetchDataFromBFF({
-      pathname,
+      pathname: overrideRendererOnTest(pathname),
       pageType,
       service,
       getAgent,

--- a/src/app/routes/onDemandAudio/getInitialData/index.ts
+++ b/src/app/routes/onDemandAudio/getInitialData/index.ts
@@ -4,6 +4,7 @@ import { BFF_FETCH_ERROR } from '#lib/logger.const';
 import { InitialDataProps } from '#app/models/types/initialData';
 import fetchDataFromBFF from '#app/routes/utils/fetchDataFromBFF';
 import overrideRendererOnTest from '#app/routes/utils/overrideRendererOnTest';
+import isTest from '#app/lib/utilities/isTest';
 import getErrorStatusCode from '../../utils/fetchPageData/utils/getErrorStatusCode';
 import { getPodcastExternalLinks } from '../tempData/podcastExternalLinks';
 import nodeLogger from '../../../lib/logger.node';
@@ -39,7 +40,7 @@ export default async ({
     const { isPodcast, getRecentEpisodesToggle } = getConfig(pathname);
 
     const { json, status } = await fetchDataFromBFF({
-      pathname: overrideRendererOnTest(pathname),
+      pathname: isTest() ? overrideRendererOnTest(pathname) : pathname,
       pageType,
       service,
       getAgent,


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAM1-1347

Overall changes
======
Always fetch live data on the test environment for on demand audio & podcasts 

Code changes
======
- use `overrideRendererOnTest` to always fetch live data when on a non-live environment
- add test
- enable smoke tests for OD Audio for a couple of services

Testing
======
### Local assets on local:
Expected result: Page should render as expected

```
yarn dev
```

- http://localhost:7080/persian/podcasts/p02pc9wf
- http://localhost:7080/gahuza/bbc_gahuza_radio/w172x7rkcj6v0vz


### Live assets on 'test' environment:
Expected result: Page should render as expected

```
yarn build:test && yarn start
```

- http://localhost.bbc.com:7080/arabic/podcasts/p02pc9qc
- http://localhost.bbc.com:7080/arabic/podcasts/p02pc9qc/p0fgnwjn
- http://localhost.bbc.com:7080/hausa/bbc_hausa_radio/programmes/p030s4mx
- http://localhost.bbc.com:7080/hausa/bbc_hausa_radio/w3ct1033
