### PR TITLE
WSTEAMA-1508 - Adds producer name to service config for all services

### DIFF
--- a/src/app/lib/config/services/afaanoromoo.ts
+++ b/src/app/lib/config/services/afaanoromoo.ts
@@ -12,7 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-afaanoromoo',
     atiAnalyticsProducerId: '2',
-    atiAnalyticsProducerName: 'AFRIQUE',
+    atiAnalyticsProducerName: 'AFAAN_OROMOO',
     chartbeatDomain: 'afaanoromoo.bbc.co.uk',
     brandName: 'BBC News Afaan Oromoo',
     product: 'BBC News',

--- a/src/app/lib/config/services/afaanoromoo.ts
+++ b/src/app/lib/config/services/afaanoromoo.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-afaanoromoo',
     atiAnalyticsProducerId: '2',
+    atiAnalyticsProducerName: 'AFRIQUE',
     chartbeatDomain: 'afaanoromoo.bbc.co.uk',
     brandName: 'BBC News Afaan Oromoo',
     product: 'BBC News',

--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-afrique',
     atiAnalyticsProducerId: '3',
+    atiAnalyticsProducerName: 'AFRIQUE',
     chartbeatDomain: 'afrique.bbc.co.uk',
     brandName: 'BBC News Afrique',
     product: 'BBC News',

--- a/src/app/lib/config/services/amharic.ts
+++ b/src/app/lib/config/services/amharic.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-amharic',
     atiAnalyticsProducerId: '4',
+    atiAnalyticsProducerName: 'AMHARIC',
     chartbeatDomain: 'amharic.bbc.co.uk',
     brandName: 'BBC News አማርኛ',
     product: 'BBC News',

--- a/src/app/lib/config/services/arabic.ts
+++ b/src/app/lib/config/services/arabic.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-arabic',
     atiAnalyticsProducerId: '5',
+    atiAnalyticsProducerName: 'ARABIC',
     chartbeatDomain: 'arabic.bbc.co.uk',
     brandName: 'BBC News عربي',
     product: 'BBC News',

--- a/src/app/lib/config/services/archive.ts
+++ b/src/app/lib/config/services/archive.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'archive',
     atiAnalyticsProducerId: '127',
+    atiAnalyticsProducerName: 'BBC_ARCHIVE',
     chartbeatDomain: 'bbc.co.uk',
     brandName: 'BBC Archive',
     product: 'BBC Archive',

--- a/src/app/lib/config/services/azeri.ts
+++ b/src/app/lib/config/services/azeri.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-azeri',
     atiAnalyticsProducerId: '6',
+    atiAnalyticsProducerName: 'AZERI',
     chartbeatDomain: 'azeri.bbc.co.uk',
     brandName: 'BBC News Azərbaycanca',
     product: 'BBC News',

--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-bengali',
     atiAnalyticsProducerId: '31',
+    atiAnalyticsProducerName: 'BENGALI',
     chartbeatDomain: 'bengali.bbc.co.uk',
     brandName: 'BBC News বাংলা',
     product: 'BBC News',

--- a/src/app/lib/config/services/burmese.ts
+++ b/src/app/lib/config/services/burmese.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-burmese',
     atiAnalyticsProducerId: '35',
+    atiAnalyticsProducerName: 'BURMESE',
     chartbeatDomain: 'burmese.bbc.co.uk',
     brandName: 'BBC News မြန်မာ',
     product: 'BBC News',

--- a/src/app/lib/config/services/cymrufyw.ts
+++ b/src/app/lib/config/services/cymrufyw.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-cymrufyw',
     atiAnalyticsProducerId: '100',
+    atiAnalyticsProducerName: 'WALES',
     chartbeatDomain: 'cymrufyw.bbc.co.uk',
     brandName: 'BBC Cymru Fyw',
     product: 'BBC News',

--- a/src/app/lib/config/services/gahuza.ts
+++ b/src/app/lib/config/services/gahuza.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-gahuza',
     atiAnalyticsProducerId: '40',
+    atiAnalyticsProducerName: 'GAHUZA',
     chartbeatDomain: 'gahuza.bbc.co.uk',
     brandName: 'BBC News Gahuza',
     product: 'BBC News',

--- a/src/app/lib/config/services/gujarati.ts
+++ b/src/app/lib/config/services/gujarati.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-gujarati',
     atiAnalyticsProducerId: '50',
+    atiAnalyticsProducerName: 'GUJARATI',
     chartbeatDomain: 'gujarati.bbc.co.uk',
     brandName: 'BBC News ગુજરાતી',
     product: 'BBC News',

--- a/src/app/lib/config/services/hausa.ts
+++ b/src/app/lib/config/services/hausa.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-hausa',
     atiAnalyticsProducerId: '51',
+    atiAnalyticsProducerName: 'HAUSA',
     chartbeatDomain: 'hausa.bbc.co.uk',
     brandName: 'BBC News Hausa',
     product: 'BBC News',

--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-hindi',
     atiAnalyticsProducerId: '52',
+    atiAnalyticsProducerName: 'HINDI',
     chartbeatDomain: 'hindi.bbc.co.uk',
     brandName: 'BBC News हिंदी',
     product: 'BBC News',

--- a/src/app/lib/config/services/igbo.ts
+++ b/src/app/lib/config/services/igbo.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-igbo',
     atiAnalyticsProducerId: '53',
+    atiAnalyticsProducerName: 'IGBO',
     chartbeatDomain: 'igbo.bbc.co.uk',
     brandName: 'BBC News Ìgbò',
     product: 'BBC News',

--- a/src/app/lib/config/services/indonesia.ts
+++ b/src/app/lib/config/services/indonesia.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-indonesia',
     atiAnalyticsProducerId: '54',
+    atiAnalyticsProducerName: 'INDONESIAN',
     chartbeatDomain: 'indonesian.bbc.co.uk', // this is meant to be different to the service name
     brandName: 'BBC News Indonesia',
     product: 'BBC News',

--- a/src/app/lib/config/services/japanese.ts
+++ b/src/app/lib/config/services/japanese.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-japanese',
     atiAnalyticsProducerId: '56',
+    atiAnalyticsProducerName: 'JAPANESE',
     chartbeatDomain: 'japanese.bbc.co.uk',
     brandName: 'BBCニュース',
     product: 'BBC News',

--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '에 업데이트 됨',
     atiAnalyticsAppName: 'news-korean',
     atiAnalyticsProducerId: '57',
+    atiAnalyticsProducerName: 'KOREAN',
     chartbeatDomain: 'korean.bbc.co.uk',
     brandName: 'BBC News 코리아',
     product: 'BBC News',

--- a/src/app/lib/config/services/kyrgyz.ts
+++ b/src/app/lib/config/services/kyrgyz.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-kyrgyz',
     atiAnalyticsProducerId: '58',
+    atiAnalyticsProducerName: 'KYRGYZ',
     chartbeatDomain: 'kyrgyz.bbc.co.uk',
     brandName: 'BBC News Кыргыз Кызматы',
     product: 'BBC News',

--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-marathi',
     atiAnalyticsProducerId: '59',
+    atiAnalyticsProducerName: 'MARATHI',
     chartbeatDomain: 'marathi.bbc.co.uk',
     brandName: 'BBC News मराठी',
     product: 'BBC News',

--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-mundo',
     atiAnalyticsProducerId: '62',
+    atiAnalyticsProducerName: 'MUNDO',
     chartbeatDomain: 'mundo.bbc.co.uk',
     brandName: 'BBC News Mundo',
     product: 'BBC News',

--- a/src/app/lib/config/services/naidheachdan.ts
+++ b/src/app/lib/config/services/naidheachdan.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-naidheachdan',
     atiAnalyticsProducerId: '79',
+    atiAnalyticsProducerName: 'SCOTLAND',
     chartbeatDomain: 'bbc.co.uk',
     brandName: 'BBC Naidheachdan',
     product: 'BBC News',

--- a/src/app/lib/config/services/nepali.ts
+++ b/src/app/lib/config/services/nepali.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: 'अद्यावधिक',
     atiAnalyticsAppName: 'news-nepali',
     atiAnalyticsProducerId: '63',
+    atiAnalyticsProducerName: 'NEPALI',
     chartbeatDomain: 'nepali.bbc.co.uk',
     brandName: 'BBC News नेपाली',
     product: 'BBC News',

--- a/src/app/lib/config/services/news.ts
+++ b/src/app/lib/config/services/news.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news',
     atiAnalyticsProducerId: '64',
+    atiAnalyticsProducerName: 'NEWS',
     chartbeatDomain: 'bbc.co.uk',
     brandName: 'BBC News',
     product: 'BBC News',

--- a/src/app/lib/config/services/newsround.ts
+++ b/src/app/lib/config/services/newsround.ts
@@ -13,6 +13,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'newsround',
     atiAnalyticsProducerId: '65',
+    atiAnalyticsProducerName: 'NEWSROUND',
     chartbeatDomain: 'bbc.co.uk',
     brandName: 'CBBC Newsround',
     product: 'CBBC Newsround',

--- a/src/app/lib/config/services/pashto.ts
+++ b/src/app/lib/config/services/pashto.ts
@@ -14,6 +14,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-pashto',
     atiAnalyticsProducerId: '68',
+    atiAnalyticsProducerName: 'PASHTO',
     brandName: 'BBC News پښتو',
     chartbeatDomain: 'pashto.bbc.co.uk',
     serviceLocalizedName: 'پښتو',

--- a/src/app/lib/config/services/pidgin.ts
+++ b/src/app/lib/config/services/pidgin.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-pidgin',
     atiAnalyticsProducerId: '70',
+    atiAnalyticsProducerName: 'PIDGIN',
     chartbeatDomain: 'pidgin.bbc.co.uk',
     brandName: 'BBC News Pidgin',
     product: 'BBC News',

--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-portuguese',
     atiAnalyticsProducerId: '33',
+    atiAnalyticsProducerName: 'BRASIL',
     chartbeatDomain: 'brasil.bbc.co.uk', // this is meant to be different to the service name
     brandName: 'BBC News Brasil',
     product: 'BBC News',

--- a/src/app/lib/config/services/punjabi.ts
+++ b/src/app/lib/config/services/punjabi.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-punjabi',
     atiAnalyticsProducerId: '73',
+    atiAnalyticsProducerName: 'PUNJABI',
     chartbeatDomain: 'punjabi.bbc.co.uk',
     brandName: 'BBC News ਪੰਜਾਬੀ',
     product: 'BBC News',

--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -318,6 +318,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-russian',
     atiAnalyticsProducerId: '75',
+    atiAnalyticsProducerName: 'RUSSIAN',
     chartbeatDomain: 'russian.bbc.co.uk',
     brandName: 'BBC News Русская служба',
     product: 'BBC News',

--- a/src/app/lib/config/services/scotland.ts
+++ b/src/app/lib/config/services/scotland.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'scotland',
     atiAnalyticsProducerId: '79',
+    atiAnalyticsProducerName: 'SCOTLAND',
     chartbeatDomain: 'bbc.co.uk',
     brandName: 'BBC Scotland',
     product: 'BBC Scotland',

--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -11,6 +11,7 @@ const baseServiceConfig = {
   articleAuthor: 'https://www.facebook.com/bbcnews',
   atiAnalyticsAppName: 'news-serbian',
   atiAnalyticsProducerId: '81',
+  atiAnalyticsProducerName: 'SERBIAN',
   chartbeatDomain: 'serbian.bbc.co.uk',
   product: 'BBC News',
   defaultImage: 'https://news.files.bbci.co.uk/ws/img/logos/og/serbian.png',

--- a/src/app/lib/config/services/sinhala.ts
+++ b/src/app/lib/config/services/sinhala.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-sinhala',
     atiAnalyticsProducerId: '82',
+    atiAnalyticsProducerName: 'SINHALA',
     chartbeatDomain: 'sinhala.bbc.co.uk',
     brandName: 'BBC News සිංහල',
     product: 'BBC News',

--- a/src/app/lib/config/services/somali.ts
+++ b/src/app/lib/config/services/somali.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-somali',
     atiAnalyticsProducerId: '83',
+    atiAnalyticsProducerName: 'SOMALI',
     chartbeatDomain: 'somali.bbc.co.uk',
     brandName: 'BBC News Somali',
     product: 'BBC News',

--- a/src/app/lib/config/services/sport.ts
+++ b/src/app/lib/config/services/sport.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'sport',
     atiAnalyticsProducerId: '85',
+    atiAnalyticsProducerName: 'SPORT',
     chartbeatDomain: 'bbc.co.uk',
     brandName: 'BBC Sport',
     product: 'BBC Sport',

--- a/src/app/lib/config/services/swahili.ts
+++ b/src/app/lib/config/services/swahili.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-swahili',
     atiAnalyticsProducerId: '86',
+    atiAnalyticsProducerName: 'SWAHILI',
     chartbeatDomain: 'swahili.bbc.co.uk',
     brandName: 'BBC News Swahili',
     product: 'BBC News',

--- a/src/app/lib/config/services/tamil.ts
+++ b/src/app/lib/config/services/tamil.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-tamil',
     atiAnalyticsProducerId: '87',
+    atiAnalyticsProducerName: 'TAMIL',
     chartbeatDomain: 'tamil.bbc.co.uk',
     brandName: 'BBC News தமிழ்',
     product: 'BBC News',

--- a/src/app/lib/config/services/telugu.ts
+++ b/src/app/lib/config/services/telugu.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-telugu',
     atiAnalyticsProducerId: '89',
+    atiAnalyticsProducerName: 'TELUGU',
     chartbeatDomain: 'telugu.bbc.co.uk',
     brandName: 'BBC News తెలుగు',
     product: 'BBC News',

--- a/src/app/lib/config/services/thai.ts
+++ b/src/app/lib/config/services/thai.ts
@@ -14,6 +14,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-thai',
     atiAnalyticsProducerId: '90',
+    atiAnalyticsProducerName: 'THAI',
     chartbeatDomain: 'thai.bbc.co.uk',
     brandName: 'BBC News ไทย',
     product: 'BBC News',

--- a/src/app/lib/config/services/tigrinya.ts
+++ b/src/app/lib/config/services/tigrinya.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-tigrinya',
     atiAnalyticsProducerId: '91',
+    atiAnalyticsProducerName: 'TIGRINYA',
     chartbeatDomain: 'tigrinya.bbc.co.uk',
     brandName: 'BBC News ትግርኛ',
     product: 'BBC News',

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-turkce',
     atiAnalyticsProducerId: '92',
+    atiAnalyticsProducerName: 'TURKISH',
     chartbeatDomain: 'turkish.bbc.co.uk', // this is meant to be different to the service name
     brandName: 'BBC News Türkçe',
     product: 'BBC News',

--- a/src/app/lib/config/services/ukchina.ts
+++ b/src/app/lib/config/services/ukchina.ts
@@ -11,6 +11,7 @@ const baseServiceConfig = {
   articleTimestampSuffix: '',
   atiAnalyticsAppName: 'news-ukchina',
   atiAnalyticsProducerId: '93',
+  atiAnalyticsProducerName: 'UK_CHINA',
   chartbeatDomain: 'ukchina.bbc.co.uk',
   brandName: 'BBC 英伦网',
   product: 'BBC',

--- a/src/app/lib/config/services/ukrainian.ts
+++ b/src/app/lib/config/services/ukrainian.ts
@@ -16,6 +16,7 @@ const baseServiceConfig = {
   articleTimestampPrefix: 'Оновлено: ',
   atiAnalyticsAppName: 'news-ukrainian',
   atiAnalyticsProducerId: '94',
+  atiAnalyticsProducerName: 'UKRAINIAN',
   chartbeatDomain: 'ukrainian.bbc.co.uk',
   brandName: 'BBC News Україна',
   product: 'BBC News',

--- a/src/app/lib/config/services/urdu.ts
+++ b/src/app/lib/config/services/urdu.ts
@@ -13,6 +13,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-urdu',
     atiAnalyticsProducerId: '95',
+    atiAnalyticsProducerName: 'URDU',
     chartbeatDomain: 'urdu.bbc.co.uk',
     brandName: 'BBC News اردو',
     defaultImage: 'https://news.files.bbci.co.uk/ws/img/logos/og/urdu.png',

--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -11,6 +11,7 @@ const baseServiceConfig = {
   articleAuthor: `https://www.facebook.com/bbcnews`,
   atiAnalyticsAppName: 'news-uzbek',
   atiAnalyticsProducerId: '96',
+  atiAnalyticsProducerName: 'UZBEK',
   chartbeatDomain: 'uzbek.bbc.co.uk',
   product: 'BBC News',
   defaultImage: 'https://news.files.bbci.co.uk/ws/img/logos/og/uzbek.png',

--- a/src/app/lib/config/services/vietnamese.ts
+++ b/src/app/lib/config/services/vietnamese.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-vietnamese',
     atiAnalyticsProducerId: '97',
+    atiAnalyticsProducerName: 'VIETNAMESE',
     chartbeatDomain: 'vietnamese.bbc.co.uk',
     brandName: 'BBC News Tiếng Việt',
     product: 'BBC News',

--- a/src/app/lib/config/services/ws.ts
+++ b/src/app/lib/config/services/ws.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news',
     atiAnalyticsProducerId: '64',
+    atiAnalyticsProducerName: 'NEWS',
     chartbeatDomain: 'bbc.co.uk',
     brandName: 'BBC News',
     product: 'BBC News',

--- a/src/app/lib/config/services/yoruba.ts
+++ b/src/app/lib/config/services/yoruba.ts
@@ -12,6 +12,7 @@ export const service: DefaultServiceConfig = {
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-yoruba',
     atiAnalyticsProducerId: '107',
+    atiAnalyticsProducerName: 'YORUBA',
     chartbeatDomain: 'yoruba.bbc.co.uk',
     brandName: 'BBC News Yorùbá',
     product: 'BBC News',

--- a/src/app/lib/config/services/zhongwen.ts
+++ b/src/app/lib/config/services/zhongwen.ts
@@ -12,6 +12,7 @@ const baseServiceConfig = {
   articleTimestampSuffix: '',
   atiAnalyticsAppName: 'news-zhongwen',
   atiAnalyticsProducerId: '38',
+  atiAnalyticsProducerName: 'CHINESE',
   chartbeatDomain: 'zhongwen.bbc.co.uk',
   brandName: 'BBC News 中文',
   product: 'BBC News',


### PR DESCRIPTION
Resolves JIRA [[1508](https://jira.dev.bbc.co.uk/browse/WSTEAMA-1508)]

Overall changes
======
Updates service config for all services to incorporate `atiAnalyticsProducerName` values that are required for Reverb reporting.

Code changes
======

- New line added for each service config file with an `atiAnalyticsProducerName` value. e.g for afaanoromoo service: `atiAnalyticsProducerName: 'AFAAN_OROMOO'`. Files located at `src/app/lib/config/services/serviceName`.
