### PR TITLE
Reinstate ArticlePage topics for Serbian and Zhongwen services

### DIFF
--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -161,7 +161,7 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
 
   const allowAdvertising = pageData?.metadata?.allowAdvertising ?? false;
   const adcampaign = pageData?.metadata?.adCampaignKeyword;
-  const isTransliterated =
+  const isUzbekArticle =
     ['uzbek'].includes(service) && pageType === ARTICLE_PAGE;
 
   const { enabled: podcastPromoEnabled } = useToggle('podcastPromo');
@@ -284,7 +284,7 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
   const promoImage = promoImageRawBlock?.model?.locator;
 
   const showTopics = Boolean(
-    showRelatedTopics && topics.length > 0 && !isTransliterated,
+    showRelatedTopics && topics.length > 0 && !isUzbekArticle,
   );
 
   return (

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -162,8 +162,7 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
   const allowAdvertising = pageData?.metadata?.allowAdvertising ?? false;
   const adcampaign = pageData?.metadata?.adCampaignKeyword;
   const isTransliterated =
-    ['serbian', 'zhongwen', 'uzbek'].includes(service) &&
-    pageType === ARTICLE_PAGE;
+    ['uzbek'].includes(service) && pageType === ARTICLE_PAGE;
 
   const { enabled: podcastPromoEnabled } = useToggle('podcastPromo');
   const headline = getHeadline(pageData) ?? '';

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -15,7 +15,11 @@ import Timestamp from '#containers/ArticleTimestamp';
 import ComscoreAnalytics from '#containers/ComscoreAnalytics';
 import SocialEmbedContainer from '#containers/SocialEmbed';
 import MediaLoader from '#app/components/MediaLoader';
-import { PHOTO_GALLERY_PAGE, STORY_PAGE } from '#app/routes/utils/pageTypes';
+import {
+  ARTICLE_PAGE,
+  PHOTO_GALLERY_PAGE,
+  STORY_PAGE,
+} from '#app/routes/utils/pageTypes';
 
 import {
   getArticleId,
@@ -140,7 +144,7 @@ const getJumptoComponent =
   };
 
 const ArticlePage = ({ pageData }: { pageData: Article }) => {
-  const { isApp } = useContext(RequestContext);
+  const { isApp, pageType, service } = useContext(RequestContext);
 
   const {
     articleAuthor,
@@ -157,6 +161,9 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
 
   const allowAdvertising = pageData?.metadata?.allowAdvertising ?? false;
   const adcampaign = pageData?.metadata?.adCampaignKeyword;
+  const isTransliterated =
+    ['serbian', 'zhongwen', 'uzbek'].includes(service) &&
+    pageType === ARTICLE_PAGE;
 
   const { enabled: podcastPromoEnabled } = useToggle('podcastPromo');
   const headline = getHeadline(pageData) ?? '';
@@ -277,7 +284,9 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
 
   const promoImage = promoImageRawBlock?.model?.locator;
 
-  const showTopics = Boolean(showRelatedTopics && topics.length > 0);
+  const showTopics = Boolean(
+    showRelatedTopics && topics.length > 0 && !isTransliterated,
+  );
 
   return (
     <div css={styles.pageWrapper}>

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -15,11 +15,7 @@ import Timestamp from '#containers/ArticleTimestamp';
 import ComscoreAnalytics from '#containers/ComscoreAnalytics';
 import SocialEmbedContainer from '#containers/SocialEmbed';
 import MediaLoader from '#app/components/MediaLoader';
-import {
-  ARTICLE_PAGE,
-  PHOTO_GALLERY_PAGE,
-  STORY_PAGE,
-} from '#app/routes/utils/pageTypes';
+import { PHOTO_GALLERY_PAGE, STORY_PAGE } from '#app/routes/utils/pageTypes';
 
 import {
   getArticleId,
@@ -144,7 +140,7 @@ const getJumptoComponent =
   };
 
 const ArticlePage = ({ pageData }: { pageData: Article }) => {
-  const { isApp, pageType, service } = useContext(RequestContext);
+  const { isApp } = useContext(RequestContext);
 
   const {
     articleAuthor,
@@ -161,9 +157,6 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
 
   const allowAdvertising = pageData?.metadata?.allowAdvertising ?? false;
   const adcampaign = pageData?.metadata?.adCampaignKeyword;
-  const isTransliterated =
-    ['serbian', 'zhongwen', 'uzbek'].includes(service) &&
-    pageType === ARTICLE_PAGE;
 
   const { enabled: podcastPromoEnabled } = useToggle('podcastPromo');
   const headline = getHeadline(pageData) ?? '';
@@ -284,9 +277,7 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
 
   const promoImage = promoImageRawBlock?.model?.locator;
 
-  const showTopics = Boolean(
-    showRelatedTopics && topics.length > 0 && !isTransliterated,
-  );
+  const showTopics = Boolean(showRelatedTopics && topics.length > 0);
 
   return (
     <div css={styles.pageWrapper}>

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -161,8 +161,7 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
 
   const allowAdvertising = pageData?.metadata?.allowAdvertising ?? false;
   const adcampaign = pageData?.metadata?.adCampaignKeyword;
-  const isUzbekArticle =
-    ['uzbek'].includes(service) && pageType === ARTICLE_PAGE;
+  const isUzbekArticle = service === 'uzbek' && pageType === ARTICLE_PAGE;
 
   const { enabled: podcastPromoEnabled } = useToggle('podcastPromo');
   const headline = getHeadline(pageData) ?? '';

--- a/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
@@ -188,7 +188,7 @@ const MediaArticlePage = ({ pageData }: { pageData: Article }) => {
     ...(isCpsMap && { pageTitle: `${atiAnalytics.pageTitle} - ${brandName}` }),
   };
 
-  const isTransliterated =
+  const isUzbekArticle =
     ['uzbek'].includes(service) && pageType === ARTICLE_PAGE;
 
   const promoImageBlocks =
@@ -207,7 +207,7 @@ const MediaArticlePage = ({ pageData }: { pageData: Article }) => {
   const promoImage = promoImageRawBlock?.model?.locator;
 
   const showTopics = Boolean(
-    showRelatedTopics && topics.length > 0 && !isTransliterated,
+    showRelatedTopics && topics.length > 0 && !isUzbekArticle,
   );
 
   const isLiveMedia = checkIsLiveMedia(blocks);

--- a/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
@@ -188,8 +188,7 @@ const MediaArticlePage = ({ pageData }: { pageData: Article }) => {
     ...(isCpsMap && { pageTitle: `${atiAnalytics.pageTitle} - ${brandName}` }),
   };
 
-  const isUzbekArticle =
-    ['uzbek'].includes(service) && pageType === ARTICLE_PAGE;
+  const isUzbekArticle = service === 'uzbek' && pageType === ARTICLE_PAGE;
 
   const promoImageBlocks =
     pageData?.promo?.images?.defaultPromoImage?.blocks ?? [];

--- a/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
@@ -4,13 +4,14 @@ import { useContext } from 'react';
 import { jsx, useTheme, Theme } from '@emotion/react';
 import MediaLoader from '#app/components/MediaLoader';
 import { MediaBlock } from '#app/components/MediaLoader/types';
-import { MEDIA_ASSET_PAGE } from '#app/routes/utils/pageTypes';
+import { ARTICLE_PAGE, MEDIA_ASSET_PAGE } from '#app/routes/utils/pageTypes';
 import { Tag } from '#app/components/LinkedData/types';
 import {
   Article,
   OptimoBylineBlock,
   OptimoBylineContributorBlock,
 } from '#app/models/types/optimo';
+import { RequestContext } from '#app/contexts/RequestContext';
 import { MediaOverrides } from '#app/models/types/media';
 import useToggle from '../../hooks/useToggle';
 import {
@@ -133,6 +134,7 @@ const getTimestampComponent =
     showTimestamp ? <Timestamp {...props} popOut={false} /> : null;
 
 const MediaArticlePage = ({ pageData }: { pageData: Article }) => {
+  const { pageType, service } = useContext(RequestContext);
   const {
     articleAuthor,
     isTrustProjectParticipant,
@@ -186,6 +188,10 @@ const MediaArticlePage = ({ pageData }: { pageData: Article }) => {
     ...(isCpsMap && { pageTitle: `${atiAnalytics.pageTitle} - ${brandName}` }),
   };
 
+  const isTransliterated =
+    ['serbian', 'zhongwen', 'uzbek'].includes(service) &&
+    pageType === ARTICLE_PAGE;
+
   const promoImageBlocks =
     pageData?.promo?.images?.defaultPromoImage?.blocks ?? [];
 
@@ -201,7 +207,9 @@ const MediaArticlePage = ({ pageData }: { pageData: Article }) => {
 
   const promoImage = promoImageRawBlock?.model?.locator;
 
-  const showTopics = Boolean(showRelatedTopics && topics.length > 0);
+  const showTopics = Boolean(
+    showRelatedTopics && topics.length > 0 && !isTransliterated,
+  );
 
   const isLiveMedia = checkIsLiveMedia(blocks);
 

--- a/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
@@ -4,14 +4,13 @@ import { useContext } from 'react';
 import { jsx, useTheme, Theme } from '@emotion/react';
 import MediaLoader from '#app/components/MediaLoader';
 import { MediaBlock } from '#app/components/MediaLoader/types';
-import { ARTICLE_PAGE, MEDIA_ASSET_PAGE } from '#app/routes/utils/pageTypes';
+import { MEDIA_ASSET_PAGE } from '#app/routes/utils/pageTypes';
 import { Tag } from '#app/components/LinkedData/types';
 import {
   Article,
   OptimoBylineBlock,
   OptimoBylineContributorBlock,
 } from '#app/models/types/optimo';
-import { RequestContext } from '#app/contexts/RequestContext';
 import { MediaOverrides } from '#app/models/types/media';
 import useToggle from '../../hooks/useToggle';
 import {
@@ -134,7 +133,6 @@ const getTimestampComponent =
     showTimestamp ? <Timestamp {...props} popOut={false} /> : null;
 
 const MediaArticlePage = ({ pageData }: { pageData: Article }) => {
-  const { pageType, service } = useContext(RequestContext);
   const {
     articleAuthor,
     isTrustProjectParticipant,
@@ -188,10 +186,6 @@ const MediaArticlePage = ({ pageData }: { pageData: Article }) => {
     ...(isCpsMap && { pageTitle: `${atiAnalytics.pageTitle} - ${brandName}` }),
   };
 
-  const isTransliterated =
-    ['serbian', 'zhongwen', 'uzbek'].includes(service) &&
-    pageType === ARTICLE_PAGE;
-
   const promoImageBlocks =
     pageData?.promo?.images?.defaultPromoImage?.blocks ?? [];
 
@@ -207,9 +201,7 @@ const MediaArticlePage = ({ pageData }: { pageData: Article }) => {
 
   const promoImage = promoImageRawBlock?.model?.locator;
 
-  const showTopics = Boolean(
-    showRelatedTopics && topics.length > 0 && !isTransliterated,
-  );
+  const showTopics = Boolean(showRelatedTopics && topics.length > 0);
 
   const isLiveMedia = checkIsLiveMedia(blocks);
 

--- a/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.tsx
@@ -189,8 +189,7 @@ const MediaArticlePage = ({ pageData }: { pageData: Article }) => {
   };
 
   const isTransliterated =
-    ['serbian', 'zhongwen', 'uzbek'].includes(service) &&
-    pageType === ARTICLE_PAGE;
+    ['uzbek'].includes(service) && pageType === ARTICLE_PAGE;
 
   const promoImageBlocks =
     pageData?.promo?.images?.defaultPromoImage?.blocks ?? [];


### PR DESCRIPTION
Overall changes
======
- Reinstates Related Topics links for Serbian and Zhongwen services now that they support transliterated topics. 

Testing
======
1. Visit http://localhost:7080/serbian/articles/cy9j40v4n75o/lat?renderer_env=live
2. Confirm the Related Topics section appears at the bottom of the article
3. Visit http://localhost:7080/zhongwen/articles/c2d3n28dnwlo/trad?renderer_env=live
4. Confirm the Related Topics section appears at the bottom of the article

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
