### PR TITLE
Marathi: podcast promo and nav udpates

### DIFF
--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -46,16 +46,16 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: false,
     showRelatedTopics: true,
     podcastPromo: {
-      title: 'पॉडकास्ट',
-      brandTitle: 'तीन गोष्टी',
-      brandDescription: 'दिवसभरातील घडामोडींचा आढावा',
+      title: 'बीबीसी मराठी व्हॉट्सॲपवर',
+      brandTitle: 'बीबीसी न्यूज मराठी आता व्हॉट्सॲपवर',
+      brandDescription: 'तुमच्या कामाच्या गोष्टी आणि बातम्या आता थेट तुमच्या फोनवर',
       image: {
-        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0940n6j.jpg',
-        alt: 'तीन गोष्टी',
+        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0kptdp6.jpg',
+        alt: 'BBC News मराठी आत्ताच फॉलो करा WhatsApp कर',
       },
       linkLabel: {
-        text: 'भाग',
-        href: 'https://www.bbc.com/marathi/podcasts/p09431p4',
+        text: 'फॉलो करा',
+        href: 'https://www.whatsapp.com/channel/0029Vaa8TxTIyPtQpqWBTh3j',
       },
     },
     translations: {
@@ -346,10 +346,6 @@ export const service: DefaultServiceConfig = {
       {
         title: 'महाराष्ट्र',
         url: '/marathi/topics/c5qvpxvv7y3t',
-      },
-      {
-        title: 'विधानसभा निवडणूक',
-        url: '/marathi/topics/c625x8zjyj7t',
       },
       {
         title: 'भारत',

--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -48,7 +48,8 @@ export const service: DefaultServiceConfig = {
     podcastPromo: {
       title: 'बीबीसी मराठी व्हॉट्सॲपवर',
       brandTitle: 'बीबीसी न्यूज मराठी आता व्हॉट्सॲपवर',
-      brandDescription: 'तुमच्या कामाच्या गोष्टी आणि बातम्या आता थेट तुमच्या फोनवर',
+      brandDescription:
+        'तुमच्या कामाच्या गोष्टी आणि बातम्या आता थेट तुमच्या फोनवर',
       image: {
         src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0kptdp6.jpg',
         alt: 'BBC News मराठी आत्ताच फॉलो करा WhatsApp कर',


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Updates the in-article podcast promo to promote Marathi's Whatsapp channel
- Removes election link from the navigation Counting the dead topic link to the navgation bar of Russian


Code changes
======

- Edited podcastPromo and Navigation sections of src/app/lib/config/services/marathi.ts 


Testing
======
1. Open a Marathi article the in-article podcast promo should promote the Whatsapp channel and point to: https://www.whatsapp.com/channel/0029Vaa8TxTIyPtQpqWBTh3j

2. The navigation should have six items with विधानसभा निवडणूक (marathi/topics/c625x8zjyj7t) no longer appearing in third position

![image](https://github.com/user-attachments/assets/0acfd03b-73bd-43b1-ba77-a782bd57230b)

![image](https://github.com/user-attachments/assets/1f4f04e2-c7c4-4f2e-84ef-eaa6d37a4b65)







Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
