### PR TITLE
WORLDSERVICE-888: Remove browser: chrome from GH workflow

### DIFF
--- a/.github/workflows/simorgh-e2e-application-nextjs.yml
+++ b/.github/workflows/simorgh-e2e-application-nextjs.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Run Simorgh E2Es (Application)
         uses: cypress-io/github-action@v6
         with:
-          browser: chrome
           build: yarn build
           start: yarn start
           command: yarn cypress:application
@@ -43,7 +42,6 @@ jobs:
       - name: Run Simorgh NextJS E2Es
         uses: cypress-io/github-action@v6
         with:
-          browser: chrome
           working-directory: ws-nextjs-app
           build: yarn build
           start: yarn start

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Run Simorgh E2Es (Pages)
         uses: cypress-io/github-action@v6
         with:
-          browser: chrome
           build: yarn build
           start: yarn start
           command: yarn cypress:pages

--- a/.github/workflows/simorgh-e2e-special-features.yml
+++ b/.github/workflows/simorgh-e2e-special-features.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Run Simorgh E2Es (Special Features)
         uses: cypress-io/github-action@v6
         with:
-          browser: chrome
           build: yarn build
           start: yarn start
           command: yarn cypress:special-features


### PR DESCRIPTION
Resolves JIRA: https://jira.dev.bbc.co.uk/browse/WORLDSERVICE-888

Summary
======
Update cypress GH workflows to remove browser
This is to remove the following warning in the cypress test output:

```
Warning: command parameter is used and the following other parameters are ignored: browser.
```

We don't need to set the browser, because we already use --browser chrome in the cypress commands in package.json

Code changes
======
- Remove `browser: chrome` from e2e workflow files 


Developer Checklist - N/A
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

