### PR TITLE
Ensure Cypress smoke tests run on local environment

### DIFF
--- a/cypress/e2e/pages/articles/index.cy.js
+++ b/cypress/e2e/pages/articles/index.cy.js
@@ -235,8 +235,6 @@ const liteTestSuites = canonicalTestSuites
     };
   });
 
-console.log({ canonicalTestSuites, ampTestSuites });
-
 runTestsForPage({
   pageType: 'articles',
   testSuites: [...canonicalTestSuites, ...ampTestSuites, ...liteTestSuites],

--- a/cypress/e2e/pages/articles/index.cy.js
+++ b/cypress/e2e/pages/articles/index.cy.js
@@ -195,7 +195,7 @@ const nonSmokeCanonicalTestSuites = [
   },
 ];
 
-const canonicalTestSuites = Cypress.env.SMOKE
+const canonicalTestSuites = Cypress.env('SMOKE')
   ? smokeCanonicalTestSuites
   : nonSmokeCanonicalTestSuites;
 
@@ -234,6 +234,8 @@ const liteTestSuites = canonicalTestSuites
       tests: [liteArticleTests],
     };
   });
+
+console.log({ canonicalTestSuites, ampTestSuites });
 
 runTestsForPage({
   pageType: 'articles',


### PR DESCRIPTION
Overall changes
======
Ensure Cypress smoke tests run on local environment

Code changes
======
- Correct logic to get cypress environment variables 

Testing
======
PR checks - runs more cypress tests than just [/news/articles/cn7k01xp8kxo.amp](http://localhost:7080/news/articles/cn7k01xp8kxo.amp)