### PR TITLE
Update Sinhala and Tamil navs to add Health, Sport, History

### DIFF
--- a/src/app/lib/config/services/sinhala.ts
+++ b/src/app/lib/config/services/sinhala.ts
@@ -43,7 +43,7 @@ export const service: DefaultServiceConfig = {
     script: sinhalese,
     manifestPath: '/sinhala/manifest.json',
     swPath: '/sw.js',
-    homePageTitle: 'මුල් පිටුව',
+    homePageTitle: 'ප්‍රධාන පුවත්',
     showAdPlaceholder: true,
     showRelatedTopics: true,
     translations: {
@@ -57,7 +57,7 @@ export const service: DefaultServiceConfig = {
         advertisementLabel: 'වෙළෙඳ දැන්වීමක් ',
       },
       seeAll: 'සියල්ල දැකගන්න',
-      home: 'මුල් පිටුව',
+      home: 'ප්‍රධාන පුවත්',
       currentPage: 'දැන් සිටින පිටුව',
       skipLinkText: 'අන්තර්ගතයට පිවිසෙන්න',
       relatedContent: 'මේ පුවතට සම්බන්ධ තවත් විස්තර',
@@ -317,7 +317,7 @@ export const service: DefaultServiceConfig = {
     timezone: 'GMT',
     navigation: [
       {
-        title: 'මුල් පිටුව',
+        title: 'ප්‍රධාන පුවත්',
         url: '/sinhala',
       },
       {
@@ -333,8 +333,12 @@ export const service: DefaultServiceConfig = {
         url: '/sinhala/topics/crldzm9n2lnt',
       },
       {
-        title: 'කලා',
-        url: '/sinhala/topics/c7zp5zxk8jxt',
+        title: 'ක්‍රීඩා',
+        url: '/sinhala/topics/cvjp2jy9g2qt',
+      },
+      {
+        title: 'සෞඛ්‍ය',
+        url: '/sinhala/topics/cz74k723j57t',
       },
     ],
   },

--- a/src/app/lib/config/services/tamil.ts
+++ b/src/app/lib/config/services/tamil.ts
@@ -430,6 +430,14 @@ export const service: DefaultServiceConfig = {
         url: '/tamil/topics/cz74k7p3qw7t',
       },
       {
+        title: 'உடல்நலம்',
+        url: '/tamil/topics/cyx5kxzdn9dt',
+      },
+      {
+        title: 'வரலாறு',
+        url: '/tamil/topics/cxnyknvykxjt',
+      },
+      {
         title: 'விளையாட்டு',
         url: '/tamil/topics/cdr56rv4qwdt',
       },


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Updates the wording for 'Home' in the Sinhala nav and page title.
- Replaces the Art topic link with Sport and Health in the Sinhala navigation
- Adds Health and History to the Tamil navigation

Code changes
======
- Edited Navigation section, title and home of src/app/lib/config/services/tamil.ts 
- Edited Navigation section, title and home of src/app/lib/config/services/sinhala.ts 


Testing
======
1. Open Tamil's front page, the third link in the nav should be  Сводка потерь and open /russian/topics/cqx9qqylwvgt
2. Open Sinhala's front page, the last two link in the nav should be ක්‍රීඩා (/sinhala/topics/cvjp2jy9g2qt) and සෞඛ්‍ය (/sinhala/topics/cz74k723j57t) the first item in the nav should be ප්‍රධාන පුවත්
3. The Sinhala page title should be "රධාන පුවත් - BBC News සිංහල"

![tamil_nav](https://github.com/user-attachments/assets/b13b0564-95b1-429a-81da-4addac268b19)
![sinhala_nav](https://github.com/user-attachments/assets/91d725fa-c25a-420d-940a-4bf00b904028)
![sinhala_title](https://github.com/user-attachments/assets/367fccd7-4a46-4748-9e99-484c8f30447d)



Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
