### PR TITLE
WSTEAM1-1612 - `noindex` meta tag for av-embeds pages

### DIFF
--- a/ws-nextjs-app/pages/[service]/av-embeds/AvEmbedsMetadata.test.tsx
+++ b/ws-nextjs-app/pages/[service]/av-embeds/AvEmbedsMetadata.test.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import {
   render,
   waitFor,
-} from '../../../../src/app/components/react-testing-library-with-providers';
-import serbianCyrCps from '../../../../data/serbian/av-embeds/cyr/srbija-68707945.json';
+} from '#app/components/react-testing-library-with-providers';
+import serbianCyrCps from '#data/serbian/av-embeds/cyr/srbija-68707945.json';
+import { AV_EMBEDS } from '#app/routes/utils/pageTypes';
+import { MediaBlock } from '#app/components/MediaLoader/types';
 import AvEmbedsMetadata from './AvEmbedsMetadata';
-import { AV_EMBEDS } from '../../../../src/app/routes/utils/pageTypes';
-import { MediaBlock } from '../../../../src/app/components/MediaLoader/types';
 
 const avEmbedsMetadataProps = {
   pageData: {
@@ -30,6 +30,18 @@ const avEmbedsMetadataProps = {
 };
 
 describe('AV Embeds Page', () => {
+  it('should render the noindex meta tag', async () => {
+    render(<AvEmbedsMetadata {...avEmbedsMetadataProps} />);
+
+    await waitFor(() => {
+      const actual = document
+        .querySelector('head > meta[name="robots"]')
+        ?.getAttribute('content');
+
+      expect(actual).toEqual('noindex');
+    });
+  });
+
   it('should render the viewport meta tag', async () => {
     render(<AvEmbedsMetadata {...avEmbedsMetadataProps} />);
 

--- a/ws-nextjs-app/pages/[service]/av-embeds/AvEmbedsMetadata.tsx
+++ b/ws-nextjs-app/pages/[service]/av-embeds/AvEmbedsMetadata.tsx
@@ -10,6 +10,7 @@ const AvEmbedsMetadata = ({ pageData }: AvEmbedsPageProps) => {
 
   return (
     <Helmet>
+      <meta name="robots" content="noindex" />
       <meta
         name="viewport"
         content="width=device-width, initial-scale=1, user-scalable=1"

--- a/ws-nextjs-app/pages/[service]/av-embeds/AvEmbedsPageLayout.test.tsx
+++ b/ws-nextjs-app/pages/[service]/av-embeds/AvEmbedsPageLayout.test.tsx
@@ -55,6 +55,7 @@ describe('AV Embeds Page', () => {
     const helmetMetaTags = Helmet.peek()?.metaTags;
 
     expect(helmetMetaTags).toEqual([
+      { name: 'robots', content: 'noindex' },
       {
         name: 'viewport',
         content: 'width=device-width, initial-scale=1, user-scalable=1',


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAM1-1612

Overall changes
======
- Adds `<meta>` `noindex` tag for av-embeds routes as CDN appears to be overwriting the `x-robots-tag` header

Testing
======
1. Visit http://localhost:7081/ws/av-embeds/articles/cd1rmn075d1o/p0jd37n8/ig?renderer_env=live
2. Inspect the page elements and confirm the `<meta name="robots" content="noindex" />` tag is present

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
