### PR TITLE
NEWSWORLDSERVICE-2155: Include all img-sharp-* dependencies as part of the nextJS upgrade 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,7 @@ updates:
           - '@next/*'
           - 'next'
           - 'next-*'
+          - '@img-sharp-*'
       loadable-minor-patch:
         patterns:
           - '@loadable/*'


### PR DESCRIPTION
Resolves JIRA  https://jira.dev.bbc.co.uk/browse/NEWSWORLDSERVICE-2155

Overall changes
======
@img-sharp-* packages are now included as part of NextJS. This ensures that they are updated at the same time as Next JS

Code changes
======
Update dependabot config

Testing
======
N/A