### PR TITLE
Russian: add the Counting the dead project topic page to navigation

### DIFF
--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -447,6 +447,10 @@ export const service: DefaultServiceConfig = {
         url: '/russian/topics/cez0n29ggrdt',
       },
       {
+        title: 'Сводка потерь',
+        url: '/russian/topics/cqx9qqylwvgt',
+      },
+      {
         title: 'Истории',
         url: '/russian/topics/cv27xky1pppt',
       },


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds Counting the dead topic link to the navgation bar of Russian

Code changes
======

- Edited Navigation section of src/app/lib/config/services/russian.ts to add Counting the dead topic link in third position


Testing
======
1. Open Russian front page, the third link in the nav should be  Сводка потерь and open /russian/topics/cqx9qqylwvgt


![russian-nav](https://github.com/user-attachments/assets/60555c0b-7f98-4d7d-ad06-6da8e26b27bf)


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
