### PR TITLE
Live page SEO optional chaining

### DIFF
--- a/src/app/lib/seoUtils/getLiveBlogPostingSchema/index.ts
+++ b/src/app/lib/seoUtils/getLiveBlogPostingSchema/index.ts
@@ -45,7 +45,8 @@ export default ({
         '@type': 'BlogPosting',
         headline:
           // @ts-expect-error - deeply nested
-          headlineBlock?.model.blocks[0]?.model.blocks[0]?.model.text ?? null,
+          headlineBlock?.model.blocks?.[0]?.model.blocks?.[0]?.model.text ??
+          null,
         publisher: {
           '@type': 'Organization',
           name: brandName,

--- a/src/app/lib/seoUtils/getLiveBlogPostingSchema/index.ts
+++ b/src/app/lib/seoUtils/getLiveBlogPostingSchema/index.ts
@@ -45,7 +45,7 @@ export default ({
         '@type': 'BlogPosting',
         headline:
           // @ts-expect-error - deeply nested
-          headlineBlock?.model.blocks[0].model.blocks[0].model.text ?? null,
+          headlineBlock?.model.blocks[0]?.model.blocks[0]?.model.text ?? null,
         publisher: {
           '@type': 'Organization',
           name: brandName,


### PR DESCRIPTION
Overall changes
======
- Adds optional chaining in the Live page SEO builder to ensure we don't attempt to access nested block structure for header blocks that may not exist

Testing
======
1. Visit http://localhost:7081/urdu/live/pakistan-61546283?renderer_env=live&page=3
2. Confirm page loads as expected

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
