### PR TITLE
WSTEAM1-1590: Change style for open media view on live headers

### DIFF
--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx
@@ -57,8 +57,8 @@ const Header = ({
         ) : null}
         <div
           css={[
-            isHeaderImage && !isMediaOpen && styles.textContainerWithImage,
-            !isHeaderImage && !isMediaOpen && styles.textContainerWithoutImage,
+            isHeaderImage && styles.textContainerWithImage,
+            !isHeaderImage && styles.textContainerWithoutImage,
             isMediaOpen && styles.textContainerMediaOpen,
           ]}
         >

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -42,17 +42,10 @@ export default {
         width: '100%',
       },
     }),
-  textContainerMediaOpen: ({ mq, gridWidths, spacings }: Theme) =>
+  textContainerMediaOpen: ({ mq }: Theme) =>
     css({
-      position: 'relative',
-      padding: `${spacings.DOUBLE}rem ${spacings.FULL}rem 0`,
-      maxWidth: `${pixelsToRem(gridWidths[1280])}rem`,
-      margin: '0 auto',
-      [mq.GROUP_2_MIN_WIDTH]: {
-        padding: `${spacings.DOUBLE}rem ${spacings.DOUBLE}rem 0`,
-      },
       [mq.GROUP_4_MIN_WIDTH]: {
-        paddingTop: `${spacings.TRIPLE}rem`,
+        maxWidth: '100%',
       },
     }),
   textContainerWithoutImage: ({ mq, gridWidths, spacings }: Theme) =>


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-1590](https://jira.dev.bbc.co.uk/browse/WSTEAM1-1590)

Overall changes
======
Removes dedicated padding for open states on live pages with a live stream.

Code changes
======
- _Changes padding on live pages._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
