### PR TITLE
Recommendations experiment return empty array

### DIFF
--- a/src/app/pages/ArticlePage/recommendationsExperiment/index.ts
+++ b/src/app/pages/ArticlePage/recommendationsExperiment/index.ts
@@ -61,7 +61,7 @@ export const transformRecsData = ({
       block => block.type === 'relatedContent',
     );
 
-    if (!relatedContentBlock) return null;
+    if (!relatedContentBlock) return [];
 
     // @ts-expect-error - nested block structure
     const relatedContentItems = relatedContentBlock?.model?.blocks?.slice(0, 4);
@@ -96,7 +96,7 @@ export const transformRecsData = ({
       },
     );
 
-    return transformedRelatedContentItems;
+    return transformedRelatedContentItems || [];
   }
 
   if (variation === 'wsoj_most_read') {
@@ -114,7 +114,7 @@ export const transformRecsData = ({
       };
     });
 
-    return transformedMostReadItems;
+    return transformedMostReadItems || [];
   }
 
   return [];

--- a/src/app/pages/ArticlePage/recommendationsExperiment/index.ts
+++ b/src/app/pages/ArticlePage/recommendationsExperiment/index.ts
@@ -50,11 +50,11 @@ export const transformRecsData = ({
   variation,
 }: TransformRecsDataProps) => {
   // Optimizely will return null initially and then 'off' for users who are not in the experiment
-  if (!variation || variation === 'off') return wsojRecs;
+  if (!variation || variation === 'off') return wsojRecs || [];
 
   if (variation === 'wsoj_off') return [];
 
-  if (variation === 'wsoj') return wsojRecs;
+  if (variation === 'wsoj') return wsojRecs || [];
 
   if (variation === 'wsoj_related_content') {
     const relatedContentBlock = pageBlocks.find(


### PR DESCRIPTION
Part of https://jira.dev.bbc.co.uk/browse/WORLDSERVICE-388

Overall changes
======
- Returns an empty array instead of `null` if RelatedContent doesn't exist
- Also defaults to an empty array if other data items are `null/undefined`

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
