### PR TITLE
WSTEAM1-1558: Watch Live Button UX & A11y

### DIFF
--- a/src/app/components/LiveMediaStream/index.styles.tsx
+++ b/src/app/components/LiveMediaStream/index.styles.tsx
@@ -4,8 +4,8 @@ import { css, Theme } from '@emotion/react';
 export default {
   componentContainer: ({ spacings }: Theme) =>
     css({
-      margin: `${spacings.FULL}rem 0`,
       width: '100%',
+      marginTop: `${spacings.FULL}rem`,
     }),
   mediaButton: ({ palette, mq }: Theme) =>
     css({
@@ -59,7 +59,7 @@ export default {
       border: 0,
       backgroundColor: palette.LIVE_CORE,
       padding: `${pixelsToRem(11)}rem`,
-      marginTop: `${spacings.FULL}rem`,
+      marginTop: `${spacings.DOUBLE}rem`,
       [mq.GROUP_2_MAX_WIDTH]: {
         width: '100%',
       },
@@ -113,7 +113,7 @@ export default {
       span: { color: palette.GREY_4 },
       display: 'block',
       width: '100%',
-      marginTop: `${spacings.HALF}rem`,
+      marginTop: `${spacings.FULL}rem`,
     }),
   mediaDescriptionGuidance: ({ spacings }: Theme) =>
     css({

--- a/src/app/components/LiveMediaStream/index.styles.tsx
+++ b/src/app/components/LiveMediaStream/index.styles.tsx
@@ -7,7 +7,17 @@ export default {
       margin: `${spacings.FULL}rem 0`,
       width: '100%',
     }),
-  playButtonText: ({ spacings, palette }: Theme) =>
+  playButton: () =>
+    css({
+      cursor: 'pointer',
+      backgroundColor: 'unset',
+      border: 'unset',
+      textAlign: 'start',
+      padding: 0,
+      display: 'block', // check with UX if we want click area this large
+      width: '100%', // check with UX if we want click area this large
+    }),
+  watchLiveCTAText: ({ spacings, palette }: Theme) =>
     css({
       color: palette.WHITE,
       display: 'flex',
@@ -30,16 +40,17 @@ export default {
     }),
   guidanceMessage: ({ palette, spacings }: Theme) =>
     css({
+      display: 'block',
       margin: `${spacings.FULL}rem 0 `,
-      color: palette.WHITE,
+      color: palette.GREY_2,
     }),
-  playButton: ({ palette, mq }: Theme) =>
+  watchLiveCTA: ({ palette, mq, spacings }: Theme) =>
     css({
-      cursor: 'pointer',
       width: `${pixelsToRem(171)}rem`,
       border: 0,
       backgroundColor: palette.LIVE_CORE,
       padding: `${pixelsToRem(11)}rem`,
+      marginTop: `${spacings.FULL}rem`,
       '&:hover': {
         backgroundColor: palette.LIVE_DARK,
       },
@@ -87,11 +98,12 @@ export default {
     css({
       maxWidth: '100%',
     }),
-  mediaDescription: ({ palette }: Theme) =>
+  mediaDescription: ({ palette, spacings }: Theme) =>
     css({
       span: { color: palette.GREY_4 },
       display: 'block',
       width: '100%',
+      marginTop: `${spacings.HALF}rem`, // not in designs - check with UX
     }),
   mediaDescriptionGuidance: ({ spacings }: Theme) =>
     css({

--- a/src/app/components/LiveMediaStream/index.styles.tsx
+++ b/src/app/components/LiveMediaStream/index.styles.tsx
@@ -7,23 +7,23 @@ export default {
       margin: `${spacings.FULL}rem 0`,
       width: '100%',
     }),
-  playButton: ({ palette, mq }: Theme) =>
+  mediaButton: ({ palette, mq }: Theme) =>
     css({
       cursor: 'pointer',
       backgroundColor: 'unset',
       border: 'unset',
       textAlign: 'start',
       padding: 0,
-      display: 'block', // check with UX if we want click area this large
-      width: '100%', // check with UX if we want click area this large
-      '&:hover .hoverStylesText span': {
+      display: 'block',
+      width: '100%',
+      '&:hover .hoverStylesText span, &:focus .hoverStylesText span': {
         textDecoration: 'underline',
       },
-      '&:hover .hoverStylesCTA': {
+      '&:hover .hoverStylesCTA, &:focus .hoverStylesCTA': {
         backgroundColor: palette.LIVE_DARK,
       },
       [mq.FORCED_COLOURS]: {
-        color: 'canvasText', // can move out of mq
+        color: 'canvasText',
       },
     }),
   watchLiveCTAText: ({ spacings, palette }: Theme) =>
@@ -66,7 +66,7 @@ export default {
       [mq.FORCED_COLOURS]: {
         color: 'canvasText',
         border: `${pixelsToRem(2)}rem solid canvasText`,
-      }, // check this is sufficient
+      },
     }),
   liveMediaStreamText: ({ palette }: Theme) =>
     css({
@@ -113,7 +113,7 @@ export default {
       span: { color: palette.GREY_4 },
       display: 'block',
       width: '100%',
-      marginTop: `${spacings.HALF}rem`, // not in designs - check with UX
+      marginTop: `${spacings.HALF}rem`,
     }),
   mediaDescriptionGuidance: ({ spacings }: Theme) =>
     css({

--- a/src/app/components/LiveMediaStream/index.styles.tsx
+++ b/src/app/components/LiveMediaStream/index.styles.tsx
@@ -14,13 +14,14 @@ export default {
       border: 'unset',
       textAlign: 'start',
       padding: 0,
-      display: 'block',
-      width: '100%',
       '&:hover .hoverStylesText span, &:focus .hoverStylesText span': {
         textDecoration: 'underline',
       },
       '&:hover .hoverStylesCTA, &:focus .hoverStylesCTA': {
         backgroundColor: palette.LIVE_DARK,
+        [mq.FORCED_COLOURS]: {
+          textDecoration: 'underline',
+        },
       },
       [mq.FORCED_COLOURS]: {
         color: 'canvasText',

--- a/src/app/components/LiveMediaStream/index.styles.tsx
+++ b/src/app/components/LiveMediaStream/index.styles.tsx
@@ -7,7 +7,7 @@ export default {
       margin: `${spacings.FULL}rem 0`,
       width: '100%',
     }),
-  playButton: () =>
+  playButton: ({ palette, mq }: Theme) =>
     css({
       cursor: 'pointer',
       backgroundColor: 'unset',
@@ -16,6 +16,15 @@ export default {
       padding: 0,
       display: 'block', // check with UX if we want click area this large
       width: '100%', // check with UX if we want click area this large
+      '&:hover .hoverStylesText span': {
+        textDecoration: 'underline',
+      },
+      '&:hover .hoverStylesCTA': {
+        backgroundColor: palette.LIVE_DARK,
+      },
+      [mq.FORCED_COLOURS]: {
+        color: 'canvasText', // can move out of mq
+      },
     }),
   watchLiveCTAText: ({ spacings, palette }: Theme) =>
     css({
@@ -51,12 +60,13 @@ export default {
       backgroundColor: palette.LIVE_CORE,
       padding: `${pixelsToRem(11)}rem`,
       marginTop: `${spacings.FULL}rem`,
-      '&:hover': {
-        backgroundColor: palette.LIVE_DARK,
-      },
       [mq.GROUP_2_MAX_WIDTH]: {
         width: '100%',
       },
+      [mq.FORCED_COLOURS]: {
+        color: 'canvasText',
+        border: `${pixelsToRem(2)}rem solid canvasText`,
+      }, // check this is sufficient
     }),
   liveMediaStreamText: ({ palette }: Theme) =>
     css({

--- a/src/app/components/LiveMediaStream/index.styles.tsx
+++ b/src/app/components/LiveMediaStream/index.styles.tsx
@@ -7,22 +7,13 @@ export default {
       width: '100%',
       marginTop: `${spacings.FULL}rem`,
     }),
-  mediaButton: ({ palette, mq }: Theme) =>
+  mediaButton: ({ mq }: Theme) =>
     css({
       cursor: 'pointer',
       backgroundColor: 'unset',
       border: 'unset',
       textAlign: 'start',
       padding: 0,
-      '&:hover .hoverStylesText span, &:focus .hoverStylesText span': {
-        textDecoration: 'underline',
-      },
-      '&:hover .hoverStylesCTA, &:focus .hoverStylesCTA': {
-        backgroundColor: palette.LIVE_DARK,
-        [mq.FORCED_COLOURS]: {
-          textDecoration: 'underline',
-        },
-      },
       [mq.FORCED_COLOURS]: {
         color: 'canvasText',
       },
@@ -66,6 +57,12 @@ export default {
       [mq.FORCED_COLOURS]: {
         color: 'canvasText',
         border: `${pixelsToRem(2)}rem solid canvasText`,
+      },
+      'button:hover &, button:focus &': {
+        backgroundColor: palette.LIVE_DARK,
+        [mq.FORCED_COLOURS]: {
+          textDecoration: 'underline',
+        },
       },
     }),
   liveMediaStreamText: ({ palette }: Theme) =>
@@ -112,6 +109,9 @@ export default {
       display: 'block',
       width: '100%',
       marginTop: `${spacings.FULL}rem`,
+      'button:hover & span, button:focus & span': {
+        textDecoration: 'underline',
+      },
     }),
   mediaDescriptionGuidance: ({ spacings }: Theme) =>
     css({

--- a/src/app/components/LiveMediaStream/index.tsx
+++ b/src/app/components/LiveMediaStream/index.tsx
@@ -102,7 +102,6 @@ const LiveMediaStream = ({ mediaCollection }: Props) => {
           </Text>
           <Text size="pica" fontVariant="sansRegular" as="span">
             {networkName}
-            <VisuallyHiddenText>, </VisuallyHiddenText>
           </Text>
         </Text>
         {warnings && (

--- a/src/app/components/LiveMediaStream/index.tsx
+++ b/src/app/components/LiveMediaStream/index.tsx
@@ -10,6 +10,7 @@ import mediaIcons from '#psammead/psammead-assets/src/svgs/mediaIcons';
 import { RequestContext } from '#app/contexts/RequestContext';
 import styles from './index.styles';
 import WARNING_LEVELS from '../MediaLoader/configs/warningLevels';
+import VisuallyHiddenText from '../VisuallyHiddenText';
 
 type WarningItem = {
   // eslint-disable-next-line camelcase
@@ -20,7 +21,7 @@ type WarningItem = {
 
 type Props = { mediaCollection: MediaCollection[] | null };
 
-const DEFAULT_WATCH__NOW = 'Watch Now';
+const DEFAULT_WATCH__NOW = 'Watch Live';
 
 const MemoizedMediaPlayer = memo(MediaLoader);
 
@@ -80,38 +81,49 @@ const LiveMediaStream = ({ mediaCollection }: Props) => {
 
   return (
     <div css={styles.componentContainer}>
-      <p
-        css={[
-          styles.mediaDescription,
-          warnings && styles.mediaDescriptionGuidance,
-        ]}
-      >
-        <Text size="pica" fontVariant="sansBold" as="span">
-          {short}
-        </Text>{' '}
-        <Text size="pica" fontVariant="sansRegular" as="span">
-          {networkName}
-        </Text>
-      </p>
-      {warnings && (
-        <Text as="p" css={styles.guidanceMessage}>
-          {warnings.warning_text}
-        </Text>
-      )}
       <button
         type="button"
         onClick={() => handleClick()}
         data-testid="watch-now-button"
-        css={[showMedia ? styles.hideComponent : styles.playButton]}
+        css={styles.playButton}
       >
         <Text
-          css={styles.playButtonText}
-          size="greatPrimer"
+          size="pica"
           fontVariant="sansBold"
+          as="span"
+          css={[
+            styles.mediaDescription,
+            warnings && styles.mediaDescriptionGuidance,
+          ]}
         >
-          {mediaIcons.video}
-          {watchNow}
+          <Text size="pica" fontVariant="sansBold" as="span">
+            {short}
+          </Text>{' '}
+          <VisuallyHiddenText>, </VisuallyHiddenText>
+          <Text size="pica" fontVariant="sansRegular" as="span">
+            {networkName}
+          </Text>
         </Text>
+        {warnings && (
+          <Text
+            as="span"
+            size="brevier"
+            fontVariant="sansRegular"
+            css={styles.guidanceMessage}
+          >
+            {warnings.warning_text}
+          </Text>
+        )}
+        <div css={[showMedia ? styles.hideComponent : styles.watchLiveCTA]}>
+          <Text
+            css={styles.watchLiveCTAText}
+            size="greatPrimer"
+            fontVariant="sansBold"
+          >
+            {mediaIcons.video}
+            {watchNow}
+          </Text>
+        </div>
       </button>
       <div css={[showMedia ? styles.liveMediaSpan : styles.hideComponent]}>
         <p css={styles.mediaDescription}>

--- a/src/app/components/LiveMediaStream/index.tsx
+++ b/src/app/components/LiveMediaStream/index.tsx
@@ -85,7 +85,7 @@ const LiveMediaStream = ({ mediaCollection }: Props) => {
         type="button"
         onClick={() => handleClick()}
         data-testid="watch-now-button"
-        css={styles.playButton}
+        css={styles.mediaButton}
       >
         <Text
           size="pica"

--- a/src/app/components/LiveMediaStream/index.tsx
+++ b/src/app/components/LiveMediaStream/index.tsx
@@ -36,7 +36,7 @@ const LiveMediaStream = ({ mediaCollection }: Props) => {
   }
 
   const {
-    media: { watchNow = DEFAULT_WATCH__NOW },
+    media: { watch = DEFAULT_WATCH__NOW },
   } = translations;
 
   const mediaItem = filterForBlockType(mediaCollection, 'liveMedia');
@@ -125,7 +125,7 @@ const LiveMediaStream = ({ mediaCollection }: Props) => {
             fontVariant="sansBold"
           >
             <PlayIcon />
-            {watchNow}
+            {watch}
           </Text>
         </div>
       </button>

--- a/src/app/components/LiveMediaStream/index.tsx
+++ b/src/app/components/LiveMediaStream/index.tsx
@@ -95,6 +95,7 @@ const LiveMediaStream = ({ mediaCollection }: Props) => {
             styles.mediaDescription,
             warnings && styles.mediaDescriptionGuidance,
           ]}
+          className="hoverStylesText"
         >
           <Text size="pica" fontVariant="sansBold" as="span">
             {short}
@@ -114,7 +115,10 @@ const LiveMediaStream = ({ mediaCollection }: Props) => {
             {warnings.warning_text}
           </Text>
         )}
-        <div css={[showMedia ? styles.hideComponent : styles.watchLiveCTA]}>
+        <div
+          className="hoverStylesCTA"
+          css={[showMedia ? styles.hideComponent : styles.watchLiveCTA]}
+        >
           <Text
             css={styles.watchLiveCTAText}
             size="greatPrimer"

--- a/src/app/components/LiveMediaStream/index.tsx
+++ b/src/app/components/LiveMediaStream/index.tsx
@@ -98,11 +98,11 @@ const LiveMediaStream = ({ mediaCollection }: Props) => {
           className="hoverStylesText"
         >
           <Text size="pica" fontVariant="sansBold" as="span">
-            {short}
-          </Text>{' '}
-          <VisuallyHiddenText>, </VisuallyHiddenText>
+            {short},{' '}
+          </Text>
           <Text size="pica" fontVariant="sansRegular" as="span">
             {networkName}
+            <VisuallyHiddenText>, </VisuallyHiddenText>
           </Text>
         </Text>
         {warnings && (
@@ -113,6 +113,7 @@ const LiveMediaStream = ({ mediaCollection }: Props) => {
             css={styles.guidanceMessage}
           >
             {warnings.warning_text}
+            <VisuallyHiddenText>, </VisuallyHiddenText>
           </Text>
         )}
         <div

--- a/src/app/components/icons/index.tsx
+++ b/src/app/components/icons/index.tsx
@@ -149,6 +149,8 @@ export const PlayIcon = ({ className }: { className?: string }) => (
     width="12"
     height="12"
     className={className}
+    focusable="false"
+    aria-hidden="true"
   >
     <path d="M29 16 5.8 1v30z" />
   </svg>

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/index.stories.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/index.stories.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import mundoLiveFixture from '#data/mundo/live/c7dkx155e626t.json';
+import { MediaCollection } from '#app/components/MediaLoader/types';
 import Header from '.';
 import metadata from './metadata.json';
 
@@ -9,6 +11,7 @@ interface ComponentProps {
   imageUrl?: string;
   imageUrlTemplate?: string;
   imageWidth?: number;
+  mediaCollections?: MediaCollection[] | null;
 }
 
 const Component = ({
@@ -18,6 +21,7 @@ const Component = ({
   imageUrl,
   imageUrlTemplate,
   imageWidth,
+  mediaCollections,
 }: ComponentProps) => {
   return (
     <Header
@@ -27,6 +31,7 @@ const Component = ({
       imageUrl={imageUrl}
       imageUrlTemplate={imageUrlTemplate}
       imageWidth={imageWidth}
+      mediaCollections={mediaCollections}
     />
   );
 };
@@ -131,5 +136,19 @@ export const TitleAndDescriptionWithLiveLabelAndImageExtraLongText = () => (
     imageUrl="https://ichef.bbci.co.uk/ace/standard/480/cpsdevpb/1d5b/test/5f969ec0-c4d8-11ed-8319-9b394d8ed0dd.jpg"
     imageUrlTemplate="https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/1d5b/test/5f969ec0-c4d8-11ed-8319-9b394d8ed0dd.jpg"
     imageWidth={660}
+  />
+);
+
+export const WithLiveMediaStream = () => (
+  <Component
+    title="An kai wa jirgin kwashe yan Turkiyya hari a Sudan"
+    showLiveLabel
+    description="Wannan shaft ne da ke kawo muku laqbarai daga sassan duniya daban-daban"
+    imageUrl="https://ichef.bbci.co.uk/ace/standard/480/cpsdevpb/1d5b/test/5f969ec0-c4d8-11ed-8319-9b394d8ed0dd.jpg"
+    imageUrlTemplate="https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/1d5b/test/5f969ec0-c4d8-11ed-8319-9b394d8ed0dd.jpg"
+    imageWidth={660}
+    mediaCollections={
+      mundoLiveFixture.data.mediaCollections as MediaCollection[]
+    }
   />
 );


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-1558](https://jira.dev.bbc.co.uk/browse/WSTEAM1-1558)

Overall changes
======
![Screenshot 2025-01-08 at 09 27 29](https://github.com/user-attachments/assets/f33494b2-42b7-4a86-8b35-a97c1c79eb38)

Applies UX designs, screen reader UX & A11y AACs to the 'Watch Live' button

(Note - the focus behaviour once button is clicked & 'Close Media' states are being handled in other tickets)

Code changes
======
- Wraps title, guidance message & WatchLiveCTA in 'mediaButton' button element.
- Renames 'playButton' to WatchLiveCTA & WatchLiveCTAText
- Applies hover & focus styles
- Applies forced colour styles
- Checks zoom, no CSS styles, focus indicator
- Adds story to LivePageHeader component

Coming in a follow up PR
- Colour contrast update
 
Optional follow up task (nice to have)
- Add logic to only add visually comma between title & brand if there is no punctuation in title.

Testing
======
[Storybook component](https://wsteam1-1558-watch-live-ux-a11y--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?globals=&args=&id=components-livemediastream--component&viewMode=story)
[Storybook component with guidance](https://wsteam1-1558-watch-live-ux-a11y--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?globals=&args=&id=components-livemediastream--component-with-guidance&viewMode=story)
[Storybook LivePageHeader](https://wsteam1-1558-watch-live-ux-a11y--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?globals=&args=&id=components-livepageheader--with-live-media-stream&viewMode=story)
Local asset: http://localhost.bbc.com:7081/mundo/live/c7dkx155e626t

Helpful Links
======
UX Design handoff figma: https://www.figma.com/design/BBLybBx1lceKYgKKGxmiwu/Live-page---Media-streaming-on-header---handoff?node-id=1351-12049&t=mDFKJXQW6CP0A9lo-4
Screen reader UX: https://paper.dropbox.com/doc/WS-Live-page-Screen-reader-UX--Cd_drUzfpS3DH8PtsqpcHWTrAg-8qm1UHDGVMhv5Qj9Q2mbi#:uid=135103855853461974121665&h2=Video-in-Header---No-media-gui
AAC: https://paper.dropbox.com/doc/Media-streaming-on-Live-page-header-Accessibility-Acceptance-Criteria--Cd9XeuiOa~qvgofSxoEXe6jRAg-IJpFNBmz2Anh6JxczSMit

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
