### PR TITLE
Decouple variation hook from other Optimizely hooks/components

### DIFF
--- a/src/app/hooks/useOptimizelyScrollDepth/index.jsx
+++ b/src/app/hooks/useOptimizelyScrollDepth/index.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, useContext } from 'react';
 import { OptimizelyContext } from '@optimizely/react-sdk';
 import { RequestContext } from '#contexts/RequestContext';
-import useOptimizelyVariation from '#hooks/useOptimizelyVariation';
 import OPTIMIZELY_CONFIG from '#lib/config/optimizely';
 
 const getScrollDepth = () =>
@@ -21,7 +20,9 @@ const useOptimizelyScrollDepth = () => {
   const [scrollSeventyFive, setScrollSeventyFive] = useState(false);
   const [scrollHundred, setScrollHundred] = useState(false);
 
-  const experimentVariation = useOptimizelyVariation(OPTIMIZELY_CONFIG.flagKey);
+  const experimentVariation =
+    optimizely?.getVariation(OPTIMIZELY_CONFIG.ruleKey) || null;
+
   const hasVariationKey = experimentVariation !== null;
 
   const sendScrollEvents = hasVariationKey && !isAmp;

--- a/src/app/hooks/useOptimizelyScrollDepth/index.test.jsx
+++ b/src/app/hooks/useOptimizelyScrollDepth/index.test.jsx
@@ -8,15 +8,13 @@ import {
 import { OptimizelyProvider } from '@optimizely/react-sdk';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
-import useOptimizelyVariation from '#hooks/useOptimizelyVariation';
 import useOptimizelyScrollDepth from '.';
-
-jest.mock('#hooks/useOptimizelyVariation', () => jest.fn());
 
 const optimizelyMock = {
   onReady: jest.fn(() => Promise.resolve()),
   setUser: jest.fn(() => Promise.resolve()),
   track: jest.fn(),
+  getVariation: jest.fn(),
 };
 
 const wrapper = ({
@@ -43,6 +41,7 @@ describe('useOptimizelyScrollDepth', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    optimizelyMock.getVariation.mockReturnValue('variationKey');
   });
 
   afterEach(() => {
@@ -50,7 +49,7 @@ describe('useOptimizelyScrollDepth', () => {
   });
 
   it('should call add event listener with scroll', () => {
-    renderHook(() => useOptimizelyScrollDepth());
+    renderHook(() => useOptimizelyScrollDepth(), { wrapper });
 
     expect(addEventListenerSpy).toHaveBeenCalledWith(
       'scroll',
@@ -60,7 +59,7 @@ describe('useOptimizelyScrollDepth', () => {
   });
 
   it('should call remove event listener with scroll', () => {
-    renderHook(() => useOptimizelyScrollDepth());
+    renderHook(() => useOptimizelyScrollDepth(), { wrapper });
 
     cleanup();
     expect(removeEventListenerSpy).toHaveBeenCalledWith(
@@ -86,7 +85,7 @@ describe('useOptimizelyScrollDepth', () => {
   });
 
   it('should not call Optimizely track function for users not in an experiment', async () => {
-    useOptimizelyVariation.mockReturnValue(null);
+    optimizelyMock.getVariation.mockReturnValue(null);
 
     const { result } = renderHook(() => useOptimizelyScrollDepth(), {
       wrapper,

--- a/src/app/legacy/containers/OptimizelyArticleCompleteTracking/index.jsx
+++ b/src/app/legacy/containers/OptimizelyArticleCompleteTracking/index.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useContext, useEffect, useRef } from 'react';
 import { OptimizelyContext } from '@optimizely/react-sdk';
 import { RequestContext } from '#contexts/RequestContext';
-import useOptimizelyVariation from '#hooks/useOptimizelyVariation';
 import OPTIMIZELY_CONFIG from '#lib/config/optimizely';
 
 const OptimizelyArticleCompleteTracking = () => {
@@ -12,7 +11,8 @@ const OptimizelyArticleCompleteTracking = () => {
   const [pageCompleteSent, setPageCompleteSent] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
 
-  const experimentVariation = useOptimizelyVariation(OPTIMIZELY_CONFIG.flagKey);
+  const experimentVariation =
+    optimizely?.getVariation(OPTIMIZELY_CONFIG.ruleKey) || null;
 
   const sendPageCompleteEvent =
     experimentVariation && !isAmp && !pageCompleteSent && isVisible;

--- a/src/app/legacy/containers/OptimizelyArticleCompleteTracking/index.test.jsx
+++ b/src/app/legacy/containers/OptimizelyArticleCompleteTracking/index.test.jsx
@@ -15,6 +15,7 @@ const optimizely = {
   onReady: jest.fn(() => Promise.resolve()),
   track: jest.fn(),
   setUser: jest.fn(() => Promise.resolve()),
+  getVariation: jest.fn(),
 };
 
 const observers = new Map();
@@ -77,6 +78,7 @@ beforeEach(() => {
   jest.useFakeTimers();
   console.error = jest.fn();
   global.IntersectionObserver = IntersectionObserver;
+  optimizely.getVariation.mockReturnValue('variation_1');
 });
 
 afterEach(() => {
@@ -129,6 +131,7 @@ describe('Optimizely Page Complete tracking', () => {
   });
 
   it('should not send tracking event when element is in view, but not in experiment variation', async () => {
+    optimizely.getVariation.mockReturnValue(null);
     useOptimizelyVariation.mockReturnValue(null);
 
     const { container } = render(


### PR DESCRIPTION
Summary
======
- Decouples the `useOptimizelyVariation` from other Optimizely hooks/components
- This is because the `useOptimizelyVariation` hook is used for client-side experiments, meaning its use in components such as `OptimizelyArticleCompleteTracking` will not work in server-side experiments as it will always return `null` as the `isClientSide` value will be `false` in that use-case

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

