### PR TITLE
Add teads.tv fonts to the CSP

### DIFF
--- a/src/server/utilities/cspHeader/directives.js
+++ b/src/server/utilities/cspHeader/directives.js
@@ -45,7 +45,11 @@ const advertisingDirectives = {
   ],
   defaultSrc: [...bbcDomains, 'https://*.googlesyndication.com'],
   styleSrc: ['https://fonts.googleapis.com'],
-  fontSrc: ['https://fonts.gstatic.com'],
+  fontSrc: [
+    'https://fonts.gstatic.com',
+    'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/',
+    'https://*.teads.tv',
+  ],
 };
 
 const directives = {
@@ -270,14 +274,12 @@ const directives = {
     canonicalLive: [
       ...bbcDomains,
       'data:', // localstorage
-      'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/', // Adverts
       ...advertisingDirectives.fontSrc,
     ],
     ampNonLive: [...bbcDomains],
     canonicalNonLive: [
       ...bbcDomains,
       'data:',
-      'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/', // Adverts
       ...advertisingDirectives.fontSrc,
     ],
   },

--- a/src/server/utilities/cspHeader/index.test.js
+++ b/src/server/utilities/cspHeader/index.test.js
@@ -134,6 +134,7 @@ describe('cspHeader', () => {
         'data:',
         'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/',
         'https://fonts.gstatic.com',
+        'https://*.teads.tv',
       ].sort(),
       frameSrcExpectation: [
         ...bbcDomains,
@@ -324,6 +325,7 @@ describe('cspHeader', () => {
         'data:',
         'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/',
         'https://fonts.gstatic.com',
+        'https://*.teads.tv',
       ].sort(),
       frameSrcExpectation: [
         ...bbcDomains,


### PR DESCRIPTION
Overall changes
======
Add teads.tv as a permitted font source in the Content Security Policy

Code changes
======
- Update CSP
- Refactor to include font-awesome 
- Update tests

Testing
======
- PR Checks

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
