### PR TITLE
Gahuza in-article promo update: WhatsApp

### DIFF
--- a/src/app/lib/config/services/gahuza.ts
+++ b/src/app/lib/config/services/gahuza.ts
@@ -46,16 +46,16 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: true,
     showRelatedTopics: true,
     podcastPromo: {
-      title: 'Podcast',
-      brandTitle: 'Ikiganiro cy’abagore',
-      brandDescription: 'Ikiganiro cy’abagore kuri BBC Gahuzamiryango',
+      title: 'Whatsapp',
+      brandTitle: 'WhatsApp channel ya BBC Gahuza ',
+      brandDescription: 'Amakuru ya BBC Gahuza ako kanya kuri WhatsApp yawe',
       image: {
-        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p082wkdq.jpg',
-        alt: 'Ikiganiro cy’abagore',
+        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0kqymfd.png',
+        alt: 'BBC Gahuza WhatsApp',
       },
       linkLabel: {
-        text: 'Inkurikirane',
-        href: 'https://www.bbc.com/gahuza/podcasts/p07yjlmf',
+        text: 'Kanda hano ujyeho',
+        href: 'https://www.whatsapp.com/channel/0029VataD35JuyADtKHXNk0N',
       },
     },
     translations: {


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Updates the in-article podcast promo to promote Gahuza's Whatsapp channel

Code changes
======

- Edited podcastPromo section of src/app/lib/config/services/gahuza.ts 


Testing
======
1. Open a Gahuza article the in-article podcast promo should promote their Whatsapp channel and point to: https://www.whatsapp.com/channel/0029VataD35JuyADtKHXNk0N



![gahuza_promo](https://github.com/user-attachments/assets/d921e738-034b-4571-819e-2f9dc2f94a70)

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
