### PR TITLE
Serbian navigation: add Student protests topic

### DIFF
--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -116,6 +116,10 @@ export const service: SerbianConfig = {
         url: '/serbian/lat',
       },
       {
+        title: 'Studentske blokade',
+        url: '/serbian/topics/cly9dd4w09wt/lat',
+      },
+      {
         title: 'Srbija',
         url: '/serbian/topics/cr50vdy9q6wt/lat',
       },
@@ -508,6 +512,10 @@ export const service: SerbianConfig = {
       {
         title: 'Почетна страна',
         url: '/serbian/cyr',
+      },
+      {
+        title: 'Студентске блокаде',
+        url: '/serbian/topics/cly9dd4w09wt/cyr',
       },
       {
         title: 'Србија',

--- a/src/integration/pages/homePage/serbianCyr/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/homePage/serbianCyr/__snapshots__/amp.test.js.snap
@@ -212,33 +212,40 @@ exports[`AMP Home Page Header Navigation link should match text and url 1`] = `
 
 exports[`AMP Home Page Header Navigation link should match text and url 2`] = `
 {
+  "text": "Студентске блокаде",
+  "url": "/serbian/topics/cly9dd4w09wt/cyr",
+}
+`;
+
+exports[`AMP Home Page Header Navigation link should match text and url 3`] = `
+{
   "text": "Србија",
   "url": "/serbian/topics/cr50vdy9q6wt/cyr",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 3`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Балкан",
   "url": "/serbian/topics/c06g87137jgt/cyr",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 4`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Свет",
   "url": "/serbian/topics/c2lej05e1eqt/cyr",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Видео",
   "url": "/serbian/topics/c44vyp5g049t/cyr",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Најпопуларније",
   "url": "/serbian/cyr/popular/read",

--- a/src/integration/pages/homePage/serbianCyr/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/serbianCyr/__snapshots__/canonical.test.js.snap
@@ -126,33 +126,40 @@ exports[`Canonical Home Page Header Navigation link should match text and url 1`
 
 exports[`Canonical Home Page Header Navigation link should match text and url 2`] = `
 {
+  "text": "Студентске блокаде",
+  "url": "/serbian/topics/cly9dd4w09wt/cyr",
+}
+`;
+
+exports[`Canonical Home Page Header Navigation link should match text and url 3`] = `
+{
   "text": "Србија",
   "url": "/serbian/topics/cr50vdy9q6wt/cyr",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 3`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Балкан",
   "url": "/serbian/topics/c06g87137jgt/cyr",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Свет",
   "url": "/serbian/topics/c2lej05e1eqt/cyr",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Видео",
   "url": "/serbian/topics/c44vyp5g049t/cyr",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Најпопуларније",
   "url": "/serbian/cyr/popular/read",

--- a/src/integration/pages/homePage/serbianLat/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/homePage/serbianLat/__snapshots__/amp.test.js.snap
@@ -212,33 +212,40 @@ exports[`AMP Home Page Header Navigation link should match text and url 1`] = `
 
 exports[`AMP Home Page Header Navigation link should match text and url 2`] = `
 {
+  "text": "Studentske blokade",
+  "url": "/serbian/topics/cly9dd4w09wt/lat",
+}
+`;
+
+exports[`AMP Home Page Header Navigation link should match text and url 3`] = `
+{
   "text": "Srbija",
   "url": "/serbian/topics/cr50vdy9q6wt/lat",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 3`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Balkan",
   "url": "/serbian/topics/c06g87137jgt/lat",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 4`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Svet",
   "url": "/serbian/topics/c2lej05e1eqt/lat",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Video",
   "url": "/serbian/topics/c44vyp5g049t/lat",
 }
 `;
 
-exports[`AMP Home Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Home Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Najpopularnije",
   "url": "/serbian/lat/popular/read",

--- a/src/integration/pages/homePage/serbianLat/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/serbianLat/__snapshots__/canonical.test.js.snap
@@ -126,33 +126,40 @@ exports[`Canonical Home Page Header Navigation link should match text and url 1`
 
 exports[`Canonical Home Page Header Navigation link should match text and url 2`] = `
 {
+  "text": "Studentske blokade",
+  "url": "/serbian/topics/cly9dd4w09wt/lat",
+}
+`;
+
+exports[`Canonical Home Page Header Navigation link should match text and url 3`] = `
+{
   "text": "Srbija",
   "url": "/serbian/topics/cr50vdy9q6wt/lat",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 3`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Balkan",
   "url": "/serbian/topics/c06g87137jgt/lat",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Svet",
   "url": "/serbian/topics/c2lej05e1eqt/lat",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Video",
   "url": "/serbian/topics/c44vyp5g049t/lat",
 }
 `;
 
-exports[`Canonical Home Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Home Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Najpopularnije",
   "url": "/serbian/lat/popular/read",

--- a/ws-nextjs-app/integration/pages/live/serbian/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/live/serbian/__snapshots__/canonical.test.ts.snap
@@ -80,33 +80,40 @@ exports[`Canonical Live Header Navigation link should match text and url 1`] = `
 
 exports[`Canonical Live Header Navigation link should match text and url 2`] = `
 {
+  "text": "Studentske blokade",
+  "url": "/serbian/topics/cly9dd4w09wt/lat",
+}
+`;
+
+exports[`Canonical Live Header Navigation link should match text and url 3`] = `
+{
   "text": "Srbija",
   "url": "/serbian/topics/cr50vdy9q6wt/lat",
 }
 `;
 
-exports[`Canonical Live Header Navigation link should match text and url 3`] = `
+exports[`Canonical Live Header Navigation link should match text and url 4`] = `
 {
   "text": "Balkan",
   "url": "/serbian/topics/c06g87137jgt/lat",
 }
 `;
 
-exports[`Canonical Live Header Navigation link should match text and url 4`] = `
+exports[`Canonical Live Header Navigation link should match text and url 5`] = `
 {
   "text": "Svet",
   "url": "/serbian/topics/c2lej05e1eqt/lat",
 }
 `;
 
-exports[`Canonical Live Header Navigation link should match text and url 5`] = `
+exports[`Canonical Live Header Navigation link should match text and url 6`] = `
 {
   "text": "Video",
   "url": "/serbian/topics/c44vyp5g049t/lat",
 }
 `;
 
-exports[`Canonical Live Header Navigation link should match text and url 6`] = `
+exports[`Canonical Live Header Navigation link should match text and url 7`] = `
 {
   "text": "Najpopularnije",
   "url": "/serbian/lat/popular/read",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds Serbian student protest topic link to the navigation bar of Serbian Latin and Cyrillic
- Removes  US election topic from Persian's navigation bar
- Update snaphsots

Code changes
======

- Edited the Latin and Cyrillic Navigation section of src/app/lib/config/services/serbian.ts to add the Serbian student protest topic link in second position
- Update snaphsots



Testing
======
1. Open Serbian Latin front page, second link in the nav should be Studentske blokade and open /serbian/topics/cly9dd4w09wt/lat
2. Open Serbian Cyrillic front page, second link in the nav should be Студентске блокаде and open /serbian/topics/cly9dd4w09wt/cyr
3. 
![sr_lat_nav](https://github.com/user-attachments/assets/038b2c5a-3ba3-4472-b694-1e37a4e926c5)
![sr_cyr_nav](https://github.com/user-attachments/assets/05c55023-c98d-41a2-a040-896e365e6d87)


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
