### PR TITLE
WORLDSERVICE-842 - Reverb experiment flag update

### DIFF
--- a/src/app/components/ATIAnalytics/atiUrl/index.test.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.test.ts
@@ -570,7 +570,8 @@ describe('Reverb', () => {
           },
           isClick: false,
           experience: {
-            engine_id: 'optimizely.mockFlagKey.variant_1',
+            engine_type: ['experimentation'],
+            engine_id: ['optimizely.mockFlagKey.variant_1'],
           },
         });
       });

--- a/src/app/components/ATIAnalytics/atiUrl/index.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.ts
@@ -549,7 +549,10 @@ export const buildReverbPageSectionEventModel = ({
       isClick: type === CLICK_EVENT,
       ...(experimentVariant && {
         experience: {
-          engine_id: `optimizely.${OPTIMIZELY_CONFIG.flagKey}.${experimentVariant}`,
+          engine_type: ['experimentation'],
+          engine_id: [
+            `optimizely.${OPTIMIZELY_CONFIG.flagKey}.${experimentVariant}`,
+          ],
         },
       }),
     },

--- a/src/app/components/ATIAnalytics/types.ts
+++ b/src/app/components/ATIAnalytics/types.ts
@@ -118,7 +118,8 @@ export type ReverbUserVars = {
 export type ReverbEventDetails = {
   anchorElement?: HTMLElement;
   experience?: {
-    engine_id: string;
+    engine_type: Array<string>;
+    engine_id: Array<string>;
   };
   event?: {
     category: string;


### PR DESCRIPTION
Part of JIRA: https://jira.dev.bbc.co.uk/browse/WORLDSERVICE-842

Summary
======
- Updates the `experience.engine_id` field to be an array of strings
- Adds `experience.engine_type` field
- Updates tests and types
- This allows the 'Experience Engine ID' field in Piano to be correctly populated with the experiment values

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

