### PR TITLE
WORLDSERVICE-817 - Add experiment variant to Reverb events

### DIFF
--- a/src/app/components/ATIAnalytics/atiUrl/index.test.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.test.ts
@@ -14,6 +14,8 @@ jest.mock('../../../lib/utilities/isLive', () => ({
   default: jest.fn(),
 }));
 
+jest.mock('#app/lib/config/optimizely', () => ({ flagKey: 'mockFlagKey' }));
+
 // @ts-expect-error required for testing purposes
 const mockAndSet = ({ name, source }, response) => {
   source[name] = jest.fn(); // eslint-disable-line no-param-reassign
@@ -370,6 +372,43 @@ describe('Reverb', () => {
         eventName: 'pageView',
       });
     });
+
+    it('should add experiment fields if experimentVariant is present', () => {
+      const reverbAnalyticsModel = buildReverbAnalyticsModel({
+        ...input,
+        experimentVariant: 'variant_1',
+      });
+
+      const pageParams = {
+        contentId: 'contentId',
+        contentType: 'contentType',
+        destination: 'statsDestination',
+        name: 'pageIdentifier',
+        producer: 'producerName',
+        additionalProperties: {
+          app_name: 'news',
+          app_type: 'getAppType',
+          content_language: 'language',
+          product_platform: null,
+          referrer_url: 'getReferrer',
+          x5: 'getHref',
+          x8: 'libraryVersion',
+          x9: 'sanitise',
+          x10: '',
+          x11: 'timePublished',
+          x12: 'timeUpdated',
+          x13: 'ldpThingLabels',
+          x14: 'ldpThingIds',
+          x16: 'campaign1~campaign2',
+          x17: 'categoryName',
+          x18: 'isLocServeCookieSet',
+          mv_creation: 'variant_1',
+          mv_test: 'mockFlagKey',
+        },
+      };
+
+      expect(reverbAnalyticsModel.params.page).toEqual(pageParams);
+    });
   });
 
   describe('buildReverbPageSectionEventModel', () => {
@@ -514,6 +553,35 @@ describe('Reverb', () => {
             action: 'view',
           },
           isClick: false,
+        });
+      });
+
+      it('should add experiment fields if experimentVariant is present', () => {
+        const reverbPageSectionViewEventModel =
+          buildReverbPageSectionEventModel({
+            ...input,
+            experimentVariant: 'variant_1',
+          });
+
+        expect(reverbPageSectionViewEventModel.eventDetails).toEqual({
+          eventName: 'sectionView',
+          eventPublisher: 'viewability',
+          item: {
+            attribution: 'advertiserID',
+            name: 'top-stories',
+            link: 'http://localhost',
+          },
+          group: {
+            name: '1234',
+          },
+          event: {
+            category: 'viewability',
+            action: 'view',
+          },
+          isClick: false,
+          experience: {
+            engine_id: 'optimizely.mockFlagKey.variant_1',
+          },
         });
       });
     });

--- a/src/app/components/ATIAnalytics/atiUrl/index.test.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.test.ts
@@ -629,6 +629,30 @@ describe('Reverb', () => {
           isClick: true,
         });
       });
+
+      it('should add experiment fields if experimentVariant is present', () => {
+        const reverbPageSectionViewEventModel =
+          buildReverbPageSectionEventModel({
+            ...input,
+            experimentVariant: 'variant_1',
+          });
+
+        expect(reverbPageSectionViewEventModel.eventDetails).toEqual({
+          eventName: 'sectionView',
+          eventPublisher: 'impression',
+          componentName: 'top-stories',
+          container: '1234',
+          attribute: 'top-stories',
+          metadata: 'format',
+          placement: 'mundo.page',
+          source: 'advertiserID',
+          result: 'http://localhost',
+          isClick: false,
+          personalisation: {
+            EXP: 'mockFlagKey::variant_1',
+          },
+        });
+      });
     });
   });
 });

--- a/src/app/components/ATIAnalytics/atiUrl/index.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.ts
@@ -545,7 +545,7 @@ export const buildReverbPageSectionEventModel = ({
         isClick: type === 'click',
         ...(experimentVariant && {
           experience: {
-            EXP: `${OPTIMIZELY_CONFIG.flagKey}::${experimentVariant}`,
+            engine_id: `optimizely.${OPTIMIZELY_CONFIG.flagKey}.${experimentVariant}`,
           },
         }),
       };

--- a/src/app/components/ATIAnalytics/atiUrl/index.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.ts
@@ -541,11 +541,6 @@ export const buildReverbPageSectionEventModel = ({
         event: {
           category: 'viewability',
           action: type === 'click' ? 'select' : 'view',
-          ...(experimentVariant && {
-            personalisation: {
-              EXP: `${OPTIMIZELY_CONFIG.flagKey}::${experimentVariant}`,
-            },
-          }),
         },
         isClick: type === 'click',
       };

--- a/src/app/components/ATIAnalytics/atiUrl/index.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.ts
@@ -1,4 +1,5 @@
 import { getEnvConfig } from '#app/lib/utilities/getEnvConfig';
+import OPTIMIZELY_CONFIG from '#lib/config/optimizely';
 import isLive from '../../../lib/utilities/isLive';
 import {
   getDestination,
@@ -442,6 +443,7 @@ export const buildReverbAnalyticsModel = ({
   statsDestination,
   timePublished,
   timeUpdated,
+  experimentVariant,
 }: ATIPageTrackingProps) => {
   const href = getHref(platform);
   const referrer = getReferrer(platform);
@@ -479,6 +481,10 @@ export const buildReverbAnalyticsModel = ({
           x16: aggregatedCampaigns,
           x17: categoryName,
           x18: isLocServeCookieSet(),
+          ...(experimentVariant && {
+            mv_test: OPTIMIZELY_CONFIG.flagKey,
+            mv_creation: `${experimentVariant}`,
+          }),
         },
       },
       user: {
@@ -501,6 +507,7 @@ export const buildReverbPageSectionEventModel = ({
   type,
   advertiserID,
   url,
+  experimentVariant,
 }: ATIEventTrackingProps) => {
   const eventDetails = isLive()
     ? {
@@ -511,9 +518,14 @@ export const buildReverbPageSectionEventModel = ({
         attribute: componentName,
         metadata: format,
         placement: pageIdentifier,
+        isClick: type === 'click',
         ...(advertiserID && { source: advertiserID }),
         ...(url && { result: url }),
-        isClick: type === 'click',
+        ...(experimentVariant && {
+          personalisation: {
+            EXP: `${OPTIMIZELY_CONFIG.flagKey}::${experimentVariant}`,
+          },
+        }),
       }
     : {
         eventName: type === 'view' ? 'sectionView' : 'sectionClick',
@@ -529,6 +541,11 @@ export const buildReverbPageSectionEventModel = ({
         event: {
           category: 'viewability',
           action: type === 'click' ? 'select' : 'view',
+          ...(experimentVariant && {
+            personalisation: {
+              EXP: `${OPTIMIZELY_CONFIG.flagKey}::${experimentVariant}`,
+            },
+          }),
         },
         isClick: type === 'click',
       };

--- a/src/app/components/ATIAnalytics/atiUrl/index.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.ts
@@ -543,6 +543,11 @@ export const buildReverbPageSectionEventModel = ({
           action: type === 'click' ? 'select' : 'view',
         },
         isClick: type === 'click',
+        ...(experimentVariant && {
+          experience: {
+            EXP: `${OPTIMIZELY_CONFIG.flagKey}::${experimentVariant}`,
+          },
+        }),
       };
 
   return {

--- a/src/app/components/ATIAnalytics/beacon/index.ts
+++ b/src/app/components/ATIAnalytics/beacon/index.ts
@@ -49,6 +49,7 @@ export const sendEventBeacon = async ({
         type,
         advertiserID,
         url,
+        experimentVariant,
       })
     : null;
 

--- a/src/app/lib/analyticsUtils/sendBeacon/index.js
+++ b/src/app/lib/analyticsUtils/sendBeacon/index.js
@@ -72,12 +72,13 @@ const reverbComponentTracking = async ({ reverbInstance, eventDetails }) => {
     anchorElement,
     originalEvent,
     isClick,
+    experience,
   } = eventDetails;
 
   const actionName = isLive() ? componentName : '';
   const actionAdditionalLabels = isLive()
     ? { attribute, container, personalisation, placement, result, source }
-    : { event, group, item };
+    : { event, group, item, experience };
 
   return reverbInstance.userActionEvent(
     eventPublisher,

--- a/src/app/lib/analyticsUtils/sendBeacon/index.js
+++ b/src/app/lib/analyticsUtils/sendBeacon/index.js
@@ -68,6 +68,7 @@ const reverbComponentTracking = async ({ reverbInstance, eventDetails }) => {
     item,
     group,
     event,
+    personalisation,
     anchorElement,
     originalEvent,
     isClick,
@@ -75,8 +76,8 @@ const reverbComponentTracking = async ({ reverbInstance, eventDetails }) => {
 
   const actionName = isLive() ? componentName : '';
   const actionAdditionalLabels = isLive()
-    ? { container, attribute, placement, source, result }
-    : { item, group, event };
+    ? { attribute, container, personalisation, placement, result, source }
+    : { event, group, item };
 
   return reverbInstance.userActionEvent(
     eventPublisher,


### PR DESCRIPTION
Resolves JIRA: https://jira.dev.bbc.co.uk/browse/WORLDSERVICE-817

Summary
======
- Adds `experimentVariant` to Reverb Piano events. This uses different syntax depending on the event, for example page-views uses the `mv_test` and `mv_creation` fields, whereas Viewability events use `experience.engine_id`


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

