### PR TITLE
Unit test to ensure service worker version number correct

### DIFF
--- a/src/sw.test.js
+++ b/src/sw.test.js
@@ -312,7 +312,7 @@ describe('Service Worker', () => {
 
       const hash = createHash('md5').update(swFile).digest('hex');
 
-      // On failure: increment the version number in ../../public/sw.js & update values in CURRENT_VERSION
+      // On failure: increment the version number in ../public/sw.js & update values in CURRENT_VERSION
       expect(CURRENT_VERSION.fileContentHash).toBe(hash);
     });
   });

--- a/src/sw.test.js
+++ b/src/sw.test.js
@@ -308,9 +308,9 @@ describe('Service Worker', () => {
     });
 
     it(`version number should match file content`, async () => {
-      const swFile = serviceWorker.toString();
-
-      const hash = createHash('md5').update(swFile).digest('hex');
+      const hash = createHash('md5')
+        .update(serviceWorker.toString())
+        .digest('hex');
 
       // On failure: increment the version number in ../public/sw.js & update values in CURRENT_VERSION
       expect(CURRENT_VERSION.fileContentHash).toBe(hash);

--- a/src/sw.test.js
+++ b/src/sw.test.js
@@ -3,11 +3,12 @@
 import fs from 'fs';
 import { join, resolve } from 'path';
 import fetchMock from 'jest-fetch-mock';
+import { createHash } from 'crypto';
 
 const serviceWorker = fs.readFileSync(join(__dirname, '..', 'public/sw.js'));
 
 const serviceWorkerCode = `${serviceWorker.toString()}
-export { fetchEventHandler };
+export { fetchEventHandler, version };
 `;
 
 fs.writeFileSync(
@@ -291,6 +292,28 @@ describe('Service Worker', () => {
         expect(fetchMock).toHaveBeenCalledWith(assetUrl);
         expect(fetchedCache[event.request]).toStrictEqual(mockResponse.clone());
       });
+    });
+  });
+
+  describe('version', () => {
+    const CURRENT_VERSION = {
+      number: 'v0.2.2',
+      fileContentHash: '3526df1507b20c47700339c8d7eb6c83',
+    };
+
+    it(`version number should be ${CURRENT_VERSION.number}`, async () => {
+      const { version } = await import('./service-worker-test');
+
+      expect(CURRENT_VERSION.number).toBe(version);
+    });
+
+    it(`version number should match file content`, async () => {
+      const swFile = serviceWorker.toString();
+
+      const hash = createHash('md5').update(swFile).digest('hex');
+
+      // On failure: increment the version number in ../../public/sw.js & update values in CURRENT_VERSION
+      expect(CURRENT_VERSION.fileContentHash).toBe(hash);
     });
   });
 });


### PR DESCRIPTION
Code changes
======
- Adds a test to the service worker suite to ensure that the version number is kept up-to-date as we update the service worker functionality

Testing
======
PR Checks only
