### PR TITLE
Enable lite for burmese

### DIFF
--- a/src/app/components/LiteSiteCta/liteSiteConfig.tsx
+++ b/src/app/components/LiteSiteCta/liteSiteConfig.tsx
@@ -8,4 +8,4 @@ export const defaultTranslations = {
   dataSaving: 'Data saving version',
 };
 
-export const liteEnabledServices: Services[] = ['gahuza'];
+export const liteEnabledServices: Services[] = ['burmese', 'gahuza'];


### PR DESCRIPTION
Summary
======
Enables lite for burmese - this will display the lite site info on the top of all lite articles

Code changes
======
- Add burmese to the list of lite enabled services


Developer Checklist - N/A
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [x] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [x] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. http://localhost:7080/burmese/articles/c4w9w44werxo.lite?renderer_env=test - the lite site info should be displayed at the top of the page


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

