### PR TITLE
[WORLDSERVICE-594] Ensure application cypress tests are running to check if service worker is available

### DIFF
--- a/cypress/e2e/application/index.cy.js
+++ b/cypress/e2e/application/index.cy.js
@@ -23,25 +23,9 @@ describe('Application', () => {
           });
         });
 
-        it(`should return a 200 status code for ${service}'s article service worker`, () => {
-          cy.testResponseCodeAndType({
-            path: `/${config[service].name}/articles/sw.js`,
-            responseCode: 200,
-            type: 'application/javascript',
-          });
-        });
-
         it(`should return a 200 status code for ${service} manifest file`, () => {
           cy.testResponseCodeAndType({
             path: `/${config[service].name}/manifest.json`,
-            responseCode: 200,
-            type: 'application/json',
-          });
-        });
-
-        it(`should return a 200 status code for ${service} article manifest file`, () => {
-          cy.testResponseCodeAndType({
-            path: `/${config[service].name}/articles/manifest.json`,
             responseCode: 200,
             type: 'application/json',
           });


### PR DESCRIPTION
Resolves JIRA: https://jira.dev.bbc.co.uk/browse/WORLDSERVICE-594

Summary
======
- Rename cypress/e2e/application/index.js -> cypress/e2e/application/index.cy.js
- Delete outdated tests

Code changes
======


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps

Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

