### PR TITLE
WSTEAMA-1412: Add custom resource loader to fetch Reverb

### DIFF
--- a/src/integration/utils/customResourceLoader.js
+++ b/src/integration/utils/customResourceLoader.js
@@ -1,0 +1,16 @@
+const jsdom = require('jsdom');
+
+class CustomResourceLoader extends jsdom.ResourceLoader {
+  fetch(url, options) {
+    if (
+      url ===
+      'https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.9.2.js'
+    ) {
+      return super.fetch(url, options);
+    }
+
+    return null;
+  }
+}
+
+module.exports = CustomResourceLoader;

--- a/src/integration/utils/fetchDom.js
+++ b/src/integration/utils/fetchDom.js
@@ -8,6 +8,8 @@ dns.setDefaultResultOrder('ipv4first');
 const { JSDOM } = require('jsdom');
 const retry = require('retry');
 
+const CustomResourceLoader = require('./customResourceLoader');
+
 const faultTolerantDomFetch = ({ url, runScripts, headers }) =>
   new Promise((resolve, reject) => {
     const oneSecond = 1000;
@@ -31,7 +33,12 @@ const faultTolerantDomFetch = ({ url, runScripts, headers }) =>
         const html = await response.text();
         const dom = new JSDOM(html, {
           url,
-          ...(runScripts ? { runScripts: 'dangerously' } : {}),
+          ...(runScripts
+            ? {
+                runScripts: 'dangerously',
+                resources: new CustomResourceLoader(),
+              }
+            : {}),
         });
 
         resolve(dom);


### PR DESCRIPTION
Resolves JIRA [WSTEAMA-1412]

Overall changes
======
Implements a [CustomResourceLoader](https://github.com/jsdom/jsdom?tab=readme-ov-file#advanced-configuration) to enable fetching Reverb.

Code changes
======

- Add a CustomResourceLoader to override fetch to facilitate fetching Reverb in integration tests.

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
