### PR TITLE
Related Content item width fix

### DIFF
--- a/src/app/components/RelatedContentSection/RelatedContentItem/index.styles.ts
+++ b/src/app/components/RelatedContentSection/RelatedContentItem/index.styles.ts
@@ -5,6 +5,7 @@ export default {
     css({
       border: '0.1875rem solid transparent',
       height: '100%',
+      width: '100%',
     }),
   promoFullWidth: () =>
     css({


### PR DESCRIPTION
Overall changes
======
- Fixes width issue highlighted on AMP for related content items that don't have a particularly long headline title, causing them to not take up the full width of the container on mobile.

Testing
======
1. Visit http://localhost:7080/news/articles/cx2g5e95r74o.amp?renderer_env=live
2. Reduce the size of your screen to mobile (the related content items should go into a single column)
3. Confirm that all the items take up 100% width of the window

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
