### PR TITLE
WSTEAMA-1572: Remove "hashedId" to match sign-in status

### DIFF
--- a/src/app/components/ATIAnalytics/atiUrl/index.test.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.test.ts
@@ -357,8 +357,11 @@ describe('Reverb', () => {
           x18: 'isLocServeCookieSet',
         },
       };
+      const userParans = { isSignedIn: false };
 
       expect(reverbAnalyticsModel.params.page).toEqual(pageParams);
+      expect(reverbAnalyticsModel.params.user).toEqual(userParans);
+
       expect(reverbAnalyticsModel.eventDetails).toEqual({
         eventName: 'pageView',
       });
@@ -438,6 +441,15 @@ describe('Reverb', () => {
         componentName: 'top-stories',
         container: '1234',
       });
+    });
+
+    it('should return the correct Reverb user object configuration', () => {
+      const reverbPageSectionViewEventModel =
+        buildReverbPageSectionEventModel(input);
+
+      expect(reverbPageSectionViewEventModel.params.user).toEqual(
+        { isSignedIn: false }
+      );
     });
   });
 });

--- a/src/app/components/ATIAnalytics/atiUrl/index.test.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.test.ts
@@ -447,9 +447,9 @@ describe('Reverb', () => {
       const reverbPageSectionViewEventModel =
         buildReverbPageSectionEventModel(input);
 
-      expect(reverbPageSectionViewEventModel.params.user).toEqual(
-        { isSignedIn: false }
-      );
+      expect(reverbPageSectionViewEventModel.params.user).toEqual({
+        isSignedIn: false,
+      });
     });
   });
 });

--- a/src/app/components/ATIAnalytics/atiUrl/index.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.ts
@@ -479,7 +479,6 @@ export const buildReverbAnalyticsModel = ({
         },
       },
       user: {
-        hashedId: getAtUserId(),
         isSignedIn: false,
       },
     },

--- a/src/app/components/ATIAnalytics/atiUrl/index.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.ts
@@ -528,7 +528,6 @@ export const buildReverbPageSectionEventModel = ({
         },
       },
       user: {
-        hashedId: getAtUserId(),
         isSignedIn: false,
       },
     },

--- a/src/app/lib/analyticsUtils/sendBeacon/index.js
+++ b/src/app/lib/analyticsUtils/sendBeacon/index.js
@@ -47,7 +47,7 @@ const setReverbPageValues = async ({ pageVars, userVars }) => {
   });
 
   window.bbcuser = {
-    getHashedId: () => [userVars.hashedId],
+    getHashedId: () => null,
     isSignedIn: () => Promise.resolve(userVars.isSignedIn),
   };
 };


### PR DESCRIPTION
Resolves JIRA [WSTEAMA-1572]

Overall changes
======
Removes the value, `hashedId`, from Reverb config since it sets the user ID instead of the visitor ID.

#### Background Context
Following [this](https://github.com/bbc/simorgh/pull/12189#discussion_r1914571670) conversation, we investigated the usage of values set in the `user` object of the
Reverb configuration. The investigation revealed that the `hashedId` we've been passing in the Reverb
configuration for the purpose of setting the visitor ID was incorrect. This is because the `hashedId` which
we pass to Reverb via the function, `getHashedId`, is meant to track users instead of visitors.

Through conversations with the Reverb, we've established that Reverb manages the generation and
persistence of the visitor ID via the `atuserid` cookie. The values stored in `atuserid` is then reported
to Piano via the query parameter, `idclient`. We therefore don't need to manage the `atuserid`
cookie in Simorgh once we transition to Reverb.

The Reverb team recommended that we should retain the user object even though our audience
is not signed in and set the function, `getHashedId` to return `null`.

See WSTEAMA-1572 for link to Slack thread

Code changes
======

- Remove `hashedId` from the Reverb page view beacon configuration.
- Remove `hashedId` from the Reverb component tracking beacon configuration. 

Testing
======
1. Visit http://localhost.bbc.com:7080/pidgin/articles/cevee1j7ymyo?renderer_env=live
2. Verify that page view and component event tracking beacons include the `idclient` query parameter.

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
