### PR TITLE
Add retryOnStatusCodeFailure to cy.visit

### DIFF
--- a/cypress/e2e/application/index.cy.js
+++ b/cypress/e2e/application/index.cy.js
@@ -39,7 +39,7 @@ describe('Application', () => {
               const topicPagePath = getTopicPagePath(currentPath);
               const fullPath = `${envConfig.baseUrl}${topicPagePath}`;
               cy.log(fullPath);
-              cy.visit(fullPath);
+              cy.visit(fullPath, { retryOnStatusCodeFailure: true });
             });
           }
         });

--- a/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
@@ -73,7 +73,7 @@ export const assertPageView = ({
 }) => {
   it(`should send a page view event with service = ${service}, page identifier = ${pageIdentifier}, application type = ${applicationType} and content type = ${contentType}`, () => {
     interceptATIAnalyticsBeacons();
-    cy.visit(path);
+    cy.visit(path, { retryOnStatusCodeFailure: true });
 
     const atiPageViewAlias = useReverb ? ATI_PAGE_VIEW_REVERB : ATI_PAGE_VIEW;
 

--- a/cypress/support/helpers/visitPage.js
+++ b/cypress/support/helpers/visitPage.js
@@ -27,5 +27,6 @@ export default (path, pageType) => {
 
   cy.visit(path, {
     failOnStatusCode,
+    retryOnStatusCodeFailure: true,
   });
 };

--- a/cypress/support/helpers/visitPage.js
+++ b/cypress/support/helpers/visitPage.js
@@ -3,6 +3,7 @@ export default (path, pageType) => {
   const isErrorPage = pageType.includes('error');
   const expectedStatus = isErrorPage ? 404 : 200;
   const failOnStatusCode = !isErrorPage;
+  const retryOnStatusCodeFailure = !isErrorPage;
 
   cy.testResponseCodeAndType({
     path,
@@ -27,6 +28,6 @@ export default (path, pageType) => {
 
   cy.visit(path, {
     failOnStatusCode,
-    retryOnStatusCodeFailure: true,
+    retryOnStatusCodeFailure,
   });
 };


### PR DESCRIPTION
Cypress tests on the pipeline keep failing out due to flaky 500's - maybe this will help?

Summary
======
https://docs.cypress.io/api/commands/request#Arguments

Code changes
======
- _A bullet point list of key code changes that have been made._


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

