### PR TITLE
WSTEAMA-1496: Enable service level migration for Reverb

### DIFF
--- a/src/app/components/ATIAnalytics/index.tsx
+++ b/src/app/components/ATIAnalytics/index.tsx
@@ -6,10 +6,11 @@ import AmpATIAnalytics from './amp';
 import { ATIProps } from './types';
 import { buildATIUrl, buildReverbParams } from './params';
 
-const ATIAnalytics = ({ data, atiData, useReverb }: ATIProps) => {
+const ATIAnalytics = ({ data, atiData }: ATIProps) => {
   const requestContext = useContext(RequestContext);
   const serviceContext = useContext(ServiceContext);
   const { isAmp } = requestContext;
+  const { useReverb } = serviceContext;
 
   const urlPageViewParams = buildATIUrl({
     requestContext,

--- a/src/app/components/ATIAnalytics/types.ts
+++ b/src/app/components/ATIAnalytics/types.ts
@@ -150,5 +150,4 @@ export interface ATIPageTrackingProps {
 export interface ATIProps {
   data?: PageData;
   atiData?: ATIData;
-  useReverb?: boolean;
 }

--- a/src/app/components/FrostedGlassPromo/types.ts
+++ b/src/app/components/FrostedGlassPromo/types.ts
@@ -1,7 +1,4 @@
-import {
-  EventTrackingBlock,
-  ReverbEventTrackingMetadata,
-} from '../../models/types/eventTracking';
+import { EventTrackingBlock } from '../../models/types/eventTracking';
 
 export type ImageProps = {
   width: number;
@@ -51,5 +48,5 @@ export type FormattedPromo = {
   image: object | null;
   url?: string;
   footer: JSX.Element;
-  eventTrackingData?: EventTrackingBlock['block'] | ReverbEventTrackingMetadata;
+  eventTrackingData?: EventTrackingBlock['block'];
 };

--- a/src/app/components/FrostedGlassPromo/withData.tsx
+++ b/src/app/components/FrostedGlassPromo/withData.tsx
@@ -133,10 +133,7 @@ const optimoPromoFormatter = (props: PromoProps): FormattedPromo => {
       altText,
       copyright: imageMetadata?.copyrightHolder,
     }),
-    eventTrackingData: {
-      ...props?.eventTrackingData?.block,
-      useReverb: props?.eventTrackingData?.useReverb,
-    },
+    eventTrackingData: props?.eventTrackingData?.block,
   };
 };
 
@@ -145,10 +142,7 @@ const cpsPromoFormatter = (props: PromoProps): FormattedPromo => ({
   footer: <TimestampFooterWithAmp {...props} />,
   url: props?.item?.locators?.assetUri,
   image: buildImageProperties(props?.item?.indexImage),
-  eventTrackingData: {
-    ...props?.eventTrackingData?.block,
-    useReverb: props?.eventTrackingData?.useReverb,
-  },
+  eventTrackingData: props?.eventTrackingData?.block,
 });
 
 const linkPromoFormatter = (props: PromoProps): FormattedPromo => ({

--- a/src/app/components/MostRead/Canonical/index.tsx
+++ b/src/app/components/MostRead/Canonical/index.tsx
@@ -16,7 +16,6 @@ interface MostReadProps {
   data: MostReadData;
   eventTrackingData?: {
     componentName: string;
-    useReverb?: boolean;
   };
 }
 

--- a/src/app/components/MostRead/index.tsx
+++ b/src/app/components/MostRead/index.tsx
@@ -35,7 +35,6 @@ interface MostReadProps {
   mobileDivider?: boolean;
   headingBackgroundColour?: string;
   className?: string;
-  useReverb?: boolean;
 }
 
 const MostRead = ({
@@ -45,7 +44,6 @@ const MostRead = ({
   mobileDivider = false,
   headingBackgroundColour = WHITE,
   className = '',
-  useReverb = false,
 }: MostReadProps) => {
   const { isAmp, pageType, variant } = useContext(RequestContext);
   const {
@@ -70,11 +68,6 @@ const MostRead = ({
     variant,
     isBff,
   });
-
-  const eventTrackingData = {
-    ...blockLevelEventTrackingData,
-    ...(useReverb ? { useReverb: true } : {}),
-  };
 
   // We render amp on ONLY STY, CSP and ARTICLE pages using amp-list.
   const AmpMostRead = () =>
@@ -103,7 +96,7 @@ const MostRead = ({
           data={data}
           columnLayout={columnLayout}
           size={size}
-          eventTrackingData={eventTrackingData}
+          eventTrackingData={blockLevelEventTrackingData}
         />
       </MostReadSection>
     ) : null;

--- a/src/app/components/MostRead/types.ts
+++ b/src/app/components/MostRead/types.ts
@@ -30,7 +30,6 @@ export interface MostReadLinkProps {
   size: Size;
   eventTrackingData?: {
     componentName: string;
-    useReverb?: boolean;
   };
 }
 

--- a/src/app/hooks/useClickTrackerHandler/index.jsx
+++ b/src/app/hooks/useClickTrackerHandler/index.jsx
@@ -22,8 +22,6 @@ const useClickTrackerHandler = (props = {}) => {
   const optimizelyMetricNameOverride = props?.optimizelyMetricNameOverride;
   const detailedPlacement = props?.detailedPlacement;
 
-  const useReverb = pathOr(false, ['useReverb'], props);
-
   const { trackingIsEnabled } = useTrackingToggle(componentName);
   const [clicked, setClicked] = useState(false);
   const eventTrackingContext = useContext(EventTrackingContext);
@@ -39,7 +37,7 @@ const useClickTrackerHandler = (props = {}) => {
     ['campaignID'],
     props,
   );
-  const { service } = useContext(ServiceContext);
+  const { service, useReverb } = useContext(ServiceContext);
 
   return useCallback(
     async event => {

--- a/src/app/hooks/useViewTracker/index.jsx
+++ b/src/app/hooks/useViewTracker/index.jsx
@@ -22,8 +22,6 @@ const useViewTracker = (props = {}) => {
   const optimizelyMetricNameOverride = props?.optimizelyMetricNameOverride;
   const detailedPlacement = props?.detailedPlacement;
 
-  const useReverb = pathOr(false, ['useReverb'], props);
-
   const observer = useRef();
   const timer = useRef(null);
   const [isInView, setIsInView] = useState();
@@ -42,7 +40,8 @@ const useViewTracker = (props = {}) => {
     ['campaignID'],
     props,
   );
-  const { service } = useContext(ServiceContext);
+
+  const { service, useReverb } = useContext(ServiceContext);
 
   const initObserver = async () => {
     if (typeof window.IntersectionObserver === 'undefined') {

--- a/src/app/legacy/containers/CpsFeaturesAnalysis/index.jsx
+++ b/src/app/legacy/containers/CpsFeaturesAnalysis/index.jsx
@@ -22,7 +22,6 @@ const eventTrackingData = {
   block: {
     componentName: 'features',
   },
-  useReverb: true,
 };
 
 const StoryPromoUlFeatures = styled(StoryPromoUl)`
@@ -64,10 +63,7 @@ const StoryPromoLiFeatures = styled(StoryPromoLi)`
 const PromoListComponent = ({ promoItems, dir = 'ltr' }) => {
   const { serviceDatetimeLocale } = useContext(ServiceContext);
 
-  const viewRef = useViewTracker({
-    ...eventTrackingData.block,
-    useReverb: true,
-  });
+  const viewRef = useViewTracker(eventTrackingData.block);
 
   return (
     <StoryPromoUlFeatures>
@@ -98,10 +94,7 @@ const PromoListComponent = ({ promoItems, dir = 'ltr' }) => {
 const PromoComponent = ({ promo, dir = 'ltr' }) => {
   const { serviceDatetimeLocale } = useContext(ServiceContext);
 
-  const viewRef = useViewTracker({
-    ...eventTrackingData.block,
-    useReverb: true,
-  });
+  const viewRef = useViewTracker(eventTrackingData.block);
 
   return (
     <div ref={viewRef}>

--- a/src/app/legacy/containers/StoryPromo/useCombinedClickTrackerHandler.js
+++ b/src/app/legacy/containers/StoryPromo/useCombinedClickTrackerHandler.js
@@ -1,25 +1,21 @@
 import path from 'ramda/src/path';
-import pathOr from 'ramda/src/pathOr';
 
 import useClickTrackerHandler from '#hooks/useClickTrackerHandler';
 
 const useCombinedClickTrackerHandler = eventTrackingData => {
   const blockData = path(['block'], eventTrackingData);
   const linkData = path(['link'], eventTrackingData);
-  const useReverb = pathOr(false, ['useReverb'], eventTrackingData);
   const optimizely = path(['block', 'optimizely'], eventTrackingData);
   const handleBlockLevelClick = useClickTrackerHandler({
     ...(blockData && {
       ...blockData,
       preventNavigation: true,
-      useReverb,
     }),
   });
   const handleLinkLevelClick = useClickTrackerHandler({
     ...(linkData && {
       ...linkData,
       preventNavigation: true,
-      useReverb,
     }),
   });
 

--- a/src/app/models/types/eventTracking.ts
+++ b/src/app/models/types/eventTracking.ts
@@ -13,7 +13,6 @@ export type EventTrackingBlock = {
   block: {
     componentName: EventTrackingMetadata['componentName'];
   };
-  useReverb?: boolean;
 };
 
 export type ReverbEventTrackingMetadata = {

--- a/src/app/models/types/eventTracking.ts
+++ b/src/app/models/types/eventTracking.ts
@@ -14,8 +14,3 @@ export type EventTrackingBlock = {
     componentName: EventTrackingMetadata['componentName'];
   };
 };
-
-export type ReverbEventTrackingMetadata = {
-  componentName?: string;
-  useReverb?: boolean;
-};

--- a/src/app/models/types/serviceConfig.ts
+++ b/src/app/models/types/serviceConfig.ts
@@ -43,6 +43,7 @@ export type ServiceConfig = {
   atiAnalyticsAppName: string;
   atiAnalyticsProducerId: string;
   atiAnalyticsProducerName?: string;
+  useReverb?: boolean;
   chartbeatDomain: string;
   brandName: string;
   product: string;

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -305,7 +305,6 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
           size="default"
           headingBackgroundColour={GREY_2}
           mobileDivider={showTopics}
-          useReverb
         />
       )}
       {enableOptimizelyEventTracking && (

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -230,7 +230,7 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
 
   return (
     <div css={styles.pageWrapper}>
-      <ATIAnalytics atiData={atiData} useReverb />
+      <ATIAnalytics atiData={atiData} />
       <ChartbeatAnalytics
         sectionName={pageData?.relatedContent?.section?.name}
         title={headline}

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.tsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.tsx
@@ -58,12 +58,8 @@ const TopStoriesSection = ({ content = [] }: { content: TopStoryItem[] }) => {
     block: {
       componentName: 'top-stories',
     },
-    useReverb: true,
   };
-  const eventTrackingDataSend = {
-    ...eventTrackingData?.block,
-    useReverb: true,
-  };
+  const eventTrackingDataSend = eventTrackingData?.block;
   const viewRef = useViewTracker(eventTrackingDataSend);
 
   const {


### PR DESCRIPTION
Resolves JIRA [WSTEAMA-1496]

Overall changes
======
Enable adoption of Reverb tracking at the service level to facilitate Reverb tracking for all page types for a given service.  

Code changes
======

- Add use of a config, `useReverb: true`, to enable Reverb tracking for a given service.

Testing
======
1. Navigate to a service config e.g [persian](https://github.com/bbc/simorgh/blob/latest/src/app/lib/config/services/persian.ts)
2. Add the config `useReverb: true` to the service config.
3. Visit the sample pages below
    ```
    http://localhost.bbc.com:7080/persian/articles/c9921k54wydo?renderer_env=live
    http://localhost.bbc.com:7080/persian?renderer_env=live
    ```
4. From the Network tab on the browser, filter requests using the text, `ati-host`.
5. You should observe Reverb tracking beacons for the page view event and all trackable components on the page.

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
