### PR TITLE
NOTICKET - Return `null` for `false` MVT variation

### DIFF
--- a/src/app/hooks/useOptimizelyMvtVariation/index.jsx
+++ b/src/app/hooks/useOptimizelyMvtVariation/index.jsx
@@ -20,6 +20,8 @@ const useOptimizelyMvtVariation = id => {
   const isEnabled = experiment.enabled;
   const variation = isEnabled && experiment.variation;
 
+  if (!variation || variation === 'false') return null;
+
   if (variation) activateExperiment(optimizely, id, variation);
 
   return variation;

--- a/src/app/hooks/useOptimizelyMvtVariation/index.test.jsx
+++ b/src/app/hooks/useOptimizelyMvtVariation/index.test.jsx
@@ -77,6 +77,19 @@ describe('useOptimizelyMvtVariation custom hook', () => {
     expect(result).toBeFalsy();
   });
 
+  it('should return null when the experiment variation is false', () => {
+    const mockMvtExperiments = [
+      {
+        experimentName: 'foo',
+        variation: 'false',
+        enabled: true,
+      },
+    ];
+
+    const result = renderUseOptimizelyMvtVariation(mockMvtExperiments, 'foo');
+    expect(result).toBeFalsy();
+  });
+
   it('should call activate experiment if experiment is enabled', () => {
     const mockMvtExperiments = [
       {

--- a/src/app/hooks/useOptimizelyMvtVariation/index.test.jsx
+++ b/src/app/hooks/useOptimizelyMvtVariation/index.test.jsx
@@ -77,7 +77,7 @@ describe('useOptimizelyMvtVariation custom hook', () => {
     expect(result).toBeFalsy();
   });
 
-  it('should return null when the experiment variation is false', () => {
+  it('should return null when the experiment variation is string "false"', () => {
     const mockMvtExperiments = [
       {
         experimentName: 'foo',
@@ -87,7 +87,20 @@ describe('useOptimizelyMvtVariation custom hook', () => {
     ];
 
     const result = renderUseOptimizelyMvtVariation(mockMvtExperiments, 'foo');
-    expect(result).toBeFalsy();
+    expect(result).toBeNull();
+  });
+
+  it('should return null when the experiment variation is boolean "false"', () => {
+    const mockMvtExperiments = [
+      {
+        experimentName: 'foo',
+        variation: false,
+        enabled: true,
+      },
+    ];
+
+    const result = renderUseOptimizelyMvtVariation(mockMvtExperiments, 'foo');
+    expect(result).toBeNull();
   });
 
   it('should call activate experiment if experiment is enabled', () => {

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -159,8 +159,6 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
     OPTIMIZELY_CONFIG.ruleKey,
   );
 
-  console.log({ experimentVariant });
-
   const isInExperiment = experimentVariant && experimentVariant !== 'off';
 
   const allowAdvertising = pageData?.metadata?.allowAdvertising ?? false;

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -158,6 +158,9 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
   const experimentVariant = useOptimizelyMvtVariation(
     OPTIMIZELY_CONFIG.ruleKey,
   );
+
+  console.log({ experimentVariant });
+
   const isInExperiment = experimentVariant && experimentVariant !== 'off';
 
   const allowAdvertising = pageData?.metadata?.allowAdvertising ?? false;


### PR DESCRIPTION
Summary
======
- Returns `null` when the variation is `false` for a server-side MVT experiment. The is the value when users are _not_ bucketed into an experiment, so the `For everyone else...` state in Optimizely. We don't want to add anything to ATI/Piano events in this case, as `false` isn't a valid variation in this case.

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

