### PR TITLE
WSTEAM1-1612 - Set `noindex` on av-embeds pages

### DIFF
--- a/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.test.ts
+++ b/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.test.ts
@@ -71,6 +71,15 @@ describe('Handle AV Route', () => {
     });
   });
 
+  it('should set the x-robots-tag header to noindex', async () => {
+    await handleAvRoute(mockGetServerSidePropsContext);
+
+    expect(mockGetServerSidePropsContext.res.setHeader).toHaveBeenCalledWith(
+      'x-robots-tag',
+      'noindex',
+    );
+  });
+
   it('should remove the x-frame-options header', async () => {
     await handleAvRoute(mockGetServerSidePropsContext);
 

--- a/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.ts
+++ b/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.ts
@@ -26,15 +26,18 @@ export default async (context: GetServerSidePropsContext) => {
   let pageStatus;
   let pageJson;
 
-  // Remove x-frame-options header to allow embedding
-  context.res.removeHeader('x-frame-options');
-
-  const parsedRoute = parseAvRoute(resolvedUrl);
+  // Set x-robots-tag header to prevent search engine indexing
+  context.res.setHeader('x-robots-tag', 'noindex');
 
   context.res.setHeader(
     'Cache-Control',
     'public, stale-if-error=90, stale-while-revalidate=30, max-age=30',
   );
+
+  // Remove x-frame-options header to allow embedding
+  context.res.removeHeader('x-frame-options');
+
+  const parsedRoute = parseAvRoute(resolvedUrl);
 
   const avEmbedsUrl = constructPageFetchUrl({
     pageType: AV_EMBEDS,


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAM1-1612

Overall changes
======
- Sets `x-robots-tag: noindex` on all av-embeds routes to prevent them being surfaced in search engines

Testing
======
1. Visit http://localhost:7081/ws/av-embeds/articles/cd1rmn075d1o/p0jd37n8/ig?renderer_env=live
2. Open dev tools > Network > Doc > click the document html
3. Click the 'Headers' tab, scroll down and confirm `X-Robots-Tag` is set

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
