### PR TITLE
Add producer name to service config

### DIFF
--- a/src/app/lib/config/services/afaanoromoo.ts
+++ b/src/app/lib/config/services/afaanoromoo.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-afaanoromoo',
     atiAnalyticsProducerId: '2',
+    atiAnalyticsProducerName: 'AFRIQUE',
     chartbeatDomain: 'afaanoromoo.bbc.co.uk',
     brandName: 'BBC News Afaan Oromoo',
     product: 'BBC News',


### PR DESCRIPTION
Resolves JIRA [[1508](https://jira.dev.bbc.co.uk/browse/WSTEAMA-1508)]

Overall changes
======
Updates service config for all services to incorporate `atiAnalyticsProducerName` values that are required for Reverb reporting.

Code changes
======

- New line added for each service config file with an `atiAnalyticsProducerName` value. e.g for afaanoromoo service: `atiAnalyticsProducerName: 'AFRIQUE'`. Files located at `src/app/lib/config/services/serviceName`.
