### PR TITLE
Add in-article WhatsApp channel promo to Afaan Oromoo and Yoruba

### DIFF
--- a/src/app/lib/config/services/afaanoromoo.ts
+++ b/src/app/lib/config/services/afaanoromoo.ts
@@ -47,6 +47,20 @@ export const service: DefaultServiceConfig = {
     frontPageTitle: 'Oduu',
     showAdPlaceholder: false,
     showRelatedTopics: true,
+    podcastPromo: {
+      title: 'WhatsApp',
+      brandTitle: 'Chaanaalii WhatsApp BBC Afaan Oromoo',
+      brandDescription:
+        'Oduu, xiinxalaafi odeessa adda addaa kallattiin argachuuf',
+      image: {
+        src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0kthbd3.png',
+        alt: 'BBC News Afaan Oromo WhatsApp irrati argadhaa',
+      },
+      linkLabel: {
+        text: 'Asiin seenaa',
+        href: 'https://bit.ly/4hIe50g',
+      },
+    },
     translations: {
       pagination: {
         previousPage: 'Kan duraa',

--- a/src/app/lib/config/services/yoruba.ts
+++ b/src/app/lib/config/services/yoruba.ts
@@ -40,8 +40,7 @@ export const service: DefaultServiceConfig = {
     podcastPromo: {
       title: 'WhatsApp',
       brandTitle: 'Èyí ni ìkànnì Whatsapp wa',
-      brandDescription:
-        'Àjáàbalẹ̀ ìròyìn BBC News Yorùbá lórí WhatsApp rẹ',
+      brandDescription: 'Àjáàbalẹ̀ ìròyìn BBC News Yorùbá lórí WhatsApp rẹ',
       image: {
         src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0kthb9n.jpg',
         alt: 'BBC News Yorùbá ti wà lórí WhatsApp',

--- a/src/app/lib/config/services/yoruba.ts
+++ b/src/app/lib/config/services/yoruba.ts
@@ -37,6 +37,20 @@ export const service: DefaultServiceConfig = {
     twitterSite: '@BBCNews', // to be updated
     showAdPlaceholder: false,
     showRelatedTopics: true,
+    podcastPromo: {
+      title: 'WhatsApp',
+      brandTitle: 'Èyí ni ìkànnì Whatsapp wa',
+      brandDescription:
+        'Àjáàbalẹ̀ ìròyìn BBC News Yorùbá lórí WhatsApp rẹ',
+      image: {
+        src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0kthb9n.jpg',
+        alt: 'BBC News Yorùbá ti wà lórí WhatsApp',
+      },
+      linkLabel: {
+        text: 'Darapọ̀ mọ́ wa nibì',
+        href: 'https://bit.ly/3Xgfl35',
+      },
+    },
     noBylinesPolicy:
       'https://www.bbc.com/yoruba/institutional-48528718#authorexpertise',
     publishingPrinciples: 'https://www.bbc.com/yoruba/institutional-48528718',


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds the in-article podcast promo to promote Afaan Oromoo's Whatsapp channel
- Adds the in-article podcast promo to promote Yoruba's Whatsapp channel

Code changes
======

- Added podcastPromo section to src/app/lib/config/services/afaanoromoo.ts 
- Added podcastPromo section to src/app/lib/config/services/yoruba.ts 

Testing
======
1. Open an Afaan Oromoo article, the in-article podcast promo should promote the Whatsapp channel and open to: https://www.whatsapp.com/channel/0029VawyHE6CBtx7GK5AV32J

2. Open a Yoruba article, the in-article podcast promo should promote the Whatsapp channel and open to: https://www.whatsapp.com/channel/0029Vb18ZTM9Gv7NliClgu0M


![afaanoromoo_whatsapp](https://github.com/user-attachments/assets/f33caf11-2508-4f05-b501-f51fd6df4360)
![yoruba_whatsapp](https://github.com/user-attachments/assets/a04a5ec9-3ced-4419-bb69-ebc89ef3c3aa)



Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
