### PR TITLE
Ignore dependabot updates to express & react-router-dom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,11 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@typescript-eslint/eslint-plugin'
         update-types: ['version-update:semver-major']
-      # https://jira.dev.bbc.co.uk/browse/NEWSWORLDSERVICE-1478 react-router & react-router-dom
+      # https://jira.dev.bbc.co.uk/browse/NEWSWORLDSERVICE-2164: Migrate all page types to Next.js + Lambda to remove Express + EC2 infrastructure
+      - dependency-name: 'react-router-config'
       - dependency-name: 'react-router-dom'
-      - dependency-name: 'react-router'
-      # https://jira.dev.bbc.co.uk/browse/NEWSWORLDSERVICE-2099: Delete path-to-regexp dependency
-      - dependency-name: 'path-to-regexp'
+      - dependency-name: 'express'
+        update-types: ['version-update:semver-major']
     labels:
       - 'dependencies'
     groups:


### PR DESCRIPTION
Resolves JIRA: 

Summary
======
Updates dependabot config so that we no longer receive major upgrades for express
Bump express from 4.21.2 to 5.1.0 #12688 has lots of failing PR checks, which cannot easily be fixed

Code changes
======
- Ignore express, react-router-dom & react-router-config updates


Developer Checklist - N/A
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

