### PR TITLE
spike: improve sw caching

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -50,7 +50,7 @@ const fetchEventHandler = async event => {
     }
   } else if (
     (
-      event.request.url.indexOf('https://static.files.bbci.co.uk/') !== -1 &&
+      event.request.url.indexOf('https://static.files.bbci.co.uk/') === 0 &&
       /((\.woff2$)|(modern\.frosted_promo+.*?\.js$)|(\/moment-lib+.*?\.js$)|(\/images\/icons\/icon-.*?\.png$))/.test(
         event.request.url,
       )

--- a/public/sw.js
+++ b/public/sw.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-undef */
 /* eslint-disable no-restricted-globals */
-const version = 'v0.2.2';
+const version = 'v0.2.3';
 const cacheName = 'simorghCache_v1';
 
 const service = self.location.pathname.split('/')[1];
@@ -16,6 +16,13 @@ self.addEventListener('install', event => {
     if (hasOfflinePageFunctionality) await cache.add(OFFLINE_PAGE);
   });
 });
+
+// versioned JS files
+const cacheableFiles = [
+  'https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.9.2.js',
+  'https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/smarttag-5.29.4.min.js'
+];
+
 
 const fetchEventHandler = async event => {
   if (
@@ -42,10 +49,14 @@ const fetchEventHandler = async event => {
       );
     }
   } else if (
-    self.location.hostname !== 'localhost' &&
-    /((\/cwr\.js$)|(\.woff2$)|(modern\.frosted_promo+.*?\.js$)|(\/moment-lib+.*?\.js$))/.test(
-      event.request.url,
+    (
+      event.request.url.indexOf('https://static.files.bbci.co.uk/') !== -1 &&
+      /((\.woff2$)|(modern\.frosted_promo+.*?\.js$)|(\/moment-lib+.*?\.js$)|(\/images\/icons\/icon-.*?\.png$))/.test(
+        event.request.url,
+      )
     )
+    ||
+    cacheableFiles.includes(event.request.url)
   ) {
     event.respondWith(
       (async () => {

--- a/src/sw.test.js
+++ b/src/sw.test.js
@@ -297,8 +297,8 @@ describe('Service Worker', () => {
 
   describe('version', () => {
     const CURRENT_VERSION = {
-      number: 'v0.2.2',
-      fileContentHash: '3526df1507b20c47700339c8d7eb6c83',
+      number: 'v0.2.3',
+      fileContentHash: '6e748772bde8e432c170da9b26f7a7f1',
     };
 
     it(`version number should be ${CURRENT_VERSION.number}`, async () => {


### PR DESCRIPTION
improves caching to:

- avoid localhost caching by targeting absolute URLs
- adds caching for versioned JS files