### PR TITLE
Remove thai asset /23122810 from cookie banner tests

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -6328,7 +6328,6 @@ module.exports = () => ({
               '/thai/articles/c442rl3md0eo', // Article
               '/thai', // Front Page
               '/thai/popular/read', // Most Read
-              '/thai/23122810', // CPS MAP
               '/thai/international-23252840', // CPS PGL
               // '', // CPS STY
             ],
@@ -6339,7 +6338,6 @@ module.exports = () => ({
               '/thai/articles/c442rl3md0eo', // Article
               '/thai', // Front Page
               '/thai/popular/read', // Most Read
-              '/thai/23122810', // CPS MAP
               '/thai/thailand-49950038', // CPS PGL
             ],
             enabled: true,


### PR DESCRIPTION
This test has been causing flaky problems for us. We have decided to just remove it to save a headache, as we think we have good coverage of the cookie banner (e.g LTR, RTL and variant assets) without it.

Overall changes
======
_A very high-level summary of easily-reproducible changes that can be understood by non-devs, and why these changes where made._

Code changes
======

- _A bullet point list of key code changes that have been made._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
