### PR TITLE
WSTEAMA-1482: Optimise Reverb usage

### DIFF
--- a/src/app/lib/analyticsUtils/sendBeacon/index.js
+++ b/src/app/lib/analyticsUtils/sendBeacon/index.js
@@ -81,11 +81,12 @@ const callReverb = async eventName => {
     async reverb => {
       if (reverb.isReady()) {
         await reverbHandlers[eventName](reverb);
-      } else {
-        return reverb.initialise().then(async () => {
-          await reverbHandlers[eventName](reverb);
-        });
+        return;
       }
+
+      reverb.initialise().then(async () => {
+        await reverbHandlers[eventName](reverb);
+      });
     },
     () => {
       logger.error(ATI_LOGGING_ERROR, {

--- a/src/app/models/types/serviceConfig.ts
+++ b/src/app/models/types/serviceConfig.ts
@@ -42,7 +42,7 @@ export type ServiceConfig = {
   articleTimestampSuffix?: string;
   atiAnalyticsAppName: string;
   atiAnalyticsProducerId: string;
-  atiAnalyticsProducerName: string;
+  atiAnalyticsProducerName?: string;
   chartbeatDomain: string;
   brandName: string;
   product: string;

--- a/src/server/Document/Renderers/CanonicalRenderer.tsx
+++ b/src/server/Document/Renderers/CanonicalRenderer.tsx
@@ -31,7 +31,6 @@ export default function CanonicalRenderer({
 }: Props) {
   const serialisedData = serialiseForScript(data);
   const appEnvVariables = serialiseForScript(getProcessEnvAppVariables());
-  
 
   return (
     <html lang="en-GB" className={NO_JS_CLASSNAME} {...htmlAttrs}>
@@ -50,7 +49,10 @@ export default function CanonicalRenderer({
             }, 5000);`,
           }}
         />
-        <script src="https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.9.2.js" />
+        <script
+          async
+          src="https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.9.2.js"
+        />
 
         {isApp && <meta name="robots" content="noindex" />}
         {title}


### PR DESCRIPTION
Resolves JIRA [WSTEAMA-1482]

Overall changes
======
Initialise Reverb once and use the resultant instance for subsequent requests.

Following the investigation into usage of static Reverb, we developed a POC
that can be viewed in [#12189](https://github.com/bbc/simorgh/pull/12189).

We shared this POC with the Reverb team. They recommended that we 
update [reverbPageViews](https://github.com/bbc/simorgh/pull/12189/files#diff-f540c0d641799ec8791863e2ccdc2d7c15d7fae1230c8533601c1d51aab0127cR55-R67) and [reverbLinkClick](https://github.com/bbc/simorgh/pull/12189/files#diff-f540c0d641799ec8791863e2ccdc2d7c15d7fae1230c8533601c1d51aab0127cR69-R90) to ensure Reverb is initialised once.

[This](https://github.com/bbc/simorgh/pull/12226/files#diff-f540c0d641799ec8791863e2ccdc2d7c15d7fae1230c8533601c1d51aab0127cR78-R97) change is aimed at achieving this recommendation.

Code changes
======

- Invoke `initialise()` once.
- Check boolean attribute, `ready`, via the function, `isReady`, to
facilitate calls to `viewEvent` and `userActionEvent` post-initialisation.
- Add `async` to the Reverb script to ensure it's a non-blocking resource.

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
