### PR TITLE
Add launch config to debug next app

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,12 @@
       "skipFiles": [
         "${workspaceFolder}/node_modules/**/*",
       ]
-    }
+    },
+    {
+      "name": "Debug Next.js: server-side",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "cd ws-nextjs-app && nvm use && yarn dev"
+    },
   ]
 }

--- a/.vscode/readme.md
+++ b/.vscode/readme.md
@@ -3,3 +3,5 @@
 The setup here mirrors the [`webpack:dev:server`](https://github.com/bbc/simorgh/blob/2944b327aac6fa22a8b5474d24e48fb631728431/package.json#L65) `package.json` script. You run it in the debug tab choosing 'Debug Express App'.
 
 ![A picture of the button to start debugging in VS Code](vscode-debug.png)
+
+You can debug the NextJS app by choosing 'Debug Next.js: server-side'; this command has been adapted from the docs [here](https://nextjs.org/docs/pages/building-your-application/configuring/debugging#debugging-with-vs-code)


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
This adds a launch config to allow for interactive debugging in VS Code of the NextJS app.


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [x] **Documentation**
    - [x] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

