### PR TITLE
WSTEAMA-1484 - Reverb unit tests

### DIFF
--- a/src/app/components/ATIAnalytics/atiUrl/index.test.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.test.ts
@@ -319,147 +319,149 @@ describe('buildATIEventTrackUrl', () => {
   });
 });
 
-describe('buildReverbAnalyticsModel', () => {
-  beforeEach(() => {
-    analyticsUtilFunctions.forEach(func => {
-      mockAndSet(func, func.name);
+describe('Reverb', () => {
+  describe('buildReverbAnalyticsModel', () => {
+    beforeEach(() => {
+      analyticsUtilFunctions.forEach(func => {
+        mockAndSet(func, func.name);
+      });
     });
-  });
 
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
 
-  const input = {
-    appName: 'news',
-    campaigns: [
-      {
-        campaignId: '1',
-        campaignName: 'campaign1',
-      },
-      {
-        campaignId: '2',
-        campaignName: 'campaign2',
-      },
-    ],
-    categoryName: 'categoryName',
-    contentId: 'contentId',
-    contentType: 'contentType',
-    language: 'language',
-    ldpThingIds: 'ldpThingIds',
-    ldpThingLabels: 'ldpThingLabels',
-    libraryVersion: 'libraryVersion',
-    pageIdentifier: 'pageIdentifier',
-    pageTitle: 'pageTitle',
-    platform: 'canonical' as Platforms,
-    previousPath: '',
-    producerName: 'producerName',
-    origin: 'http://localhost',
-    nationsProducer: '',
-    statsDestination: 'statsDestination',
-    timePublished: 'timePublished',
-    timeUpdated: 'timeUpdated',
-  };
-
-  it('should return the correct Reverb analytics model', () => {
-    const reverbAnalyticsModel = buildReverbAnalyticsModel(input);
-
-    const pageParams = {
+    const input = {
+      appName: 'news',
+      campaigns: [
+        {
+          campaignId: '1',
+          campaignName: 'campaign1',
+        },
+        {
+          campaignId: '2',
+          campaignName: 'campaign2',
+        },
+      ],
+      categoryName: 'categoryName',
       contentId: 'contentId',
       contentType: 'contentType',
-      destination: 'statsDestination',
-      name: 'pageIdentifier',
-      producer: 'producerName',
-      additionalProperties: {
-        app_name: 'news',
-        app_type: 'getAppType',
-        content_language: 'language',
-        product_platform: null,
-        referrer_url: 'getReferrer',
-        x5: 'getHref',
-        x8: 'libraryVersion',
-        x9: 'sanitise',
-        x10: '',
-        x11: 'timePublished',
-        x12: 'timeUpdated',
-        x13: 'ldpThingLabels',
-        x14: 'ldpThingIds',
-        x16: 'campaign1~campaign2',
-        x17: 'categoryName',
-        x18: 'isLocServeCookieSet',
-      },
+      language: 'language',
+      ldpThingIds: 'ldpThingIds',
+      ldpThingLabels: 'ldpThingLabels',
+      libraryVersion: 'libraryVersion',
+      pageIdentifier: 'pageIdentifier',
+      pageTitle: 'pageTitle',
+      platform: 'canonical' as Platforms,
+      previousPath: '',
+      producerName: 'producerName',
+      origin: 'http://localhost',
+      nationsProducer: '',
+      statsDestination: 'statsDestination',
+      timePublished: 'timePublished',
+      timeUpdated: 'timeUpdated',
     };
 
-    expect(reverbAnalyticsModel.params.page).toEqual(pageParams);
+    it('should return the correct Reverb analytics model', () => {
+      const reverbAnalyticsModel = buildReverbAnalyticsModel(input);
+
+      const pageParams = {
+        contentId: 'contentId',
+        contentType: 'contentType',
+        destination: 'statsDestination',
+        name: 'pageIdentifier',
+        producer: 'producerName',
+        additionalProperties: {
+          app_name: 'news',
+          app_type: 'getAppType',
+          content_language: 'language',
+          product_platform: null,
+          referrer_url: 'getReferrer',
+          x5: 'getHref',
+          x8: 'libraryVersion',
+          x9: 'sanitise',
+          x10: '',
+          x11: 'timePublished',
+          x12: 'timeUpdated',
+          x13: 'ldpThingLabels',
+          x14: 'ldpThingIds',
+          x16: 'campaign1~campaign2',
+          x17: 'categoryName',
+          x18: 'isLocServeCookieSet',
+        },
+      };
+
+      expect(reverbAnalyticsModel.params.page).toEqual(pageParams);
+    });
   });
-});
 
-describe('buildReverbPageSectionEventModel', () => {
-  const input = {
-    pageIdentifier: 'mundo.page',
-    producerName: 'MUNDO',
-    statsDestination: 'statsDestination',
-    componentName: 'top-stories',
-    campaignID: '1234',
-    format: 'format',
-    type: 'view',
-    advertiserID: 'advertiserID',
-    url: 'http://localhost',
-  };
-
-  it('should return the correct Reverb page section view event model', () => {
-    const reverbPageSectionViewEventModel =
-      buildReverbPageSectionEventModel(input);
-
-    const pageSectionViewEventParams = {
-      destination: 'statsDestination',
-      name: 'mundo.page',
-      producer: 'MUNDO',
-      additionalProperties: {
-        ati: 'PUB-[1234]-[top-stories]-[]-[format]-[mundo.page]-[]-[advertiserID]-[http://localhost]',
-        type: 'AT',
-      },
+  describe('buildReverbPageSectionEventModel', () => {
+    const input = {
+      pageIdentifier: 'mundo.page',
+      producerName: 'MUNDO',
+      statsDestination: 'statsDestination',
+      componentName: 'top-stories',
+      campaignID: '1234',
+      format: 'format',
+      type: 'view',
+      advertiserID: 'advertiserID',
+      url: 'http://localhost',
     };
 
-    expect(reverbPageSectionViewEventModel.params.page).toEqual(
-      pageSectionViewEventParams,
-    );
-  });
+    it('should return the correct Reverb page section view event model', () => {
+      const reverbPageSectionViewEventModel =
+        buildReverbPageSectionEventModel(input);
 
-  it('should return the correct eventName for the Reverb page section view event model', () => {
-    const reverbPageSectionViewEventModel =
-      buildReverbPageSectionEventModel(input);
+      const pageSectionViewEventParams = {
+        destination: 'statsDestination',
+        name: 'mundo.page',
+        producer: 'MUNDO',
+        additionalProperties: {
+          ati: 'PUB-[1234]-[top-stories]-[]-[format]-[mundo.page]-[]-[advertiserID]-[http://localhost]',
+          type: 'AT',
+        },
+      };
 
-    expect(reverbPageSectionViewEventModel.eventName).toEqual('sectionView');
-  });
-
-  it('should return the correct Reverb page section click event model', () => {
-    const reverbPageSectionViewEventModel = buildReverbPageSectionEventModel({
-      ...input,
-      type: 'click',
+      expect(reverbPageSectionViewEventModel.params.page).toEqual(
+        pageSectionViewEventParams,
+      );
     });
 
-    const pageSectionViewEventParams = {
-      destination: 'statsDestination',
-      name: 'mundo.page',
-      producer: 'MUNDO',
-      additionalProperties: {
-        atc: 'PUB-[1234]-[top-stories]-[]-[format]-[mundo.page]-[]-[advertiserID]-[http://localhost]',
-        type: 'AT',
-      },
-    };
+    it('should return the correct eventName for the Reverb page section view event model', () => {
+      const reverbPageSectionViewEventModel =
+        buildReverbPageSectionEventModel(input);
 
-    expect(reverbPageSectionViewEventModel.params.page).toEqual(
-      pageSectionViewEventParams,
-    );
-  });
-
-  it('should return the correct eventName for the Reverb page section click event model', () => {
-    const reverbPageSectionViewEventModel = buildReverbPageSectionEventModel({
-      ...input,
-      type: 'click',
+      expect(reverbPageSectionViewEventModel.eventName).toEqual('sectionView');
     });
 
-    expect(reverbPageSectionViewEventModel.eventName).toEqual('sectionClick');
+    it('should return the correct Reverb page section click event model', () => {
+      const reverbPageSectionViewEventModel = buildReverbPageSectionEventModel({
+        ...input,
+        type: 'click',
+      });
+
+      const pageSectionViewEventParams = {
+        destination: 'statsDestination',
+        name: 'mundo.page',
+        producer: 'MUNDO',
+        additionalProperties: {
+          atc: 'PUB-[1234]-[top-stories]-[]-[format]-[mundo.page]-[]-[advertiserID]-[http://localhost]',
+          type: 'AT',
+        },
+      };
+
+      expect(reverbPageSectionViewEventModel.params.page).toEqual(
+        pageSectionViewEventParams,
+      );
+    });
+
+    it('should return the correct eventName for the Reverb page section click event model', () => {
+      const reverbPageSectionViewEventModel = buildReverbPageSectionEventModel({
+        ...input,
+        type: 'click',
+      });
+
+      expect(reverbPageSectionViewEventModel.eventName).toEqual('sectionClick');
+    });
   });
 });

--- a/src/app/components/ATIAnalytics/atiUrl/index.test.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.test.ts
@@ -1,6 +1,12 @@
 import { resetWindowValue } from '#psammead/psammead-test-helpers/src';
+import { Platforms } from '#app/models/types/global';
 import * as genericLabelHelpers from '../../../lib/analyticsUtils';
-import { buildATIPageTrackPath, buildATIEventTrackUrl } from '.';
+import {
+  buildATIPageTrackPath,
+  buildATIEventTrackUrl,
+  buildReverbAnalyticsModel,
+  buildReverbPageSectionEventModel,
+} from '.';
 
 // @ts-expect-error required for testing purposes
 const mockAndSet = ({ name, source }, response) => {
@@ -309,5 +315,140 @@ describe('buildATIEventTrackUrl', () => {
       'mv_creation=variant_1',
       'type=AT',
     ]);
+  });
+});
+
+describe('buildReverbAnalyticsModel', () => {
+  const input = {
+    appName: 'news',
+    campaigns: [
+      {
+        campaignId: '1',
+        campaignName: 'campaign1',
+      },
+      {
+        campaignId: '2',
+        campaignName: 'campaign2',
+      },
+    ],
+    categoryName: 'categoryName',
+    contentId: 'contentId',
+    contentType: 'contentType',
+    language: 'language',
+    ldpThingIds: 'ldpThingIds',
+    ldpThingLabels: 'ldpThingLabels',
+    libraryVersion: 'libraryVersion',
+    pageIdentifier: 'pageIdentifier',
+    pageTitle: 'pageTitle',
+    platform: 'canonical' as Platforms,
+    previousPath: '',
+    producerName: 'producerName',
+    origin: 'http://localhost',
+    nationsProducer: '',
+    statsDestination: 'statsDestination',
+    timePublished: 'timePublished',
+    timeUpdated: 'timeUpdated',
+  };
+
+  it('should return the correct Reverb analytics model', () => {
+    const reverbAnalyticsModel = buildReverbAnalyticsModel(input);
+
+    const pageParams = {
+      contentId: 'contentId',
+      contentType: 'contentType',
+      destination: 'statsDestination',
+      name: 'pageIdentifier',
+      producer: 'producerName',
+      additionalProperties: {
+        app_name: 'news',
+        app_type: 'responsive',
+        content_language: 'language',
+        product_platform: null,
+        referrer_url: null,
+        x5: 'http%253A%252F%252Flocalhost%252F',
+        x8: 'libraryVersion',
+        x9: 'pageTitle',
+        x10: '',
+        x11: 'timePublished',
+        x12: 'timeUpdated',
+        x13: 'ldpThingLabels',
+        x14: 'ldpThingIds',
+        x16: 'campaign1~campaign2',
+        x17: 'categoryName',
+        x18: false,
+      },
+    };
+
+    expect(reverbAnalyticsModel.params.page).toEqual(pageParams);
+  });
+});
+
+describe('buildReverbPageSectionEventModel', () => {
+  const input = {
+    pageIdentifier: 'mundo.page',
+    producerName: 'MUNDO',
+    statsDestination: 'statsDestination',
+    componentName: 'top-stories',
+    campaignID: '1234',
+    format: 'format',
+    type: 'view',
+    advertiserID: 'advertiserID',
+    url: 'http://localhost',
+  };
+
+  it('should return the correct Reverb page section view event model', () => {
+    const reverbPageSectionViewEventModel =
+      buildReverbPageSectionEventModel(input);
+
+    const pageSectionViewEventParams = {
+      destination: 'statsDestination',
+      name: 'mundo.page',
+      producer: 'MUNDO',
+      additionalProperties: {
+        ati: 'PUB-[1234]-[top-stories]-[]-[format]-[mundo.page]-[]-[advertiserID]-[http://localhost]',
+        type: 'AT',
+      },
+    };
+
+    expect(reverbPageSectionViewEventModel.params.page).toEqual(
+      pageSectionViewEventParams,
+    );
+  });
+
+  it('should return the correct eventName for the Reverb page section view event model', () => {
+    const reverbPageSectionViewEventModel =
+      buildReverbPageSectionEventModel(input);
+
+    expect(reverbPageSectionViewEventModel.eventName).toEqual('sectionView');
+  });
+
+  it('should return the correct Reverb page section click event model', () => {
+    const reverbPageSectionViewEventModel = buildReverbPageSectionEventModel({
+      ...input,
+      type: 'click',
+    });
+
+    const pageSectionViewEventParams = {
+      destination: 'statsDestination',
+      name: 'mundo.page',
+      producer: 'MUNDO',
+      additionalProperties: {
+        atc: 'PUB-[1234]-[top-stories]-[]-[format]-[mundo.page]-[]-[advertiserID]-[http://localhost]',
+        type: 'AT',
+      },
+    };
+
+    expect(reverbPageSectionViewEventModel.params.page).toEqual(
+      pageSectionViewEventParams,
+    );
+  });
+
+  it('should return the correct eventName for the Reverb page section click event model', () => {
+    const reverbPageSectionViewEventModel = buildReverbPageSectionEventModel({
+      ...input,
+      type: 'click',
+    });
+
+    expect(reverbPageSectionViewEventModel.eventName).toEqual('sectionClick');
   });
 });

--- a/src/app/components/ATIAnalytics/atiUrl/index.test.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.test.ts
@@ -56,6 +56,7 @@ describe('getThingAttributes', () => {
 
   afterEach(() => {
     jest.resetAllMocks();
+
     resetWindowValue('location', windowLocation);
   });
 
@@ -319,6 +320,16 @@ describe('buildATIEventTrackUrl', () => {
 });
 
 describe('buildReverbAnalyticsModel', () => {
+  beforeEach(() => {
+    analyticsUtilFunctions.forEach(func => {
+      mockAndSet(func, func.name);
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   const input = {
     appName: 'news',
     campaigns: [
@@ -361,13 +372,13 @@ describe('buildReverbAnalyticsModel', () => {
       producer: 'producerName',
       additionalProperties: {
         app_name: 'news',
-        app_type: 'responsive',
+        app_type: 'getAppType',
         content_language: 'language',
         product_platform: null,
-        referrer_url: null,
-        x5: 'http%253A%252F%252Flocalhost%252F',
+        referrer_url: 'getReferrer',
+        x5: 'getHref',
         x8: 'libraryVersion',
-        x9: 'pageTitle',
+        x9: 'sanitise',
         x10: '',
         x11: 'timePublished',
         x12: 'timeUpdated',
@@ -375,7 +386,7 @@ describe('buildReverbAnalyticsModel', () => {
         x14: 'ldpThingIds',
         x16: 'campaign1~campaign2',
         x17: 'categoryName',
-        x18: false,
+        x18: 'isLocServeCookieSet',
       },
     };
 

--- a/src/app/components/ATIAnalytics/beacon/index.test.ts
+++ b/src/app/components/ATIAnalytics/beacon/index.test.ts
@@ -61,41 +61,43 @@ describe('beacon', () => {
       });
     });
 
-    it('should call reverb view event exactly once', async () => {
-      await sendEventBeacon({
-        type: 'view',
-        service: 'news',
-        componentName: 'component',
-        pageIdentifier: 'pageIdentifier',
-        detailedPlacement: 'detailedPlacement',
-        useReverb: true,
+    describe('Reverb', () => {
+      it('should call reverb view event exactly once', async () => {
+        await sendEventBeacon({
+          type: 'view',
+          service: 'news',
+          componentName: 'component',
+          pageIdentifier: 'pageIdentifier',
+          detailedPlacement: 'detailedPlacement',
+          useReverb: true,
+        });
+        expect(sendBeaconSpy).toHaveBeenCalledTimes(1);
+
+        expect(reverbMock.viewEvent).toHaveBeenCalledTimes(1);
       });
-      expect(sendBeaconSpy).toHaveBeenCalledTimes(1);
 
-      expect(reverbMock.viewEvent).toHaveBeenCalledTimes(1);
-    });
+      it('should call reverb click event exactly once', async () => {
+        await sendEventBeacon({
+          type: 'click',
+          service: 'news',
+          componentName: 'component',
+          pageIdentifier: 'pageIdentifier',
+          detailedPlacement: 'detailedPlacement',
+          useReverb: true,
+        });
+        expect(sendBeaconSpy).toHaveBeenCalledTimes(1);
 
-    it('should call reverb click event exactly once', async () => {
-      await sendEventBeacon({
-        type: 'click',
-        service: 'news',
-        componentName: 'component',
-        pageIdentifier: 'pageIdentifier',
-        detailedPlacement: 'detailedPlacement',
-        useReverb: true,
+        expect(reverbMock.userActionEvent).toHaveBeenCalledTimes(1);
+
+        expect(reverbMock.userActionEvent).toHaveBeenCalledWith(
+          'click',
+          'Top Stories Link',
+          {},
+          {},
+          {},
+          true,
+        );
       });
-      expect(sendBeaconSpy).toHaveBeenCalledTimes(1);
-
-      expect(reverbMock.userActionEvent).toHaveBeenCalledTimes(1);
-
-      expect(reverbMock.userActionEvent).toHaveBeenCalledWith(
-        'click',
-        'Top Stories Link',
-        {},
-        {},
-        {},
-        true,
-      );
     });
   });
 });

--- a/src/app/components/ATIAnalytics/beacon/index.test.ts
+++ b/src/app/components/ATIAnalytics/beacon/index.test.ts
@@ -18,7 +18,6 @@ const reverbMock = {
   userActionEvent: jest.fn(),
 };
 
-// @ts-expect-error '__reverb' is added to the window object by a script tag
 // eslint-disable-next-line no-underscore-dangle
 window.__reverb = {
   __reverbLoadedPromise: Promise.resolve(reverbMock),

--- a/src/app/components/ATIAnalytics/beacon/index.test.ts
+++ b/src/app/components/ATIAnalytics/beacon/index.test.ts
@@ -11,6 +11,19 @@ const sendBeaconSpy = jest.spyOn(sendBeacon, 'default');
   .fn()
   .mockReturnValue('00-00-00');
 
+const reverbMock = {
+  isReady: jest.fn(),
+  initialise: jest.fn(() => Promise.resolve()),
+  viewEvent: jest.fn(),
+  userActionEvent: jest.fn(),
+};
+
+// @ts-expect-error '__reverb' is added to the window object by a script tag
+// eslint-disable-next-line no-underscore-dangle
+window.__reverb = {
+  __reverbLoadedPromise: Promise.resolve(reverbMock),
+};
+
 describe('beacon', () => {
   const originalATIBaseUrl = process.env.SIMORGH_ATI_BASE_URL;
   const atiBaseUrl = 'https://foobar.com?';
@@ -47,6 +60,43 @@ describe('beacon', () => {
         atc: 'PUB-[]-[component]-[]-[]-[pageIdentifier]-[detailedPlacement]-[]-[]',
         type: 'AT',
       });
+    });
+
+    it('should call reverb view event exactly once', async () => {
+      await sendEventBeacon({
+        type: 'view',
+        service: 'news',
+        componentName: 'component',
+        pageIdentifier: 'pageIdentifier',
+        detailedPlacement: 'detailedPlacement',
+        useReverb: true,
+      });
+      expect(sendBeaconSpy).toHaveBeenCalledTimes(1);
+
+      expect(reverbMock.viewEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call reverb click event exactly once', async () => {
+      await sendEventBeacon({
+        type: 'click',
+        service: 'news',
+        componentName: 'component',
+        pageIdentifier: 'pageIdentifier',
+        detailedPlacement: 'detailedPlacement',
+        useReverb: true,
+      });
+      expect(sendBeaconSpy).toHaveBeenCalledTimes(1);
+
+      expect(reverbMock.userActionEvent).toHaveBeenCalledTimes(1);
+
+      expect(reverbMock.userActionEvent).toHaveBeenCalledWith(
+        'click',
+        'Top Stories Link',
+        {},
+        {},
+        {},
+        true,
+      );
     });
   });
 });

--- a/src/app/components/ATIAnalytics/index.test.tsx
+++ b/src/app/components/ATIAnalytics/index.test.tsx
@@ -9,6 +9,8 @@ import {
   setWindowValue,
   resetWindowValue,
 } from '#psammead/psammead-test-helpers/src';
+import { ServiceContext } from '#contexts/ServiceContext';
+import { ServiceConfig } from '#models/types/serviceConfig';
 import styAssetData from './fixtures/storyPage.json';
 import pglAssetData from './fixtures/photoGalleryPage.json';
 import mapAssetData from './fixtures/mediaAssetPage.json';
@@ -1133,6 +1135,70 @@ describe('ATI Analytics Container', () => {
         x11: '[2019-05-30T14:23:38.000Z]',
         x12: '[2019-07-19T12:46:18.000Z]',
         ref: '${documentReferrer}',
+      });
+    });
+  });
+
+  describe('Reverb', () => {
+    it('should supply reverbParams when Reverb is enabled', () => {
+      const mockCanonical = jest.fn().mockReturnValue('canonical-return-value');
+      // @ts-expect-error - we need to mock these functions to ensure tests are deterministic
+      canonical.default = mockCanonical;
+
+      const {
+        metadata: { atiAnalytics },
+      } = articleDataNews;
+
+      // @ts-expect-error - only partial data required to manually set 'useReverb' to true
+      const serviceContextProps: ServiceConfig = {
+        atiAnalyticsAppName: 'atiAnalyticsAppName',
+        atiAnalyticsProducerId: 'atiAnalyticsProducerId',
+        service: 'pidgin',
+        brandName: 'brandName',
+        lang: 'pcm',
+        useReverb: true,
+      };
+
+      render(
+        <ServiceContext.Provider value={serviceContextProps}>
+          <ATIAnalytics atiData={atiAnalytics} />
+        </ServiceContext.Provider>,
+        {
+          ...defaultRenderProps,
+          atiData: atiAnalytics,
+          isAmp: false,
+          pageData: articleDataNews,
+          pageType: ARTICLE_PAGE,
+          service: 'pidgin',
+          isUK: true,
+        },
+      );
+
+      const { reverbParams } = mockCanonical.mock.calls[0][0];
+
+      expect(reverbParams.params.page).toEqual({
+        contentId: 'urn:bbc:optimo:c0000000001o',
+        contentType: 'article',
+        destination: 'WS_NEWS_LANGUAGES_TEST',
+        name: 'news.articles.c0000000001o.page',
+        additionalProperties: {
+          app_name: 'atiAnalyticsAppName',
+          app_type: 'responsive',
+          content_language: 'en-gb',
+          product_platform: null,
+          referrer_url: null,
+          x5: 'http%253A%252F%252Flocalhost%252F',
+          x8: 'simorgh',
+          x9: 'Article%20Headline%20for%20SEO',
+          x10: null,
+          x11: '2018-01-01T12:01:00.000Z',
+          x12: '2018-01-01T14:00:00.000Z',
+          x13: 'Royal+Wedding+2018~Duchess+of+Sussex',
+          x14: '2351f2b2-ce36-4f44-996d-c3c4f7f90eaa~803eaeb9-c0c3-4f1b-9a66-90efac3df2dc',
+          x16: '',
+          x17: 'Royal+Wedding+2018~Duchess+of+Sussex',
+          x18: false,
+        },
       });
     });
   });

--- a/src/app/lib/analyticsUtils/sendBeacon/index.test.js
+++ b/src/app/lib/analyticsUtils/sendBeacon/index.test.js
@@ -5,6 +5,18 @@ import { ATI_LOGGING_ERROR } from '#app/lib/logger.const';
 let fetchResponse;
 let isOnClient;
 
+const reverbMock = {
+  isReady: jest.fn(),
+  initialise: jest.fn(() => Promise.resolve()),
+  viewEvent: jest.fn(),
+  userActionEvent: jest.fn(),
+};
+
+// eslint-disable-next-line no-underscore-dangle
+window.__reverb = {
+  __reverbLoadedPromise: Promise.resolve(reverbMock),
+};
+
 describe('sendBeacon', () => {
   beforeEach(() => {
     isOnClient = true;
@@ -36,6 +48,32 @@ describe('sendBeacon', () => {
     sendBeacon('https://foobar.com');
 
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  describe('Reverb', () => {
+    const reverbConfig = {
+      params: {
+        page: 'page',
+        user: '1234-5678',
+      },
+      eventName: 'pageView',
+    };
+
+    it('should call Reverb viewEvent if Reverb config is passed', async () => {
+      const sendBeacon = require('./index').default;
+
+      await sendBeacon('https://foobar.com', reverbConfig);
+
+      expect(reverbMock.viewEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call "fetch" if Reverb config is passed', async () => {
+      const sendBeacon = require('./index').default;
+
+      await sendBeacon('https://foobar.com', reverbConfig);
+
+      expect(fetch).not.toHaveBeenCalled();
+    });
   });
 
   describe('when the fetch fails', () => {

--- a/src/app/models/types/eventTracking.ts
+++ b/src/app/models/types/eventTracking.ts
@@ -1,5 +1,12 @@
 import { ReactSDKClient } from '@optimizely/react-sdk';
 
+export type ReverbClient = {
+  isReady: () => boolean;
+  initialise: () => Promise<void>;
+  viewEvent: () => void;
+  userActionEvent: () => void;
+};
+
 export type EventTrackingMetadata = {
   componentName: string;
   detailedPlacement?: string;

--- a/src/app/models/types/eventTracking.ts
+++ b/src/app/models/types/eventTracking.ts
@@ -4,7 +4,8 @@ export type ReverbClient = {
   isReady: () => boolean;
   initialise: () => Promise<void>;
   viewEvent: () => void;
-  userActionEvent: () => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userActionEvent: (...args: any[]) => void;
 };
 
 export type EventTrackingMetadata = {

--- a/src/app/models/types/eventTracking.ts
+++ b/src/app/models/types/eventTracking.ts
@@ -4,8 +4,7 @@ export type ReverbClient = {
   isReady: () => boolean;
   initialise: () => Promise<void>;
   viewEvent: () => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userActionEvent: (...args: any[]) => void;
+  userActionEvent: (...args: unknown[]) => void;
 };
 
 export type EventTrackingMetadata = {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,11 @@
+import { ReverbClient } from '#models/types/eventTracking';
+import { BumpType } from '#app/components/MediaLoader/types';
+
 declare global {
   interface Window {
+    __reverb: {
+      __reverbLoadedPromise: Promise<ReverbClient>;
+    };
     requirejs: (
       bumpVersion: string[],
       callback: (Bump: BumpType) => void,


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAMA-1484

Overall changes
======
- Adds initial set of unit test coverage for areas where Reverb has been introduced
- Adds `window` type for `__reverb`

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
