### PR TITLE
Burmese: add Earthquake topic to nav and update lite CTA

### DIFF
--- a/src/app/lib/config/services/burmese.ts
+++ b/src/app/lib/config/services/burmese.ts
@@ -367,8 +367,8 @@ export const service: DefaultServiceConfig = {
         url: '/burmese',
       },
       {
-      title: 'မြန်မာငလျင်',
-      url: '/burmese/topics/c793wppj0r1t',
+        title: 'မြန်မာငလျင်',
+        url: '/burmese/topics/c793wppj0r1t',
       },
       {
         title: 'မြန်မာ့ရေးရာ',

--- a/src/app/lib/config/services/burmese.ts
+++ b/src/app/lib/config/services/burmese.ts
@@ -85,7 +85,7 @@ export const service: DefaultServiceConfig = {
         informationPageLink:
           'https://www.bbc.com/burmese/articles/cwy69wyx71go',
         dataSaving: 'ဒေတာကုန်ကျမှုသက်သာစေသည့် ဝက်ဘ်စာမျက်နှာ',
-        articleDataSavingLinkText: 'စာသား သက်သက်ဖတ်ရန်',
+        articleDataSavingLinkText: 'ဒေတာကုန်ကျမှုသက်သာအောင် စာသားသက်သက်ဖတ်ရ',
       },
       mediaAssetPage: {
         mediaPlayer: 'မီဒီယာ ပလေယာ',
@@ -365,6 +365,10 @@ export const service: DefaultServiceConfig = {
       {
         title: 'ပင်မစာမျက်နှာ',
         url: '/burmese',
+      },
+      {
+      title: 'မြန်မာငလျင်',
+      url: '/burmese/topics/c793wppj0r1t',
       },
       {
         title: 'မြန်မာ့ရေးရာ',


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Add Earthquake topic link to the Burmese navigation
- Updates lite CTA with text that makes more explicit the data saving benefits of the lite site


Code changes
======

- Edited liteSite section of src/app/lib/config/services/burmese.ts 
- Edited Navigation section of src/app/lib/config/services/burmese.ts to add earthquake topic link in second position


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._

![image](https://github.com/user-attachments/assets/5d803f8e-3b2d-4c7a-aec3-7cf705528e0b)
![image](https://github.com/user-attachments/assets/08143c0d-2b29-465b-bfec-15be7ccbcf51)






Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

