### PR TITLE
WORLDSERVICE-469 Update the MAP (Media Article Page) to support PV

### DIFF
--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -253,11 +253,12 @@ const MediaLoader = ({ blocks, className, embedded, uniqueId }: Props) => {
           <Metadata blocks={blocks} embedURL={playerConfig?.externalEmbedUrl} />
         )
       }
-      {showPortraitTitle && onMapPage (
-        <strong css={styles.titlePortrait}>
-          {translations.media.watchMoments || 'Watch Moments'}
-        </strong>
-      )}
+      {showPortraitTitle &&
+        onMapPage &&(
+          <strong css={styles.titlePortrait}>
+            {translations.media.watchMoments || 'Watch Moments'}
+          </strong>
+        )}
       <figure
         data-e2e="media-loader__container"
         className={className}

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -243,6 +243,8 @@ const MediaLoader = ({ blocks, className, embedded, uniqueId }: Props) => {
 
   const showPortraitTitle = orientation === 'portrait' && !embedded;
 
+  const onMapPage = false;
+
   return (
     <>
       {
@@ -251,7 +253,7 @@ const MediaLoader = ({ blocks, className, embedded, uniqueId }: Props) => {
           <Metadata blocks={blocks} embedURL={playerConfig?.externalEmbedUrl} />
         )
       }
-      {showPortraitTitle && (
+      {showPortraitTitle && onMapPage (
         <strong css={styles.titlePortrait}>
           {translations.media.watchMoments || 'Watch Moments'}
         </strong>

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -243,7 +243,7 @@ const MediaLoader = ({ blocks, className, embedded, uniqueId }: Props) => {
 
   const showPortraitTitle = orientation === 'portrait' && !embedded;
 
-  const onMapPage = false;
+  const onMapPage = pageType === MEDIA_ARTICLE_PAGE ? false : true;
 
   return (
     <>
@@ -253,12 +253,11 @@ const MediaLoader = ({ blocks, className, embedded, uniqueId }: Props) => {
           <Metadata blocks={blocks} embedURL={playerConfig?.externalEmbedUrl} />
         )
       }
-      {showPortraitTitle &&
-        onMapPage &&(
-          <strong css={styles.titlePortrait}>
-            {translations.media.watchMoments || 'Watch Moments'}
-          </strong>
-        )}
+      {showPortraitTitle && onMapPage && (
+        <strong css={styles.titlePortrait}>
+          {translations.media.watchMoments || 'Watch Moments'}
+        </strong>
+      )}
       <figure
         data-e2e="media-loader__container"
         className={className}

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -243,7 +243,7 @@ const MediaLoader = ({ blocks, className, embedded, uniqueId }: Props) => {
 
   const showPortraitTitle = orientation === 'portrait' && !embedded;
 
-  const onMapPage = pageType === MEDIA_ARTICLE_PAGE ? false : true;
+  const onMapPage = pageType !== MEDIA_ARTICLE_PAGE;
 
   return (
     <>

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -241,9 +241,8 @@ const MediaLoader = ({ blocks, className, embedded, uniqueId }: Props) => {
 
   const hasPlaceholder = Boolean(showPlaceholder && placeholderSrc);
 
-  const showPortraitTitle = orientation === 'portrait' && !embedded;
-
-  const onMapPage = pageType !== MEDIA_ARTICLE_PAGE;
+  const showPortraitTitle =
+    orientation === 'portrait' && pageType !== MEDIA_ARTICLE_PAGE && !embedded;
 
   return (
     <>
@@ -253,7 +252,7 @@ const MediaLoader = ({ blocks, className, embedded, uniqueId }: Props) => {
           <Metadata blocks={blocks} embedURL={playerConfig?.externalEmbedUrl} />
         )
       }
-      {showPortraitTitle && onMapPage && (
+      {showPortraitTitle && (
         <strong css={styles.titlePortrait}>
           {translations.media.watchMoments || 'Watch Moments'}
         </strong>


### PR DESCRIPTION
Resolves JIRA: [WORLDSERVICE-469](https://jira.dev.bbc.co.uk/browse/WORLDSERVICE-469)

Summary
======
Ensures that any media article page handles `PVs` according to UX specs

Code changes
======
Added logic that checks if a `PV` is on a `MEDIA_ARTICLE_PAGE` page

if on a `MEDIA_ARTICLE_PAGE` then `onMapPage` is set to `ture`

`onMapPage` is then used to decide whether to show `watchMoments` or not


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

