### PR TITLE
WSTEAM1-1587: High Contrast text & play icon

### DIFF
--- a/src/app/components/LiveHeaderMedia/index.styles.tsx
+++ b/src/app/components/LiveHeaderMedia/index.styles.tsx
@@ -64,11 +64,6 @@ export default {
         color: 'canvasText',
       },
     }),
-  title: () =>
-    css({
-      display: 'block',
-      width: '100%',
-    }),
   guidanceMessage: ({ palette, spacings, mq }: Theme) =>
     css({
       display: 'block',
@@ -91,20 +86,6 @@ export default {
       },
       [mq.FORCED_COLOURS]: {
         border: `${pixelsToRem(2)}rem solid canvasText`,
-      },
-    }),
-  liveMediaStreamText: ({ palette }: Theme) =>
-    css({
-      color: palette.GREY_4,
-    }),
-  liveMediaStreamContainer: ({ mq }: Theme) =>
-    css({
-      maxWidth: '60%',
-      [mq.GROUP_2_MAX_WIDTH]: {
-        width: '100%',
-      },
-      [mq.GROUP_4_MAX_WIDTH]: {
-        width: '50%',
       },
     }),
   closeButton: () =>
@@ -140,10 +121,6 @@ export default {
       [mq.FORCED_COLOURS]: {
         color: 'canvasText',
       },
-    }),
-  liveMediaSpan: () =>
-    css({
-      maxWidth: '100%',
     }),
   mediaLoader: ({ spacings }: Theme) =>
     css({
@@ -185,6 +162,5 @@ export default {
       },
     }),
 
-  underlineFocus: () => css({ display: 'none' }),
   hideComponent: () => css({ display: 'none' }),
 };

--- a/src/app/components/LiveHeaderMedia/index.styles.tsx
+++ b/src/app/components/LiveHeaderMedia/index.styles.tsx
@@ -11,7 +11,7 @@ export default {
         display: 'none',
       },
     }),
-  nojs: ({ palette, spacings, fontSizes, fontVariants }: Theme) =>
+  nojs: ({ palette, spacings, fontSizes, fontVariants, mq }: Theme) =>
     css({
       ...fontSizes.pica,
       ...fontVariants.sansRegular,
@@ -24,14 +24,14 @@ export default {
         marginTop: `${spacings.DOUBLE}rem`,
         fontWeight: 'normal',
       },
-    }),
-  mediaButton: ({ mq }: Theme) =>
-    css({
-      position: 'relative',
-      padding: 0,
       [mq.FORCED_COLOURS]: {
         color: 'canvasText',
       },
+    }),
+  mediaButton: () =>
+    css({
+      position: 'relative',
+      padding: 0,
     }),
   openButton: () =>
     css({
@@ -40,7 +40,7 @@ export default {
       border: 'unset',
       textAlign: 'start',
     }),
-  watchLiveCTAText: ({ spacings, palette }: Theme) =>
+  watchLiveCTAText: ({ spacings, palette, mq }: Theme) =>
     css({
       color: palette.WHITE,
       display: 'flex',
@@ -53,9 +53,15 @@ export default {
         fill: 'currentcolor',
         color: palette.WHITE,
         marginInlineEnd: `${spacings.FULL}rem`,
+        [mq.FORCED_COLOURS]: {
+          color: 'canvasText',
+        },
       },
       'button:hover &, button:focus-visible &': {
         textDecoration: 'underline',
+      },
+      [mq.FORCED_COLOURS]: {
+        color: 'canvasText',
       },
     }),
   title: () =>
@@ -63,12 +69,15 @@ export default {
       display: 'block',
       width: '100%',
     }),
-  guidanceMessage: ({ palette, spacings }: Theme) =>
+  guidanceMessage: ({ palette, spacings, mq }: Theme) =>
     css({
       display: 'block',
       marginTop: `${spacings.DOUBLE}rem`,
       color: palette.GREY_2,
       textAlign: 'start',
+      [mq.FORCED_COLOURS]: {
+        color: 'canvasText',
+      },
     }),
   watchLiveCTA: ({ palette, mq, spacings }: Theme) =>
     css({
@@ -81,7 +90,6 @@ export default {
         width: '100%',
       },
       [mq.FORCED_COLOURS]: {
-        color: 'canvasText',
         border: `${pixelsToRem(2)}rem solid canvasText`,
       },
     }),
@@ -119,6 +127,9 @@ export default {
         height: `${spacings.DOUBLE}rem`,
         width: `${spacings.DOUBLE}rem`,
         margin: `${pixelsToRem(13)}rem`,
+        [mq.FORCED_COLOURS]: {
+          color: 'canvasText',
+        },
       },
       backgroundColor: palette.BLACK,
       border: `${palette.WHITE} solid ${pixelsToRem(1)}rem`,
@@ -146,14 +157,24 @@ export default {
       marginTop: 0,
       span: { margin: 0 },
     }),
-  openMediaDescription: ({ palette }: Theme) =>
+  openMediaDescription: ({ palette, mq }: Theme) =>
     css({
-      span: { color: palette.GREY_4 },
+      span: {
+        color: palette.GREY_4,
+        [mq.FORCED_COLOURS]: {
+          color: 'canvasText',
+        },
+      },
     }),
   closeMediaDescription: ({ mq, palette }: Theme) =>
     css({
       textAlign: 'start',
-      span: { color: palette.WHITE },
+      span: {
+        color: palette.WHITE,
+        [mq.FORCED_COLOURS]: {
+          color: 'canvasText',
+        },
+      },
       'button:hover &, button:focus-visible &': {
         span: {
           textDecoration: 'underline',


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-1587](https://jira.dev.bbc.co.uk/browse/WSTEAM1-1587)

Overall changes
======
Makes text & play icon visible on Windows High Contrast mode.

Code changes
======
- Applies 'color: canvastext' directly to elements which have colour styles
- Removes unused styles

Testing
======
Visit storybook link on Windows High Contrast mode

- https://wsteam1-1587-high-contrast-fix--5d28eb3fe163f6002046d6fa.chromatic.com/?path=/story/components-livepageheader--with-live-media-stream

Check that text and play icon are visible (e.g. they should match the text colour specified by the user, and not remain white). Do this for both the 'Watch Video CTA' and 'Close Video CTA'

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
