### PR TITLE
Disable service worker caching on localhost

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-undef */
 /* eslint-disable no-restricted-globals */
-const version = 'v0.2.1c';
+const version = 'v0.2.2';
 const cacheName = 'simorghCache_v1';
 
 const service = self.location.pathname.split('/')[1];

--- a/public/sw.js
+++ b/public/sw.js
@@ -7,13 +7,13 @@ const version = 'v0.2.2';
 const cacheName = 'simorghCache_v1';
 
 const service = self.location.pathname.split('/')[1];
-const has_offline_page_functionality = false;
+const hasOfflinePageFunctionality = false;
 const OFFLINE_PAGE = `/${service}/offline`;
 
 self.addEventListener('install', event => {
   event.waitUntil(async () => {
     const cache = await caches.open(cacheName);
-    if (has_offline_page_functionality) await cache.add(OFFLINE_PAGE);
+    if (hasOfflinePageFunctionality) await cache.add(OFFLINE_PAGE);
   });
 });
 
@@ -58,10 +58,7 @@ const fetchEventHandler = async event => {
         return response;
       })(),
     );
-  } else if (
-    has_offline_page_functionality &&
-    event.request.mode === 'navigate'
-  ) {
+  } else if (hasOfflinePageFunctionality && event.request.mode === 'navigate') {
     event.respondWith(async () => {
       try {
         const preloadResponse = await event.preloadResponse;

--- a/public/sw.js
+++ b/public/sw.js
@@ -18,7 +18,6 @@ self.addEventListener('install', event => {
 });
 
 const fetchEventHandler = async event => {
-  if (self.location.hostname === 'localhost') return;
   if (
     /^https:\/\/ichef(\.test)?\.bbci\.co\.uk\/(news|images|ace\/(standard|ws))\/.+.webp$/.test(
       event.request.url,
@@ -43,6 +42,7 @@ const fetchEventHandler = async event => {
       );
     }
   } else if (
+    self.location.hostname !== 'localhost' &&
     /((\/cwr\.js$)|(\.woff2$)|(modern\.frosted_promo+.*?\.js$)|(\/moment-lib+.*?\.js$))/.test(
       event.request.url,
     )

--- a/public/sw.js
+++ b/public/sw.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-undef */
 /* eslint-disable no-restricted-globals */
-const version = 'v0.2.1a';
+const version = 'v0.2.1c';
 const cacheName = 'simorghCache_v1';
 
 const service = self.location.pathname.split('/')[1];
@@ -18,6 +18,7 @@ self.addEventListener('install', event => {
 });
 
 const fetchEventHandler = async event => {
+  if (self.location.hostname === 'localhost') return;
   if (
     /^https:\/\/ichef(\.test)?\.bbci\.co\.uk\/(news|images|ace\/(standard|ws))\/.+.webp$/.test(
       event.request.url,

--- a/src/sw.test.js
+++ b/src/sw.test.js
@@ -28,6 +28,7 @@ describe('Service Worker', () => {
     /* eslint-disable-next-line no-restricted-globals */
     global.self.location = {
       pathname: 'https://www.bbc.com/mundo/articles/c2343244t',
+      hostname: 'www.bbc.com',
     };
   });
 
@@ -167,7 +168,24 @@ describe('Service Worker', () => {
       /* eslint-disable-next-line no-restricted-globals */
       global.self.location = {
         pathname: 'https://www.bbc.com/mundo/articles/c2343244t',
+        hostname: 'www.bbc.com',
       };
+    });
+
+    it('does not cache on localhost', async () => {
+      global.self.location.hostname = 'localhost';
+
+      ({ fetchEventHandler } = await import('./service-worker-test'));
+
+      const event = {
+        request: new Request(global.self.location.pathname),
+        respondWith: jest.fn(),
+      };
+
+      await fetchEventHandler(event);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(event.respondWith).not.toHaveBeenCalled();
     });
 
     describe('when url is not cacheable', () => {


### PR DESCRIPTION
Overall changes
======
Fixes an issue with the service worker causing a blank screen on all pages apart from homepage when running `yarn dev`

Code changes
======
- Disable caching on localhost
- Update tests

Testing
======

Localhost Only:
Run `yarn dev`