### PR TITLE
WSTEAM1-1584: Invert Focus Indicator

### DIFF
--- a/src/app/components/LiveHeaderMedia/index.tsx
+++ b/src/app/components/LiveHeaderMedia/index.tsx
@@ -134,6 +134,7 @@ const LiveHeaderMedia = ({ mediaCollection }: Props) => {
           type="button"
           onClick={() => handleClick()}
           data-testid="watch-now-close-button"
+          className="focusIndicatorInvert"
           css={[
             showMedia ? styles.closeButton : styles.openButton,
             styles.mediaButton,

--- a/src/app/components/ThemeProvider/focusIndicator.ts
+++ b/src/app/components/ThemeProvider/focusIndicator.ts
@@ -54,7 +54,8 @@ const focusIndicator = ({ palette }: Theme) => css`
   }
 
   // Overrides focus indicator styles with inverted colours. Used on a dark background page. E.g. Episode lists.
-  a.focusIndicatorInvert:focus-visible {
+  a.focusIndicatorInvert:focus-visible,
+  button.focusIndicatorInvert:focus-visible {
     outline: ${focusIndicatorThickness} solid ${palette.WHITE};
     box-shadow: 0 0 0 ${focusIndicatorThickness} ${palette.BLACK};
     outline-offset: ${focusIndicatorThickness};


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAM1-1584

Overall changes
======
Inverts focus indicator(black inside white outside)

Before
![Screenshot 2025-01-14 at 11 41 20](https://github.com/user-attachments/assets/8d227f93-45bb-49e8-a2a0-92ce46b2c418)
![Screenshot 2025-01-14 at 11 41 24](https://github.com/user-attachments/assets/0f8e7e8a-450c-4ea9-bc1d-43823c46d625)


After
![Screenshot 2025-01-14 at 11 40 28](https://github.com/user-attachments/assets/7f953538-7e03-46d4-9564-4d325fa97ca1)
![Screenshot 2025-01-14 at 11 40 38](https://github.com/user-attachments/assets/36cc6d4d-2894-45bf-8596-9dae802ac305)



Code changes
======


Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
