### PR TITLE
WORLDSERVICE - Re-add Chromatic Checks on Latest

### DIFF
--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - '**'
+  push:
+      branches:
+      - 'latest'
 
 permissions:
   statuses: write


### PR DESCRIPTION
Resolves GitHub Pages

Overall changes
======
re-adds Chromatic checks that run on `latest` within `.github/workflows/simorgh-misc-checks.yml`

Links to #12434 

Helpful Links
======
[YAML](https://www.freecodecamp.org/news/what-is-yaml-the-yml-file-format/)

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

