### PR TITLE
Allows service worker to run in production mode only

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-undef */
 /* eslint-disable no-restricted-globals */
-const version = 'v0.2.2';
+const version = 'v0.2.3';
 const cacheName = 'simorghCache_v1';
 
 const service = self.location.pathname.split('/')[1];
@@ -42,7 +42,6 @@ const fetchEventHandler = async event => {
       );
     }
   } else if (
-    self.location.hostname !== 'localhost' &&
     /((\/cwr\.js$)|(\.woff2$)|(modern\.frosted_promo+.*?\.js$)|(\/moment-lib+.*?\.js$))/.test(
       event.request.url,
     )

--- a/src/app/components/ServiceWorker/index.tsx
+++ b/src/app/components/ServiceWorker/index.tsx
@@ -38,16 +38,20 @@ const AmpServiceWorker = ({
 export default () => {
   const { swPath, service } = useContext(ServiceContext);
   const { isAmp, canonicalLink } = useContext(RequestContext);
+  const nodeEnvironment = process.env.NODE_ENV;
   const swSrc = `${getEnvConfig().SIMORGH_BASE_URL}/${service}${swPath}`;
 
   useEffect(() => {
     const shouldInstallServiceWorker =
-      swPath && onClient() && 'serviceWorker' in navigator;
+      swPath &&
+      onClient() &&
+      'serviceWorker' in navigator &&
+      nodeEnvironment === 'production';
 
     if (shouldInstallServiceWorker) {
       navigator.serviceWorker.register(`/${service}${swPath}`);
     }
-  }, [swPath, service]);
+  }, [swPath, service, nodeEnvironment]);
 
   return !isLocal() && isAmp && swPath ? (
     <>

--- a/src/sw.test.js
+++ b/src/sw.test.js
@@ -297,8 +297,8 @@ describe('Service Worker', () => {
 
   describe('version', () => {
     const CURRENT_VERSION = {
-      number: 'v0.2.2',
-      fileContentHash: '3526df1507b20c47700339c8d7eb6c83',
+      number: 'v0.2.3',
+      fileContentHash: '09621546be5598b0536276a54011ca94',
     };
 
     it(`version number should be ${CURRENT_VERSION.number}`, async () => {


### PR DESCRIPTION
Overall changes
======
Ensures the service worker can run on local environments, but only when running `yarn build; yarn start`, as there was an issue with webpack + cached files.

Code changes
======
- Update service worker to remove localhost check & update tests
- Update service worker component to only register the service worker when in production mode (`yarn dev` = development mode whilst `yarn start` is production mode, as well as the test & live environments)

Testing
======
- Run `yarn dev` & check service worker in incognito browser - service worker not activated
- Run `yarn build; yarn start` & check service worker in incognito browser - service worker is activated

