### PR TITLE
Fix Uzbek latn `lang` config value

### DIFF
--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -45,8 +45,8 @@ const defaultCyrillicConfig = {
   datetimeLocale: `uz`,
   externalLinkText: ', ташқи',
   homePageTitle: 'Бош саҳифа',
-  lang: `uz-Cyrl`,
-  locale: `uz-UZ`,
+  lang: 'uz-cyrl',
+  locale: 'uz-UZ',
   // valid ISO 639-1 code - this is not the same as lang! see explanation in #3405
   isoLang: 'uz',
   noBylinesPolicy:
@@ -381,8 +381,8 @@ export const service: UzbekConfig = {
     datetimeLocale: `uz-latn`,
     externalLinkText: ', tashqi',
     homePageTitle: 'Bosh sahifa',
-    lang: `uz-Cyrl`,
-    locale: `uz-UZ`,
+    lang: 'uz-latn',
+    locale: 'uz-UZ',
     // valid ISO 639-1 code - this is not the same as lang! see explanation in #3405
     isoLang: 'uz',
     noBylinesPolicy:


### PR DESCRIPTION
Summary
======
- Fixes the uzbek-latn lang value to be correct for Uzbek Latin language


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

