### PR TITLE
Updates to the navigation of Marathi and Pashto

### DIFF
--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -361,6 +361,10 @@ export const service: DefaultServiceConfig = {
         url: '/marathi/topics/cl29j0epz13t',
       },
       {
+        title: 'सोपी गोष्ट',
+        url: '/marathi/topics/cpxrqmrke02t',
+      },
+      {
         title: 'लोकप्रिय',
         url: '/marathi/popular/read',
       },

--- a/src/app/lib/config/services/pashto.ts
+++ b/src/app/lib/config/services/pashto.ts
@@ -362,20 +362,16 @@ export const service: DefaultServiceConfig = {
         url: '/pashto/topics/cr50y59q860t',
       },
       {
-        title: 'ويډيوګانې',
-        url: '/pashto/topics/c2m45zyk0mmt',
+        title: 'اقتصاد او سوداګري',
+        url: '/pashto/topics/cy087kqvl1yt',
       },
       {
-        title: 'ځانګړې پاڼې',
-        url: '/pashto/topics/c6pxyz4e0ryt',
+        title: 'ساینس او ټکنالوژي',
+        url: '/pashto/topics/ckgrvled11kt',
       },
       {
-        title: 'کالم',
-        url: '/pashto/topics/cq57nwne9lzt',
-      },
-      {
-        title: 'پر سټلایت خپرونې',
-        url: '/pashto/articles/c4n55eygdn0o',
+        title: 'هنر او ادب',
+        url: '/pashto/topics/c8xqkd91knnt',
       },
       {
         title: 'راډیویي خپرونې',

--- a/src/integration/pages/onDemandAudioPage/pashto.expired/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/pashto.expired/__snapshots__/canonical.test.js.snap
@@ -173,33 +173,26 @@ exports[`Canonical On Demand Audio Page Header Navigation link should match text
 
 exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 7`] = `
 {
-  "text": "ويډيوګانې",
-  "url": "/pashto/topics/c2m45zyk0mmt",
+  "text": "اقتصاد او سوداګري",
+  "url": "/pashto/topics/cy087kqvl1yt",
 }
 `;
 
 exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 8`] = `
 {
-  "text": "ځانګړې پاڼې",
-  "url": "/pashto/topics/c6pxyz4e0ryt",
+  "text": "ساینس او ټکنالوژي",
+  "url": "/pashto/topics/ckgrvled11kt",
 }
 `;
 
 exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 9`] = `
 {
-  "text": "کالم",
-  "url": "/pashto/topics/cq57nwne9lzt",
+  "text": "هنر او ادب",
+  "url": "/pashto/topics/c8xqkd91knnt",
 }
 `;
 
 exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 10`] = `
-{
-  "text": "پر سټلایت خپرونې",
-  "url": "/pashto/articles/c4n55eygdn0o",
-}
-`;
-
-exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 11`] = `
 {
   "text": "راډیویي خپرونې",
   "url": "/pashto/topics/c9xz1ekw79nt",

--- a/src/integration/pages/onDemandAudioPage/pashto/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/pashto/__snapshots__/canonical.test.js.snap
@@ -161,33 +161,26 @@ exports[`Canonical On Demand Audio Page Header Navigation link should match text
 
 exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 7`] = `
 {
-  "text": "ويډيوګانې",
-  "url": "/pashto/topics/c2m45zyk0mmt",
+  "text": "اقتصاد او سوداګري",
+  "url": "/pashto/topics/cy087kqvl1yt",
 }
 `;
 
 exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 8`] = `
 {
-  "text": "ځانګړې پاڼې",
-  "url": "/pashto/topics/c6pxyz4e0ryt",
+  "text": "ساینس او ټکنالوژي",
+  "url": "/pashto/topics/ckgrvled11kt",
 }
 `;
 
 exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 9`] = `
 {
-  "text": "کالم",
-  "url": "/pashto/topics/cq57nwne9lzt",
+  "text": "هنر او ادب",
+  "url": "/pashto/topics/c8xqkd91knnt",
 }
 `;
 
 exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 10`] = `
-{
-  "text": "پر سټلایت خپرونې",
-  "url": "/pashto/articles/c4n55eygdn0o",
-}
-`;
-
-exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 11`] = `
 {
   "text": "راډیویي خپرونې",
   "url": "/pashto/topics/c9xz1ekw79nt",

--- a/src/integration/pages/onDemandAudioPage/pashtoBrand/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/pashtoBrand/__snapshots__/canonical.test.js.snap
@@ -161,33 +161,26 @@ exports[`Canonical On Demand Audio Page Header Navigation link should match text
 
 exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 7`] = `
 {
-  "text": "ويډيوګانې",
-  "url": "/pashto/topics/c2m45zyk0mmt",
+  "text": "اقتصاد او سوداګري",
+  "url": "/pashto/topics/cy087kqvl1yt",
 }
 `;
 
 exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 8`] = `
 {
-  "text": "ځانګړې پاڼې",
-  "url": "/pashto/topics/c6pxyz4e0ryt",
+  "text": "ساینس او ټکنالوژي",
+  "url": "/pashto/topics/ckgrvled11kt",
 }
 `;
 
 exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 9`] = `
 {
-  "text": "کالم",
-  "url": "/pashto/topics/cq57nwne9lzt",
+  "text": "هنر او ادب",
+  "url": "/pashto/topics/c8xqkd91knnt",
 }
 `;
 
 exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 10`] = `
-{
-  "text": "پر سټلایت خپرونې",
-  "url": "/pashto/articles/c4n55eygdn0o",
-}
-`;
-
-exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 11`] = `
 {
   "text": "راډیویي خپرونې",
   "url": "/pashto/topics/c9xz1ekw79nt",

--- a/src/integration/pages/onDemandTVPage/pashto.expired/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/pashto.expired/__snapshots__/canonical.test.js.snap
@@ -171,33 +171,26 @@ exports[`Canonical Pashto On Demand TV Page Header Navigation link should match 
 
 exports[`Canonical Pashto On Demand TV Page Header Navigation link should match text and url 7`] = `
 {
-  "text": "ويډيوګانې",
-  "url": "/pashto/topics/c2m45zyk0mmt",
+  "text": "اقتصاد او سوداګري",
+  "url": "/pashto/topics/cy087kqvl1yt",
 }
 `;
 
 exports[`Canonical Pashto On Demand TV Page Header Navigation link should match text and url 8`] = `
 {
-  "text": "ځانګړې پاڼې",
-  "url": "/pashto/topics/c6pxyz4e0ryt",
+  "text": "ساینس او ټکنالوژي",
+  "url": "/pashto/topics/ckgrvled11kt",
 }
 `;
 
 exports[`Canonical Pashto On Demand TV Page Header Navigation link should match text and url 9`] = `
 {
-  "text": "کالم",
-  "url": "/pashto/topics/cq57nwne9lzt",
+  "text": "هنر او ادب",
+  "url": "/pashto/topics/c8xqkd91knnt",
 }
 `;
 
 exports[`Canonical Pashto On Demand TV Page Header Navigation link should match text and url 10`] = `
-{
-  "text": "پر سټلایت خپرونې",
-  "url": "/pashto/articles/c4n55eygdn0o",
-}
-`;
-
-exports[`Canonical Pashto On Demand TV Page Header Navigation link should match text and url 11`] = `
 {
   "text": "راډیویي خپرونې",
   "url": "/pashto/topics/c9xz1ekw79nt",

--- a/src/integration/pages/onDemandTVPage/pashtoBrand/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/pashtoBrand/__snapshots__/canonical.test.js.snap
@@ -161,33 +161,26 @@ exports[`Canonical On Demand T V Page Header Navigation link should match text a
 
 exports[`Canonical On Demand T V Page Header Navigation link should match text and url 7`] = `
 {
-  "text": "ويډيوګانې",
-  "url": "/pashto/topics/c2m45zyk0mmt",
+  "text": "اقتصاد او سوداګري",
+  "url": "/pashto/topics/cy087kqvl1yt",
 }
 `;
 
 exports[`Canonical On Demand T V Page Header Navigation link should match text and url 8`] = `
 {
-  "text": "ځانګړې پاڼې",
-  "url": "/pashto/topics/c6pxyz4e0ryt",
+  "text": "ساینس او ټکنالوژي",
+  "url": "/pashto/topics/ckgrvled11kt",
 }
 `;
 
 exports[`Canonical On Demand T V Page Header Navigation link should match text and url 9`] = `
 {
-  "text": "کالم",
-  "url": "/pashto/topics/cq57nwne9lzt",
+  "text": "هنر او ادب",
+  "url": "/pashto/topics/c8xqkd91knnt",
 }
 `;
 
 exports[`Canonical On Demand T V Page Header Navigation link should match text and url 10`] = `
-{
-  "text": "پر سټلایت خپرونې",
-  "url": "/pashto/articles/c4n55eygdn0o",
-}
-`;
-
-exports[`Canonical On Demand T V Page Header Navigation link should match text and url 11`] = `
 {
   "text": "راډیویي خپرونې",
   "url": "/pashto/topics/c9xz1ekw79nt",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Add link to "News explained" topic page to the navigation of Marathi
- Add links to Bussiness, Science and Technology and Art and Culture topics to the navigation of Pashto and remove the links to Video, Special pages and Columns

Code changes
======

- Edited Navigation section of src/app/lib/config/services/marathi.ts
- Edited Navigation section of src/app/lib/config/services/pashto.ts 


Testing
======
1. Open Marathi's front page, the sixth link in the nav should be सोपी गोष्ट (/marathi/topics/cpxrqmrke02t)
2. Open Pashto's front page, the nav shoul have the followung items:
Homepage | Afghanistan | Pakhtunkhwa | World | Women | Sport | Economy and Business | Science and Technology | Art and Literature | Radio

![marathi_nav](https://github.com/user-attachments/assets/37efed08-88de-45a5-a9ca-512b6f1e3aee)
![pashto_nav](https://github.com/user-attachments/assets/0596d955-74b9-4759-a296-e51a2ef124c6)







Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
