### PR TITLE
Add first() assertion to scrollablePromo cypress tests

### DIFF
--- a/cypress/e2e/specialFeatures/atiAnalytics/assertions/scrollablePromo.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/assertions/scrollablePromo.js
@@ -12,7 +12,7 @@ export const assertScrollablePromoComponentView = ({
       interceptATIAnalyticsBeacons();
       cy.visit(url);
 
-      cy.get('[data-e2e="scrollable-promos"]').scrollIntoView({
+      cy.get('[data-e2e="scrollable-promos"]').first().scrollIntoView({
         duration: 1000,
       });
 
@@ -34,7 +34,7 @@ export const assertScrollablePromoComponentClick = ({
       interceptATIAnalyticsBeacons();
       cy.visit(url);
 
-      cy.get('[data-e2e="scrollable-promos"]').scrollIntoView({
+      cy.get('[data-e2e="scrollable-promos"]').first().scrollIntoView({
         duration: 1000,
       });
 

--- a/cypress/e2e/specialFeatures/atiAnalytics/assertions/scrollablePromo.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/assertions/scrollablePromo.js
@@ -39,7 +39,7 @@ export const assertScrollablePromoComponentClick = ({
       });
 
       // Click on first item
-      cy.get('[data-e2e="scrollable-promos"]').find('a').click();
+      cy.get('[data-e2e="scrollable-promos"]').first().find('a').click();
 
       assertATIComponentClickEvent({
         component: SCROLLABLE_PROMO,


### PR DESCRIPTION
Resolves failing tests in alerts channel

Overall changes
======

Adds .first() before calling scrollIntoView() to ensure it is always callled with only one element, as whenever it is called with more than one element cypress automatically fails out.

Code changes
======

- _A bullet point list of key code changes that have been made._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
