### PR TITLE
Hindi: The Lens podcast links and promo

### DIFF
--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -49,16 +49,16 @@ export const service: DefaultServiceConfig = {
     googleSiteVerification: 'D-aEHUiyVaMoUJXjVRbDVkxS0dLTMUZLD3dLPTnWO4Q',
     podcastPromo: {
       title: 'पॉडकास्ट',
-      brandTitle: 'दिनभर: पूरा दिन,पूरी ख़बर (Dinbhar)',
+      brandTitle: 'The Lens: मुकेश शर्मा के साथ',
       brandDescription:
-        'वो राष्ट्रीय और अंतरराष्ट्रीय ख़बरें जो दिनभर सुर्खियां बनीं.',
+        'हफ़्ते की सबसे बड़ी न्यूज़ स्टोरी पर चर्चा: मुकेश शर्मा के साथ.',
       image: {
-        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p09ds7cb.jpg',
-        alt: 'दिनभर',
+        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0kjf0d8.jpg',
+        alt: 'मुकेश शर्मा',
       },
       linkLabel: {
         text: 'दिनभर: पूरा दिन,पूरी ख़बर',
-        href: 'https://www.bbc.com/hindi/podcasts/p09ds7zx',
+        href: 'https://www.bbc.com/hindi/podcasts/p0kjf03y',
       },
       skipLink: {
         text: 'छोड़कर %title% आगे बढ़ें',

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/hindi.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/hindi.js
@@ -246,12 +246,13 @@ const externalLinks = {
       },
       {
         linkText: 'Apple',
-        linkUrl: 'https://podcasts.apple.com/us/podcast/the-lens-मुकेश-शर्मा-के-साथ/id1791099679',
+        linkUrl:
+          'https://podcasts.apple.com/us/podcast/the-lens-मुकेश-शर्मा-के-साथ/id1791099679',
         linkType: 'apple',
       },
       {
         linkText: 'Jio Saavn',
-        linkUrl: 
+        linkUrl:
           'https://www.jiosaavn.com/shows/the-lens-%e0%a4%ae%e0%a5%81%e0%a4%95%e0%a5%87%e0%a4%b6-%e0%a4%b6%e0%a4%b0%e0%a5%8d%e0%a4%ae%e0%a4%be-%e0%a4%95%e0%a5%87-%e0%a4%b8%e0%a4%be%e0%a4%a5/1/ESz7PpxJiiA_',
         linkType: 'gaana',
       },

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/hindi.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/hindi.js
@@ -238,6 +238,24 @@ const externalLinks = {
         linkType: 'gaana',
       },
     ],
+    p0kjf03y: [
+      {
+        linkText: 'Spotify',
+        linkUrl: 'https://open.spotify.com/show/33zf2Pgpq1w0BXp1Vhe9vz',
+        linkType: 'spotify',
+      },
+      {
+        linkText: 'Apple',
+        linkUrl: 'https://podcasts.apple.com/us/podcast/the-lens-मुकेश-शर्मा-के-साथ/id1791099679',
+        linkType: 'apple',
+      },
+      {
+        linkText: 'Jio Saavn',
+        linkUrl: 
+          'https://www.jiosaavn.com/shows/the-lens-%e0%a4%ae%e0%a5%81%e0%a4%95%e0%a5%87%e0%a4%b6-%e0%a4%b6%e0%a4%b0%e0%a5%8d%e0%a4%ae%e0%a4%be-%e0%a4%95%e0%a5%87-%e0%a4%b8%e0%a4%be%e0%a4%a5/1/ESz7PpxJiiA_',
+        linkType: 'gaana',
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Added external podcast links to the new Hindi podcast: https://www.bbc.com/hindi/podcasts/p0kjf03y
- Updated in-article promo to promote this new podcast

Code changes
======
- Added section for podcast id p0kjf03y to src/app/routes/onDemandAudio/tempData/podcastExternalLinks/hindi.js
- Edited podcastPromo section of src/app/lib/config/services/hindi.ts


Testing
======
1. Open /hindi/podcasts/p0kjf03y the external links section under the player should inculde links Spotify, Applie and Jio Saavn
2. Open a Hindi article, the podcast promo should now promote The Lens podcast and open /hindi/podcasts/p0kjf03y

<img width="320" alt="lens_image" src="https://github.com/user-attachments/assets/6cf34b50-6b53-40ba-ad6b-0b5e533f4d54" />




Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
