### PR TITLE
Add retryOnStatusCodeFailure to an Articles Cypress test

### DIFF
--- a/cypress/e2e/pages/articles/tests.js
+++ b/cypress/e2e/pages/articles/tests.js
@@ -57,6 +57,7 @@ export default ({ service, pageType, variant = 'default' }) => {
             cy.request({
               url: href,
               failOnStatusCode: false,
+              retryOnStatusCodeFailure: true,
             }).then(resp => {
               expect(resp.status).to.not.equal(404);
             });


### PR DESCRIPTION
Resolves JIRA: 

Summary
======

Had 3 flaky fails in a row of this test  `it('should have an inline link to an article page', () => {` as the request to the inline link falsely failed out as a 404. Hopefullly this helps.

Command documented in [here](https://docs.cypress.io/api/commands/request)



Code changes
======
- _A bullet point list of key code changes that have been made._


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

