### PR TITLE
Indian sites, Swahili, Azeri, Brasil Tigrinya updates

### DIFF
--- a/src/app/lib/config/services/azeri.ts
+++ b/src/app/lib/config/services/azeri.ts
@@ -262,6 +262,19 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'Digər xəbərlər',
       featuresAnalysisTitle: 'Bunları da oxuyun',
+      ugc: {
+        // Optional
+        optional: 'vacib deyil',
+
+        // File upload
+        fileUploadButton: 'Faylı seçin',
+
+        // Submit button
+        submitButton: 'Göndərin',
+
+        // Form Screen
+        dataPolicyHeading: 'Bizim informasiya siyasə timiz',
+      },
     },
     mostRead: {
       header: 'Ən çox oxunan',

--- a/src/app/lib/config/services/gujarati.ts
+++ b/src/app/lib/config/services/gujarati.ts
@@ -228,6 +228,7 @@ export const service: DefaultServiceConfig = {
         },
         listen: 'સાંભળો',
         watch: 'જુઓ',
+        watchMoments: 'વીડિયો જુઓ',
         liveLabel: 'LIVE',
         nextLabel: 'NEXT',
         previousRadioShow: 'આ પહેલાંનો રેડિયો શો',

--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -253,6 +253,7 @@ export const service: DefaultServiceConfig = {
         },
         listen: 'सुनिए',
         watch: 'देखिए',
+        watchMoments: 'शॉर्ट वीडियो देखिए',
         listenLive: 'लाइव सुनें',
         listenNext: 'इसके बाद सुनिए',
         liveLabel: 'लाइव',

--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -234,6 +234,7 @@ export const service: DefaultServiceConfig = {
         },
         listen: 'ऐका',
         watch: 'पाहा',
+        watchMoments: 'शॉर्ट व्हीडिओ पाहा',
         liveLabel: 'LIVE',
         nextLabel: 'पुढचे',
         listenLive: 'ऐका',

--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -239,6 +239,7 @@ export const service: DefaultServiceConfig = {
         video: 'Vídeo',
         listen: 'Listen',
         watch: 'Assista',
+        watchMoments: 'Assista',
         listenLive: 'Ouça ao vivo',
         listenNext: 'Ouça o próximo',
         liveLabel: 'AO VIVO',

--- a/src/app/lib/config/services/punjabi.ts
+++ b/src/app/lib/config/services/punjabi.ts
@@ -220,6 +220,7 @@ export const service: DefaultServiceConfig = {
         video: 'ਵੀਡੀਓ',
         listen: 'ਸੁਣੋ',
         watch: 'ਦੇਖੋ',
+        watchMoments: 'ਸ਼ਾਰਟ ਵੀਡੀਓ ਦੇਖੋ',
         listenLive: 'live ਸੁਣੋ',
         liveLabel: 'LIVE',
         nextLabel: 'NEXT',

--- a/src/app/lib/config/services/swahili.ts
+++ b/src/app/lib/config/services/swahili.ts
@@ -231,6 +231,7 @@ export const service: DefaultServiceConfig = {
         },
         listen: 'Sikiliza',
         watch: 'Tazama',
+        watchMoments: 'Tazama hapa',
         liveLabel: 'Moja kwa moja',
         nextLabel: 'MBELE',
         previousRadioShow: 'Kipindi kilichopita cha redio',

--- a/src/app/lib/config/services/tamil.ts
+++ b/src/app/lib/config/services/tamil.ts
@@ -236,6 +236,7 @@ export const service: DefaultServiceConfig = {
         },
         listen: 'கேட்க',
         watch: 'பார்க்க',
+        watchMoments: 'ஷார்ட் வீடியோ',
         listenLive: 'நேரலையை கேட்க',
         liveLabel: 'நேரலை',
         nextLabel: 'NEXT',

--- a/src/app/lib/config/services/telugu.ts
+++ b/src/app/lib/config/services/telugu.ts
@@ -228,6 +228,7 @@ export const service: DefaultServiceConfig = {
         },
         listen: 'వినండి',
         watch: 'చూడండి',
+        watchMoments: 'షార్ట్ వీడియో చూడండి',
         listenLive: 'లైవ్ వినండి',
         liveLabel: 'లైవ్',
         nextLabel: 'NEXT',

--- a/src/app/lib/config/services/tigrinya.ts
+++ b/src/app/lib/config/services/tigrinya.ts
@@ -45,6 +45,23 @@ export const service: DefaultServiceConfig = {
     frontPageTitle: 'ዜና',
     showAdPlaceholder: false,
     showRelatedTopics: true,
+    podcastPromo: {
+      title: 'መወዓውዒ ዋትስኣፕ ቻነል',
+      brandTitle: 'ዋትስኣፕ ቻነል ቢቢሲ ትግርኛ',
+      brandDescription: 'ዜና፡ ትንታነን ታሪኻትን ብቐጥታ ኣብ ዋትስኣፕ ንምርካብ',
+      image: {
+        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0kxgny2.png',
+        alt: 'ቢቢሲ ትግርኛ ኣብ ዋትስኣፕ ቻነል',
+      },
+      linkLabel: {
+        text: 'ነዚ መላግቦ ብምጥዋቕ ኣባል ቻነልና ኵኑ!',
+        href: 'https://www.whatsapp.com/channel/0029VasPgatEVccGCsD4B42n',
+      },
+      skipLink: {
+        text: 'መወዓውዒ ስገሮ፣ ንባብካ ቀጽል',
+        endTextVisuallyHidden: 'መዛዘሚ መወዓውዒ ዋትስኣፕ ቻነል',
+      },
+    },
     translations: {
       pagination: {
         previousPage: 'ናይ ሕሉፍ',


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds Vertical video "Watch moments' string to the six Indian sites, Brasil and Swahili
- Adds a few ugc translations to Azeri 
- Add  in-article podcast promo for Tigrinya to promote their new Whatsapp channel

Code changes
======

- Added watchMoments:  string to media translations section in src/app/lib/config/services/gujarati.ts 
- Added watchMoments:  string to media translations section in src/app/lib/config/services/hindi.ts 
- Added watchMoments:  string to media translations section in src/app/lib/config/services/marathi.ts
- Added watchMoments:  string to media translations section in src/app/lib/config/services/portuguese.ts 
- Added watchMoments:  string to media translations section in src/app/lib/config/services/punjabi.ts 
- Added watchMoments:  string to media translations section in src/app/lib/config/services/swahili.ts 
- Added watchMoments:  string to media translations section in src/app/lib/config/services/tamil.ts 
- Added watchMoments:  string to media translations section in src/app/lib/config/services/telugu.ts 
- Added ugc section to the translations in src/app/lib/config/services/azeri.ts 
- Added podcastPromo section to src/app/lib/config/services/tigrinya.ts 

Testing
======
1. Open a Tigrinya article, the in-article podcast promo should promote their Whatsapp channel

![image](https://github.com/user-attachments/assets/f6516633-fc86-4d5a-b800-b9ad5436d4d0)






Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
