### PR TITLE
Add in-article WhatsApp channel promo to Amharic

### DIFF
--- a/src/app/lib/config/services/amharic.ts
+++ b/src/app/lib/config/services/amharic.ts
@@ -48,8 +48,7 @@ export const service: DefaultServiceConfig = {
     podcastPromo: {
       title: 'ቢቢሲ አማርኛ በዋትስአፕ',
       brandTitle: 'የቢቢሲ አማርኛ ዋትስአፕ ቻናል',
-      brandDescription:
-        'ዜና፣ ትንታኔ እና ታሪኮችን በቀጥታ በዋትስአፕ ለማግኘት',
+      brandDescription: 'ዜና፣ ትንታኔ እና ታሪኮችን በቀጥታ በዋትስአፕ ለማግኘት',
       image: {
         src: 'https://ichef.bbci.co.uk/images/ic/$recipe//p0krq6vq.png',
         alt: 'የቢቢሲ አማርኛ ዋትስአፕ ቻናል',

--- a/src/app/lib/config/services/amharic.ts
+++ b/src/app/lib/config/services/amharic.ts
@@ -45,6 +45,20 @@ export const service: DefaultServiceConfig = {
     frontPageTitle: 'ዜና',
     showAdPlaceholder: false,
     showRelatedTopics: true,
+    podcastPromo: {
+      title: 'ቢቢሲ አማርኛ በዋትስአፕ',
+      brandTitle: 'የቢቢሲ አማርኛ ዋትስአፕ ቻናል',
+      brandDescription:
+        'ዜና፣ ትንታኔ እና ታሪኮችን በቀጥታ በዋትስአፕ ለማግኘት',
+      image: {
+        src: 'https://ichef.bbci.co.uk/images/ic/$recipe//p0krq6vq.png',
+        alt: 'የቢቢሲ አማርኛ ዋትስአፕ ቻናል',
+      },
+      linkLabel: {
+        text: 'ይህን በመጫን የቻናላችን አባል ይሁኑ!',
+        href: 'https://bit.ly/4gsoTyI',
+      },
+    },
     translations: {
       pagination: {
         page: 'ገፁ',


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds the in-article podcast promo to promote Amharic Whatsapp channel


Code changes
======

- Added podcastPromo section to src/app/lib/config/services/amharic.ts 


Testing
======
1. Open an Amharic article, the in-article podcast promo should promote the Whatsapp channel and open to: https://www.whatsapp.com/channel/0029VawqnhN0QeacmCRo7f00

![am_whatsapp](https://github.com/user-attachments/assets/f811bd99-d8a9-477f-8157-d1e0dec95c20)




Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
