### PR TITLE
Afrique, Gahuza and Persian nav updates

### DIFF
--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -340,6 +340,10 @@ export const service: DefaultServiceConfig = {
         url: '/afrique',
       },
       {
+        title: 'Conflit en RDC',
+        url: '/afrique/topics/cge72ry253jt',
+      },
+      {
         title: 'Ecoutez en direct',
         url: '/afrique/bbc_afrique_radio/liveradio',
       },

--- a/src/app/lib/config/services/gahuza.ts
+++ b/src/app/lib/config/services/gahuza.ts
@@ -355,6 +355,10 @@ export const service: DefaultServiceConfig = {
         url: '/gahuza',
       },
       {
+        title: 'Ibitero bya M23 muri Congo',
+        url: '/gahuza/topics/cx2qn9pqx4yt',
+      },
+      {
         title: 'Ibiyaga binini',
         url: '/gahuza/topics/c06gq67y3w5t',
       },

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -446,10 +446,6 @@ export const service: DefaultServiceConfig = {
         url: '/persian/topics/cj31ldvmg1et',
       },
       {
-        title: 'انتخابات آمریکا',
-        url: '/persian/topics/cj1gj22k6z6t',
-      },
-      {
         title: 'پخش زنده',
         url: '/persian/media-49522521',
       },

--- a/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
@@ -186,82 +186,75 @@ exports[`AMP Articles Header Navigation link should match text and url 2`] = `
 
 exports[`AMP Articles Header Navigation link should match text and url 3`] = `
 {
-  "text": "انتخابات آمریکا",
-  "url": "/persian/topics/cj1gj22k6z6t",
-}
-`;
-
-exports[`AMP Articles Header Navigation link should match text and url 4`] = `
-{
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 5`] = `
+exports[`AMP Articles Header Navigation link should match text and url 4`] = `
 {
   "text": "ویدیو",
   "url": "/persian/topics/c6z7mnr559gt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 6`] = `
+exports[`AMP Articles Header Navigation link should match text and url 5`] = `
 {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 7`] = `
+exports[`AMP Articles Header Navigation link should match text and url 6`] = `
 {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 8`] = `
+exports[`AMP Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 9`] = `
+exports[`AMP Articles Header Navigation link should match text and url 8`] = `
 {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 10`] = `
+exports[`AMP Articles Header Navigation link should match text and url 9`] = `
 {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 11`] = `
+exports[`AMP Articles Header Navigation link should match text and url 10`] = `
 {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 12`] = `
+exports[`AMP Articles Header Navigation link should match text and url 11`] = `
 {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 13`] = `
+exports[`AMP Articles Header Navigation link should match text and url 12`] = `
 {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 14`] = `
+exports[`AMP Articles Header Navigation link should match text and url 13`] = `
 {
   "text": "فراتر از خبر",
   "url": "/persian/topics/cxr3ex12k6et",

--- a/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
@@ -139,82 +139,75 @@ exports[`Canonical Articles Header Navigation link should match text and url 2`]
 
 exports[`Canonical Articles Header Navigation link should match text and url 3`] = `
 {
-  "text": "انتخابات آمریکا",
-  "url": "/persian/topics/cj1gj22k6z6t",
-}
-`;
-
-exports[`Canonical Articles Header Navigation link should match text and url 4`] = `
-{
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 5`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 4`] = `
 {
   "text": "ویدیو",
   "url": "/persian/topics/c6z7mnr559gt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 6`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 5`] = `
 {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 7`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 6`] = `
 {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 8`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 9`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 8`] = `
 {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 10`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 9`] = `
 {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 11`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 10`] = `
 {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 12`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 11`] = `
 {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 13`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 12`] = `
 {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 14`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 13`] = `
 {
   "text": "فراتر از خبر",
   "url": "/persian/topics/cxr3ex12k6et",

--- a/src/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.js.snap
@@ -186,82 +186,75 @@ exports[`AMP Articles Header Navigation link should match text and url 2`] = `
 
 exports[`AMP Articles Header Navigation link should match text and url 3`] = `
 {
-  "text": "انتخابات آمریکا",
-  "url": "/persian/topics/cj1gj22k6z6t",
-}
-`;
-
-exports[`AMP Articles Header Navigation link should match text and url 4`] = `
-{
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 5`] = `
+exports[`AMP Articles Header Navigation link should match text and url 4`] = `
 {
   "text": "ویدیو",
   "url": "/persian/topics/c6z7mnr559gt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 6`] = `
+exports[`AMP Articles Header Navigation link should match text and url 5`] = `
 {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 7`] = `
+exports[`AMP Articles Header Navigation link should match text and url 6`] = `
 {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 8`] = `
+exports[`AMP Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 9`] = `
+exports[`AMP Articles Header Navigation link should match text and url 8`] = `
 {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 10`] = `
+exports[`AMP Articles Header Navigation link should match text and url 9`] = `
 {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 11`] = `
+exports[`AMP Articles Header Navigation link should match text and url 10`] = `
 {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 12`] = `
+exports[`AMP Articles Header Navigation link should match text and url 11`] = `
 {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 13`] = `
+exports[`AMP Articles Header Navigation link should match text and url 12`] = `
 {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 14`] = `
+exports[`AMP Articles Header Navigation link should match text and url 13`] = `
 {
   "text": "فراتر از خبر",
   "url": "/persian/topics/cxr3ex12k6et",

--- a/src/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.js.snap
@@ -136,82 +136,75 @@ exports[`Canonical Articles Header Navigation link should match text and url 2`]
 
 exports[`Canonical Articles Header Navigation link should match text and url 3`] = `
 {
-  "text": "انتخابات آمریکا",
-  "url": "/persian/topics/cj1gj22k6z6t",
-}
-`;
-
-exports[`Canonical Articles Header Navigation link should match text and url 4`] = `
-{
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 5`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 4`] = `
 {
   "text": "ویدیو",
   "url": "/persian/topics/c6z7mnr559gt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 6`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 5`] = `
 {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 7`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 6`] = `
 {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 8`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 9`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 8`] = `
 {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 10`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 9`] = `
 {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 11`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 10`] = `
 {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 12`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 11`] = `
 {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 13`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 12`] = `
 {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 14`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 13`] = `
 {
   "text": "فراتر از خبر",
   "url": "/persian/topics/cxr3ex12k6et",

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
@@ -223,61 +223,68 @@ exports[`AMP Feature Index page Header Navigation link should match text and url
 
 exports[`AMP Feature Index page Header Navigation link should match text and url 2`] = `
 {
+  "text": "Conflit en RDC",
+  "url": "/afrique/topics/cge72ry253jt",
+}
+`;
+
+exports[`AMP Feature Index page Header Navigation link should match text and url 3`] = `
+{
   "text": "Ecoutez en direct",
   "url": "/afrique/bbc_afrique_radio/liveradio",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 3`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 4`] = `
 {
   "text": "Afrique",
   "url": "/afrique/topics/cvqxn2k7kv7t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 4`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
 {
   "text": "Monde",
   "url": "/afrique/topics/cvqxn21vx11t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 6`] = `
 {
   "text": "Santé",
   "url": "/afrique/topics/c06gq9jxz3rt",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 6`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 7`] = `
 {
   "text": "Science et technologie",
   "url": "/afrique/topics/crezq2zk0q4t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 7`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 8`] = `
 {
   "text": "Economie",
   "url": "/afrique/topics/cnq687nr9v1t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 8`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 9`] = `
 {
   "text": "Culture",
   "url": "/afrique/topics/cnq687nrrw8t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 9`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 10`] = `
 {
   "text": "Vidéos",
   "url": "/afrique/topics/cz4vn9gyd6rt",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 10`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 11`] = `
 {
   "text": "Nos émissions",
   "url": "/afrique/topics/c88nzggm8gxt",

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
@@ -132,61 +132,68 @@ exports[`Canonical Feature Index page Header Navigation link should match text a
 
 exports[`Canonical Feature Index page Header Navigation link should match text and url 2`] = `
 {
+  "text": "Conflit en RDC",
+  "url": "/afrique/topics/cge72ry253jt",
+}
+`;
+
+exports[`Canonical Feature Index page Header Navigation link should match text and url 3`] = `
+{
   "text": "Ecoutez en direct",
   "url": "/afrique/bbc_afrique_radio/liveradio",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 3`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 4`] = `
 {
   "text": "Afrique",
   "url": "/afrique/topics/cvqxn2k7kv7t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
 {
   "text": "Monde",
   "url": "/afrique/topics/cvqxn21vx11t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 6`] = `
 {
   "text": "Santé",
   "url": "/afrique/topics/c06gq9jxz3rt",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 7`] = `
 {
   "text": "Science et technologie",
   "url": "/afrique/topics/crezq2zk0q4t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 8`] = `
 {
   "text": "Economie",
   "url": "/afrique/topics/cnq687nr9v1t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 9`] = `
 {
   "text": "Culture",
   "url": "/afrique/topics/cnq687nrrw8t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 10`] = `
 {
   "text": "Vidéos",
   "url": "/afrique/topics/cz4vn9gyd6rt",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 11`] = `
 {
   "text": "Nos émissions",
   "url": "/afrique/topics/c88nzggm8gxt",

--- a/src/integration/pages/liveRadio/gahuza/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/gahuza/__snapshots__/canonical.test.js.snap
@@ -126,33 +126,40 @@ exports[`Canonical Live Radio Header Navigation link should match text and url 1
 
 exports[`Canonical Live Radio Header Navigation link should match text and url 2`] = `
 {
+  "text": "Ibitero bya M23 muri Congo",
+  "url": "/gahuza/topics/cx2qn9pqx4yt",
+}
+`;
+
+exports[`Canonical Live Radio Header Navigation link should match text and url 3`] = `
+{
   "text": "Ibiyaga binini",
   "url": "/gahuza/topics/c06gq67y3w5t",
 }
 `;
 
-exports[`Canonical Live Radio Header Navigation link should match text and url 3`] = `
+exports[`Canonical Live Radio Header Navigation link should match text and url 4`] = `
 {
   "text": "Afrika",
   "url": "/gahuza/topics/crvnv566zx9t",
 }
 `;
 
-exports[`Canonical Live Radio Header Navigation link should match text and url 4`] = `
+exports[`Canonical Live Radio Header Navigation link should match text and url 5`] = `
 {
   "text": "Mpuzamahanga",
   "url": "/gahuza/topics/c9dvd93jjkkt",
 }
 `;
 
-exports[`Canonical Live Radio Header Navigation link should match text and url 5`] = `
+exports[`Canonical Live Radio Header Navigation link should match text and url 6`] = `
 {
   "text": "Imikino",
   "url": "/gahuza/topics/c5qvpq0jzy7t",
 }
 `;
 
-exports[`Canonical Live Radio Header Navigation link should match text and url 6`] = `
+exports[`Canonical Live Radio Header Navigation link should match text and url 7`] = `
 {
   "text": "Amajwi n’amashusho",
   "url": "/gahuza/topics/crldzm936jmt",

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
@@ -230,82 +230,75 @@ exports[`AMP Media Asset Page Header Navigation link should match text and url 2
 
 exports[`AMP Media Asset Page Header Navigation link should match text and url 3`] = `
 {
-  "text": "انتخابات آمریکا",
-  "url": "/persian/topics/cj1gj22k6z6t",
-}
-`;
-
-exports[`AMP Media Asset Page Header Navigation link should match text and url 4`] = `
-{
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 4`] = `
 {
   "text": "ویدیو",
   "url": "/persian/topics/c6z7mnr559gt",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 5`] = `
 {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 6`] = `
 {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 8`] = `
 {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 9`] = `
 {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 11`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 10`] = `
 {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 12`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 11`] = `
 {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 13`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 12`] = `
 {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 14`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 13`] = `
 {
   "text": "فراتر از خبر",
   "url": "/persian/topics/cxr3ex12k6et",

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
@@ -139,82 +139,75 @@ exports[`Canonical Media Asset Page Header Navigation link should match text and
 
 exports[`Canonical Media Asset Page Header Navigation link should match text and url 3`] = `
 {
-  "text": "انتخابات آمریکا",
-  "url": "/persian/topics/cj1gj22k6z6t",
-}
-`;
-
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 4`] = `
-{
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 4`] = `
 {
   "text": "ویدیو",
   "url": "/persian/topics/c6z7mnr559gt",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 5`] = `
 {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 6`] = `
 {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 8`] = `
 {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 9`] = `
 {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 10`] = `
 {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 12`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 11`] = `
 {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 13`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 12`] = `
 {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 14`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 13`] = `
 {
   "text": "فراتر از خبر",
   "url": "/persian/topics/cxr3ex12k6et",

--- a/src/integration/pages/onDemandAudioPage/gahuza.expired/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/gahuza.expired/__snapshots__/canonical.test.js.snap
@@ -138,33 +138,40 @@ exports[`Canonical On Demand Audio Page Header Navigation link should match text
 
 exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 2`] = `
 {
+  "text": "Ibitero bya M23 muri Congo",
+  "url": "/gahuza/topics/cx2qn9pqx4yt",
+}
+`;
+
+exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 3`] = `
+{
   "text": "Ibiyaga binini",
   "url": "/gahuza/topics/c06gq67y3w5t",
 }
 `;
 
-exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 3`] = `
+exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Afrika",
   "url": "/gahuza/topics/crvnv566zx9t",
 }
 `;
 
-exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Mpuzamahanga",
   "url": "/gahuza/topics/c9dvd93jjkkt",
 }
 `;
 
-exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Imikino",
   "url": "/gahuza/topics/c5qvpq0jzy7t",
 }
 `;
 
-exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Amajwi n’amashusho",
   "url": "/gahuza/topics/crldzm936jmt",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds RDC conlfict topic links to the navigation bar of Afrique and Gahuza
- Removes  US election topic from Persian's navigation bar

Code changes
======

- Edited Navigation section of src/app/lib/config/services/afrique.ts to add RDC conflict topic link in second position
- Edited Navigation section of src/app/lib/config/services/gahuza.ts to add RDC conflict topic link in second position
- Edited Navigation section of src/app/lib/config/services/persian.ts to add US election topic link from thirsd position



Testing
======
1. Open Afrique's front page, second link in the nav should be Conflit en RDC  2024 and open [/afrique/topics/cge72ry253jt](https://www.bbc.com/afrique/topics/cge72ry253jt)
2. Open Afrique's front page, second link in the nav should be Ibitero bya M23 muri Congo  2024 and open /gahuza/topics/cx2qn9pqx4yt
3. Open Persian's front page [انتخابات آمریکا](https://www.bbc.com/persian/topics/cj1gj22k6z6t) should not longeer appear in third position

![afrique_nav](https://github.com/user-attachments/assets/095653c2-6a88-4920-8641-79c83afc4a38)

![gahuza_nav](https://github.com/user-attachments/assets/76520844-dd13-4b7a-b3dc-b24c4cc64d7f)

![persian_nav](https://github.com/user-attachments/assets/36df0f52-db00-4aac-afe9-a82e0d058cd3)



Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
