### PR TITLE
FIX: Send referrer as plain text and encode x5 correctly

### DIFF
--- a/src/app/components/ATIAnalytics/atiUrl/index.test.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.test.ts
@@ -357,10 +357,10 @@ describe('Reverb', () => {
           x18: 'isLocServeCookieSet',
         },
       };
-      const userParans = { isSignedIn: false };
+      const userParams = { isSignedIn: false };
 
       expect(reverbAnalyticsModel.params.page).toEqual(pageParams);
-      expect(reverbAnalyticsModel.params.user).toEqual(userParans);
+      expect(reverbAnalyticsModel.params.user).toEqual(userParams);
 
       expect(reverbAnalyticsModel.eventDetails).toEqual({
         eventName: 'pageView',

--- a/src/app/components/ATIAnalytics/atiUrl/index.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.ts
@@ -463,7 +463,7 @@ export const buildReverbAnalyticsModel = ({
           app_type: getAppType(platform),
           content_language: language,
           product_platform: onOnionTld() ? 'tor-bbc' : null,
-          referrer_url: referrer && referrer,
+          referrer_url: referrer,
           x5: href && encodeURIComponent(href),
           x8: libraryVersion,
           x9: sanitise(pageTitle),

--- a/src/app/components/ATIAnalytics/atiUrl/index.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.ts
@@ -463,9 +463,8 @@ export const buildReverbAnalyticsModel = ({
           app_type: getAppType(platform),
           content_language: language,
           product_platform: onOnionTld() ? 'tor-bbc' : null,
-          referrer_url:
-            referrer && encodeURIComponent(encodeURIComponent(referrer)),
-          x5: href && encodeURIComponent(encodeURIComponent(href)),
+          referrer_url: referrer && referrer,
+          x5: href && encodeURIComponent(href),
           x8: libraryVersion,
           x9: sanitise(pageTitle),
           x10: nationsProducer && nationsProducer,

--- a/src/app/components/ATIAnalytics/index.test.tsx
+++ b/src/app/components/ATIAnalytics/index.test.tsx
@@ -1046,6 +1046,7 @@ describe('ATI Analytics Container', () => {
       const serviceContextProps: ServiceConfig = {
         atiAnalyticsAppName: 'atiAnalyticsAppName',
         atiAnalyticsProducerId: 'atiAnalyticsProducerId',
+        atiAnalyticsProducerName: 'atiAnalyticsProducerName',
         service: 'pidgin',
         brandName: 'brandName',
         lang: 'pcm',
@@ -1074,13 +1075,14 @@ describe('ATI Analytics Container', () => {
         contentType: 'article',
         destination: 'WS_NEWS_LANGUAGES_TEST',
         name: 'news.articles.c0000000001o.page',
+        producer: 'atiAnalyticsProducerName',
         additionalProperties: {
           app_name: 'atiAnalyticsAppName',
           app_type: 'responsive',
           content_language: 'en-gb',
           product_platform: null,
           referrer_url: null,
-          x5: 'http%253A%252F%252Flocalhost%252F',
+          x5: 'http%3A%2F%2Flocalhost%2F',
           x8: 'simorgh',
           x9: 'Article%20Headline%20for%20SEO',
           x10: null,


### PR DESCRIPTION
Resolves JIRA [FIX: Reverb]

Overall changes
======
Send `referrer` and `url ` in the correct format to resolve data pollution in Telescope.

Code changes
======
- Set referrer as plain text in values reported via Reverb's page view event.
- Encode x5 once to match the formatting in Simorgh's current logic.

Testing
======
#### x5
1. Visit an asset that uses Reverb tracking e.g http://localhost.bbc.com:7080/pidgin/articles/c4gp243w4xyo?renderer_env=live
2. Examine the `x5` query parameter in the page view beacon.
3. `x5` should be decodable to a plain text URL using tools such as [urldecoder](https://www.urldecoder.org/).

#### ref
1. Visit an asset that uses Reverb tracking e.g http://localhost.bbc.com:7080/pidgin/articles/c4gp243w4xyo?renderer_env=live
2. Edit any of the links in the Top Stories sections to include `?renderer_env=live` at the end.
3. Click on the link you've edited in step (2) above.
4. Examine the `ref` query parameter in the page view beacon.
5. `ref` should be a plain text URL.

##### BEFORE
![Screenshot 2025-03-05 at 15 51 56](https://github.com/user-attachments/assets/1ef3411f-fc58-4e1b-a6b1-fe1b210be3f9)

##### AFTER
![Screenshot 2025-03-05 at 15 51 11](https://github.com/user-attachments/assets/8c603c47-88d5-469c-af82-732914a520fe)


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
