### PR TITLE
Move `SIMORGH_DATA` script to `head`

### DIFF
--- a/src/server/Document/Renderers/CanonicalRenderer.tsx
+++ b/src/server/Document/Renderers/CanonicalRenderer.tsx
@@ -69,15 +69,14 @@ export default function CanonicalRenderer({
             __html: `window.SIMORGH_ENV_VARS=${appEnvVariables}`,
           }}
         />
-      </head>
-      <body>
-        <div id="root" dangerouslySetInnerHTML={{ __html: html || '' }} />
         <script
-          // This script should be the first script tag in the body, otherwise Opera Mini has trouble parsing the `window.SIMORGH_DATA` object
           dangerouslySetInnerHTML={{
             __html: `window.SIMORGH_DATA=${serialisedData}`,
           }}
         />
+      </head>
+      <body>
+        <div id="root" dangerouslySetInnerHTML={{ __html: html || '' }} />
         {links}
         <IfAboveIE9>
           {modernScripts}

--- a/src/server/Document/__snapshots__/component.test.jsx.snap
+++ b/src/server/Document/__snapshots__/component.test.jsx.snap
@@ -131,7 +131,10 @@ exports[`Document Component should render APP version correctly 1`] = `
       .css-7prgni-StyledLink{display:inline-block;}
     </style>
     <script>
-      window.SIMORGH_ENV_VARS={"SIMORGH_APP_ENV":"local","SIMORGH_ATI_BASE_URL":"https://logws1363.ati-host.net?","SIMORGH_BASE_URL":"http://localhost:7080","SIMORGH_CONFIG_CACHE_ITEMS":"400","SIMORGH_CONFIG_CACHE_MAX_AGE_SECONDS":"300","SIMORGH_CONFIG_TIMEOUT_SECONDS":"5","SIMORGH_CONFIG_URL":"https://config.test.api.bbci.co.uk/","SIMORGH_CSP_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_ICHEF_BASE_URL":"https://ichef.bbci.co.uk","SIMORGH_INCLUDES_BASE_URL":"https://www.test.bbc.com/ws/includes","SIMORGH_INCLUDES_BASE_AMP_URL":"https://news.test.files.bbci.co.uk","SIMORGH_MOST_READ_CDN_URL":"http://localhost:7080","SIMORGH_OPTIMIZELY_SDK_KEY":"LptPKDnHyAFu9V12s5xCz","SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN":"http://localhost:7080","SIMORGH_PUBLIC_STATIC_ASSETS_PATH":"/","SIMORGH_REVERB_SOURCE":"https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.9.2.js","SIMORGH_WEBVITALS_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE":"100"}
+      window.SIMORGH_ENV_VARS={"SIMORGH_APP_ENV":"local","SIMORGH_ATI_BASE_URL":"https://logws1363.ati-host.net?","SIMORGH_BASE_URL":"https://www.test.bbc.com","SIMORGH_CONFIG_CACHE_ITEMS":"400","SIMORGH_CONFIG_CACHE_MAX_AGE_SECONDS":"300","SIMORGH_CONFIG_TIMEOUT_SECONDS":"1","SIMORGH_CONFIG_URL":"https://config.test.api.bbci.co.uk/","SIMORGH_CSP_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_ICHEF_BASE_URL":"https://ichef.test.bbci.co.uk","SIMORGH_INCLUDES_BASE_URL":"https://www.test.bbc.com/ws/includes","SIMORGH_INCLUDES_BASE_AMP_URL":"https://news.test.files.bbci.co.uk","SIMORGH_MOST_READ_CDN_URL":"https://web-cdn.test.api.bbci.co.uk","SIMORGH_OPTIMIZELY_SDK_KEY":"LptPKDnHyAFu9V12s5xCz","SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN":"http://localhost:7080","SIMORGH_PUBLIC_STATIC_ASSETS_PATH":"/","SIMORGH_REVERB_SOURCE":"https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.9.2.js","SIMORGH_WEBVITALS_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE":"100"}
+    </script>
+    <script>
+      window.SIMORGH_DATA={"test":"data"}
     </script>
   </head>
   <body>
@@ -142,9 +145,6 @@ exports[`Document Component should render APP version correctly 1`] = `
         App!
       </h1>
     </div>
-    <script>
-      window.SIMORGH_DATA={"test":"data"}
-    </script>
     <div>
       <!--[if !IE]&gt;&lt;!-->
     </div>
@@ -271,7 +271,10 @@ exports[`Document Component should render correctly 1`] = `
       .css-7prgni-StyledLink{display:inline-block;}
     </style>
     <script>
-      window.SIMORGH_ENV_VARS={"SIMORGH_APP_ENV":"local","SIMORGH_ATI_BASE_URL":"https://logws1363.ati-host.net?","SIMORGH_BASE_URL":"http://localhost:7080","SIMORGH_CONFIG_CACHE_ITEMS":"400","SIMORGH_CONFIG_CACHE_MAX_AGE_SECONDS":"300","SIMORGH_CONFIG_TIMEOUT_SECONDS":"5","SIMORGH_CONFIG_URL":"https://config.test.api.bbci.co.uk/","SIMORGH_CSP_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_ICHEF_BASE_URL":"https://ichef.bbci.co.uk","SIMORGH_INCLUDES_BASE_URL":"https://www.test.bbc.com/ws/includes","SIMORGH_INCLUDES_BASE_AMP_URL":"https://news.test.files.bbci.co.uk","SIMORGH_MOST_READ_CDN_URL":"http://localhost:7080","SIMORGH_OPTIMIZELY_SDK_KEY":"LptPKDnHyAFu9V12s5xCz","SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN":"http://localhost:7080","SIMORGH_PUBLIC_STATIC_ASSETS_PATH":"/","SIMORGH_REVERB_SOURCE":"https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.9.2.js","SIMORGH_WEBVITALS_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE":"100"}
+      window.SIMORGH_ENV_VARS={"SIMORGH_APP_ENV":"local","SIMORGH_ATI_BASE_URL":"https://logws1363.ati-host.net?","SIMORGH_BASE_URL":"https://www.test.bbc.com","SIMORGH_CONFIG_CACHE_ITEMS":"400","SIMORGH_CONFIG_CACHE_MAX_AGE_SECONDS":"300","SIMORGH_CONFIG_TIMEOUT_SECONDS":"1","SIMORGH_CONFIG_URL":"https://config.test.api.bbci.co.uk/","SIMORGH_CSP_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_ICHEF_BASE_URL":"https://ichef.test.bbci.co.uk","SIMORGH_INCLUDES_BASE_URL":"https://www.test.bbc.com/ws/includes","SIMORGH_INCLUDES_BASE_AMP_URL":"https://news.test.files.bbci.co.uk","SIMORGH_MOST_READ_CDN_URL":"https://web-cdn.test.api.bbci.co.uk","SIMORGH_OPTIMIZELY_SDK_KEY":"LptPKDnHyAFu9V12s5xCz","SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN":"http://localhost:7080","SIMORGH_PUBLIC_STATIC_ASSETS_PATH":"/","SIMORGH_REVERB_SOURCE":"https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.9.2.js","SIMORGH_WEBVITALS_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE":"100"}
+    </script>
+    <script>
+      window.SIMORGH_DATA={"test":"data"}
     </script>
   </head>
   <body>
@@ -282,9 +285,6 @@ exports[`Document Component should render correctly 1`] = `
         App!
       </h1>
     </div>
-    <script>
-      window.SIMORGH_DATA={"test":"data"}
-    </script>
     <div>
       <!--[if !IE]&gt;&lt;!-->
     </div>

--- a/src/server/Document/component.test.jsx
+++ b/src/server/Document/component.test.jsx
@@ -131,19 +131,4 @@ describe('Document Component', () => {
 
     expect(head).toContainHTML('<meta name="robots" content="noindex" />');
   });
-
-  it('should render the "window.SIMORGH_DATA" object as the first script tag in the body', () => {
-    const dom = new JSDOM(
-      renderToString(<TestDocumentComponent service="news" />),
-    );
-
-    const body = dom.window.document.querySelector('body');
-    const scripts = body.querySelectorAll('script');
-
-    const firstScript = scripts[0];
-
-    expect(firstScript.innerHTML).toBe(
-      `window.SIMORGH_DATA=${JSON.stringify(data)}`,
-    );
-  });
 });


### PR DESCRIPTION
Overall changes
======
- Moves script that sets the `window.SIMORGH_DATA` value into the document `head` instead of the `body`.
- E2Es failed on occasion due to the app not hydrating, which is handled with https://github.com/bbc/simorgh/blob/75295317799fcd98d034c7639afd54dca42323c6/src/client.js#L24
- Moving the script into the head could maybe help ensure its available before execution of `client.js`

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
