### PR TITLE
WORLDSERVICE-270:  Small fix for live page header

### DIFF
--- a/src/app/components/LiveHeaderMedia/index.styles.tsx
+++ b/src/app/components/LiveHeaderMedia/index.styles.tsx
@@ -30,12 +30,18 @@ export default {
       position: 'relative',
       padding: 0,
     }),
-  openButton: () =>
+  openButton: ({ mq }: Theme) =>
     css({
       cursor: 'pointer',
       backgroundColor: 'unset',
       border: 'unset',
       textAlign: 'start',
+      [mq.GROUP_2_MAX_WIDTH && mq.GROUP_3_MAX_WIDTH && mq.GROUP_4_MAX_WIDTH]: {
+        marginTop: '0.75rem',
+      },
+      [mq.GROUP_5_MIN_WIDTH]: {
+        marginTop: '0.75rem',
+      },
     }),
   watchLiveCTAText: ({ spacings, palette, mq }: Theme) =>
     css({

--- a/src/app/components/LiveHeaderMedia/index.styles.tsx
+++ b/src/app/components/LiveHeaderMedia/index.styles.tsx
@@ -121,7 +121,7 @@ export default {
       width: '100%',
       marginTop: 0,
       span: { margin: 0 },
-      minHeight: '3.75rem',
+      minHeight: '2.5rem',
     }),
   openMediaDescription: ({ palette }: Theme) =>
     css({

--- a/src/app/components/LiveHeaderMedia/index.styles.tsx
+++ b/src/app/components/LiveHeaderMedia/index.styles.tsx
@@ -115,13 +115,13 @@ export default {
       maxWidth: '100%',
       marginTop: `${spacings.DOUBLE}rem`,
     }),
-  mediaDescription: () =>
+  mediaDescription: ({ spacings }: Theme) =>
     css({
       display: 'block',
       width: '100%',
       marginTop: 0,
       span: { margin: 0 },
-      minHeight: '2.5rem',
+      minHeight: `${spacings.QUINTUPLE}rem`,
     }),
   openMediaDescription: ({ palette }: Theme) =>
     css({

--- a/src/app/components/LiveHeaderMedia/index.styles.tsx
+++ b/src/app/components/LiveHeaderMedia/index.styles.tsx
@@ -30,18 +30,12 @@ export default {
       position: 'relative',
       padding: 0,
     }),
-  openButton: ({ mq }: Theme) =>
+  openButton: () =>
     css({
       cursor: 'pointer',
       backgroundColor: 'unset',
       border: 'unset',
       textAlign: 'start',
-      [mq.GROUP_2_MAX_WIDTH && mq.GROUP_3_MAX_WIDTH && mq.GROUP_4_MAX_WIDTH]: {
-        marginTop: '0.75rem',
-      },
-      [mq.GROUP_5_MIN_WIDTH]: {
-        marginTop: '0.75rem',
-      },
     }),
   watchLiveCTAText: ({ spacings, palette, mq }: Theme) =>
     css({
@@ -127,6 +121,7 @@ export default {
       width: '100%',
       marginTop: 0,
       span: { margin: 0 },
+      minHeight: '3.75rem',
     }),
   openMediaDescription: ({ palette }: Theme) =>
     css({


### PR DESCRIPTION
Resolves JIRA: https://jira.dev.bbc.co.uk/browse/WORLDSERVICE-270

Small changes for Live page header "jumping" (see in screenshot):

<img width="1330" alt="Screenshot 2025-05-15 at 10 27 49" src="https://github.com/user-attachments/assets/15d8b349-5eab-44cf-996a-34c187419e7a" />
<img width="1296" alt="Screenshot 2025-05-15 at 10 28 00" src="https://github.com/user-attachments/assets/f5e78432-7f8c-4da7-bb5f-4104237ddacf" />
