### PR TITLE
Swaps find and first for scroll promo click E2E test

### DIFF
--- a/cypress/e2e/specialFeatures/atiAnalytics/assertions/scrollablePromo.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/assertions/scrollablePromo.js
@@ -39,7 +39,7 @@ export const assertScrollablePromoComponentClick = ({
       });
 
       // Click on first item
-      cy.get('[data-e2e="scrollable-promos"]').first().find('a').click();
+      cy.get('[data-e2e="scrollable-promos"]').find('a').first().click();
 
       assertATIComponentClickEvent({
         component: SCROLLABLE_PROMO,


### PR DESCRIPTION
Resolves JIRA N/A

Overall changes
======
Swaps the find and first function, to target a single scrollable promo link

Code changes
======

- Swaps order of find and first function in e2e test for scrollable promo

Testing
======
1. Temp change `"cypress:interactive": "cypress open"` to `"cypress:interactive": "CYPRESS_APP_ENV=live cypress open"` in package.json
2. Run script with yarn
3. Run the ati analytics e2e test suite

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
