### PR TITLE
Top Bar OJ - Move Optimizely HOC to root layout wrapper

### DIFF
--- a/src/app/components/PageLayoutWrapper/index.test.tsx
+++ b/src/app/components/PageLayoutWrapper/index.test.tsx
@@ -9,7 +9,6 @@ describe('PageLayoutWrapper', () => {
   it('should render default page wrapper with children', async () => {
     const { container } = render(
       <PageLayoutWrapper
-        // @ts-expect-error - metadata type is mocked for test purposes
         pageData={{ metadata: { type: 'test-page-type' } }}
         status={200}
       >

--- a/src/app/components/PageLayoutWrapper/index.tsx
+++ b/src/app/components/PageLayoutWrapper/index.tsx
@@ -9,6 +9,7 @@ import GlobalStyles from '#psammead/psammead-styles/src/global-styles';
 import { PageTypes } from '#app/models/types/global';
 import useOptimizelyMvtVariation from '#app/hooks/useOptimizelyMvtVariation';
 import OPTIMIZELY_CONFIG from '#app/lib/config/optimizely';
+import withOptimizelyProvider from '#app/legacy/containers/PageHandlers/withOptimizelyProvider';
 import { TopStoryItem } from '../../pages/ArticlePage/PagePromoSections/TopStoriesSection/types';
 import WebVitals from '../../legacy/containers/WebVitals';
 import HeaderContainer from '../../legacy/containers/Header';
@@ -243,4 +244,4 @@ const PageLayoutWrapper = ({
   );
 };
 
-export default PageLayoutWrapper;
+export default withOptimizelyProvider(PageLayoutWrapper);

--- a/src/app/pages/ArticlePage/index.tsx
+++ b/src/app/pages/ArticlePage/index.tsx
@@ -1,7 +1,4 @@
-import withOptimizelyProvider from '#app/legacy/containers/PageHandlers/withOptimizelyProvider';
 import ArticlePage from './ArticlePage';
 import applyBasicPageHandlers from '../utils/applyBasicPageHandlers';
 
-const ArticlePageWithOptimizely = withOptimizelyProvider(ArticlePage);
-
-export default applyBasicPageHandlers(ArticlePageWithOptimizely);
+export default applyBasicPageHandlers(ArticlePage);


### PR DESCRIPTION
Summary
======
- Moves the `withOptimizelyProvider` HOC to the root layout component for the Top Bar OJ experiment as components in the experiment sit outside of the ArticlePage component

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

