### PR TITLE
WORLDSERVICE-682: RTL Mobile Space Fix

### DIFF
--- a/src/app/components/PageLayoutWrapper/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/PageLayoutWrapper/__snapshots__/index.test.tsx.snap
@@ -826,22 +826,21 @@ exports[`PageLayoutWrapper should render default page wrapper with children 1`] 
 .emotion-136 {
   position: absolute;
   width: calc(100vw - 0.8rem);
-  left: 0;
+  inset-inline-start: 0;
 }
 
 @media (min-width: 1041px) {
   .emotion-136 {
     width: calc(100vw + 0.8rem);
-    left: calc(-1 * (100vw - 1014px) / 2);
+    inset-inline-start: calc(-1 * (100vw - 1014px) / 2);
   }
 }
 
 .emotion-136::after {
   content: '';
   position: absolute;
-  bottom: 0;
-  right: 0;
-  left: -0.8rem;
+  inset-block-end: 0;
+  inset-inline: -0.8rem 0;
   width: calc(100% + 0.8rem);
   border-bottom: 0.0625rem solid #E6E8EA;
 }

--- a/src/app/legacy/containers/Header/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/Header/__snapshots__/index.test.jsx.snap
@@ -811,22 +811,21 @@ exports[`Header Snapshots should render correctly for WS TV page 1`] = `
 .emotion-135 {
   position: absolute;
   width: calc(100vw - 0.8rem);
-  left: 0;
+  inset-inline-start: 0;
 }
 
 @media (min-width: 1041px) {
   .emotion-135 {
     width: calc(100vw + 0.8rem);
-    left: calc(-1 * (100vw - 1014px) / 2);
+    inset-inline-start: calc(-1 * (100vw - 1014px) / 2);
   }
 }
 
 .emotion-135::after {
   content: '';
   position: absolute;
-  bottom: 0;
-  right: 0;
-  left: -0.8rem;
+  inset-block-end: 0;
+  inset-inline: -0.8rem 0;
   width: calc(100% + 0.8rem);
   border-bottom: 0.0625rem solid #E6E8EA;
 }
@@ -2141,22 +2140,21 @@ exports[`Header Snapshots should render correctly for WS on demand audio page 1`
 .emotion-135 {
   position: absolute;
   width: calc(100vw - 0.8rem);
-  left: 0;
+  inset-inline-start: 0;
 }
 
 @media (min-width: 1041px) {
   .emotion-135 {
     width: calc(100vw + 0.8rem);
-    left: calc(-1 * (100vw - 1014px) / 2);
+    inset-inline-start: calc(-1 * (100vw - 1014px) / 2);
   }
 }
 
 .emotion-135::after {
   content: '';
   position: absolute;
-  bottom: 0;
-  right: 0;
-  left: -0.8rem;
+  inset-block-end: 0;
+  inset-inline: -0.8rem 0;
   width: calc(100% + 0.8rem);
   border-bottom: 0.0625rem solid #E6E8EA;
 }
@@ -3471,22 +3469,21 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 .emotion-135 {
   position: absolute;
   width: calc(100vw - 0.8rem);
-  left: 0;
+  inset-inline-start: 0;
 }
 
 @media (min-width: 1041px) {
   .emotion-135 {
     width: calc(100vw + 0.8rem);
-    left: calc(-1 * (100vw - 1014px) / 2);
+    inset-inline-start: calc(-1 * (100vw - 1014px) / 2);
   }
 }
 
 .emotion-135::after {
   content: '';
   position: absolute;
-  bottom: 0;
-  right: 0;
-  left: -0.8rem;
+  inset-block-end: 0;
+  inset-inline: -0.8rem 0;
   width: calc(100% + 0.8rem);
   border-bottom: 0.0625rem solid #E6E8EA;
 }
@@ -4801,22 +4798,21 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 .emotion-135 {
   position: absolute;
   width: calc(100vw - 0.8rem);
-  left: 0;
+  inset-inline-start: 0;
 }
 
 @media (min-width: 1041px) {
   .emotion-135 {
     width: calc(100vw + 0.8rem);
-    left: calc(-1 * (100vw - 1014px) / 2);
+    inset-inline-start: calc(-1 * (100vw - 1014px) / 2);
   }
 }
 
 .emotion-135::after {
   content: '';
   position: absolute;
-  bottom: 0;
-  right: 0;
-  left: -0.8rem;
+  inset-block-end: 0;
+  inset-inline: -0.8rem 0;
   width: calc(100% + 0.8rem);
   border-bottom: 0.0625rem solid #E6E8EA;
 }

--- a/src/app/legacy/containers/Navigation/__snapshots__/index.canonical.test.jsx.snap
+++ b/src/app/legacy/containers/Navigation/__snapshots__/index.canonical.test.jsx.snap
@@ -190,22 +190,21 @@ exports[`Canonical Navigation snapshots should correctly render Canonical naviga
 .emotion-15 {
   position: absolute;
   width: calc(100vw - 0.8rem);
-  left: 0;
+  inset-inline-start: 0;
 }
 
 @media (min-width: 1041px) {
   .emotion-15 {
     width: calc(100vw + 0.8rem);
-    left: calc(-1 * (100vw - 1014px) / 2);
+    inset-inline-start: calc(-1 * (100vw - 1014px) / 2);
   }
 }
 
 .emotion-15::after {
   content: '';
   position: absolute;
-  bottom: 0;
-  right: 0;
-  left: -0.8rem;
+  inset-block-end: 0;
+  inset-inline: -0.8rem 0;
   width: calc(100% + 0.8rem);
   border-bottom: 0.0625rem solid #E6E8EA;
 }

--- a/src/app/legacy/containers/Navigation/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/Navigation/__snapshots__/index.test.jsx.snap
@@ -2747,22 +2747,21 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
 .emotion-113 {
   position: absolute;
   width: calc(100vw - 0.8rem);
-  left: 0;
+  inset-inline-start: 0;
 }
 
 @media (min-width: 1041px) {
   .emotion-113 {
     width: calc(100vw + 0.8rem);
-    left: calc(-1 * (100vw - 1014px) / 2);
+    inset-inline-start: calc(-1 * (100vw - 1014px) / 2);
   }
 }
 
 .emotion-113::after {
   content: '';
   position: absolute;
-  bottom: 0;
-  right: 0;
-  left: -0.8rem;
+  inset-block-end: 0;
+  inset-inline: -0.8rem 0;
   width: calc(100% + 0.8rem);
   border-bottom: 0.0625rem solid #E6E8EA;
 }
@@ -3513,22 +3512,21 @@ exports[`Navigation Container should correctly render canonical navigation on no
 .emotion-107 {
   position: absolute;
   width: calc(100vw - 0.8rem);
-  left: 0;
+  inset-inline-start: 0;
 }
 
 @media (min-width: 1041px) {
   .emotion-107 {
     width: calc(100vw + 0.8rem);
-    left: calc(-1 * (100vw - 1014px) / 2);
+    inset-inline-start: calc(-1 * (100vw - 1014px) / 2);
   }
 }
 
 .emotion-107::after {
   content: '';
   position: absolute;
-  bottom: 0;
-  right: 0;
-  left: -0.8rem;
+  inset-block-end: 0;
+  inset-inline: -0.8rem 0;
   width: calc(100% + 0.8rem);
   border-bottom: 0.0625rem solid #E6E8EA;
 }
@@ -4259,22 +4257,21 @@ exports[`Navigation Container should correctly render canonical navigation on no
 .emotion-107 {
   position: absolute;
   width: calc(100vw - 0.8rem);
-  left: 0;
+  inset-inline-start: 0;
 }
 
 @media (min-width: 1041px) {
   .emotion-107 {
     width: calc(100vw + 0.8rem);
-    left: calc(-1 * (100vw - 1014px) / 2);
+    inset-inline-start: calc(-1 * (100vw - 1014px) / 2);
   }
 }
 
 .emotion-107::after {
   content: '';
   position: absolute;
-  bottom: 0;
-  right: 0;
-  left: -0.8rem;
+  inset-block-end: 0;
+  inset-inline: -0.8rem 0;
   width: calc(100% + 0.8rem);
   border-bottom: 0.0625rem solid #E6E8EA;
 }

--- a/src/app/legacy/containers/Navigation/index.canonical.jsx
+++ b/src/app/legacy/containers/Navigation/index.canonical.jsx
@@ -18,17 +18,16 @@ const ScrollableWrapper = styled.div`
 const Divider = styled.div`
   position: absolute;
   width: calc(100vw - 0.8rem);
-  left: 0;
+  inset-inline-start: 0;
   @media (min-width: 1041px) {
     width: calc(100vw + 0.8rem);
-    left: calc(-1 * (100vw - 1014px) / 2);
+    inset-inline-start: calc(-1 * (100vw - 1014px) / 2);
   }
   &::after {
     content: '';
     position: absolute;
-    bottom: 0;
-    right: 0;
-    left: -0.8rem;
+    inset-block-end: 0;
+    inset-inline: -0.8rem 0;
     width: calc(100% + 0.8rem);
     border-bottom: 0.0625rem solid ${props => props.theme.palette.GREY_3};
   }


### PR DESCRIPTION
Resolves JIRA: [WORLDSERVICE-682](https://jira.dev.bbc.co.uk/browse/WORLDSERVICE-682)

Summary
======
Swaps out explicit top, bottom, left, right with inset blocks and inlines for reading direction agnostics for the navigation divider.

Code changes
======
- Swaps individual insets for inset-block and inset-inline in the navigation divider.


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

