### PR TITLE
Korean nav add Election + update Tigrinya and Telugu Most read header

### DIFF
--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -331,6 +331,10 @@ export const service: DefaultServiceConfig = {
         url: '/korean',
       },
       {
+        title: '2025 대선',
+        url: '/korean/topics/crldxe422e0t',
+      },
+      {
         title: '비디오',
         url: '/korean/topics/cnwng7v0e54t',
       },

--- a/src/app/lib/config/services/telugu.ts
+++ b/src/app/lib/config/services/telugu.ts
@@ -274,7 +274,7 @@ export const service: DefaultServiceConfig = {
       latestMediaTitle: 'తాజా వార్తలు',
     },
     mostRead: {
-      header: 'Popular Reads',
+      header: 'పాపులర్',
       lastUpdated: 'చివరిగా అప్‌డేట్ అయిన తేదీ:',
       numberOfItems: 10,
       hasMostRead: true,

--- a/src/app/lib/config/services/tigrinya.ts
+++ b/src/app/lib/config/services/tigrinya.ts
@@ -263,7 +263,7 @@ export const service: DefaultServiceConfig = {
       latestMediaTitle: 'ናይ መወዳእታ',
     },
     mostRead: {
-      header: 'ብብዝሒ ዝተነበ',
+      header: 'ዝያዳ ዝተነበ',
       lastUpdated: 'ንመወዳእታ እዋን ዝተመሓየሸሉ:',
       numberOfItems: 10,
       hasMostRead: true,

--- a/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
@@ -126,26 +126,33 @@ exports[`Canonical Korean Live Radio Page Header Navigation link should match te
 
 exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 2`] = `
 {
+  "text": "2025 대선",
+  "url": "/korean/topics/crldxe422e0t",
+}
+`;
+
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 3`] = `
+{
   "text": "비디오",
   "url": "/korean/topics/cnwng7v0e54t",
 }
 `;
 
-exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 3`] = `
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 4`] = `
 {
   "text": "라디오",
   "url": "/korean/bbc_korean_radio/programmes/w13xttll",
 }
 `;
 
-exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 5`] = `
 {
   "text": "다운로드",
   "url": "/korean/downloads",
 }
 `;
 
-exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 6`] = `
 {
   "text": "TOP 뉴스",
   "url": "/korean/popular/read",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Adds Election topic link to the navgation bar of Korean
- Upadates the Most read header for Telugu and Tigrinya



Code changes
======

- Edited Navigation section of src/app/lib/config/services/korean.ts to add Election topic link in second position
- Edited header in mostRead section of src/app/lib/config/services/telugu.ts
- Edited header in mostRead section of src/app/lib/config/services/tigrinya.ts
- Updated snapshot

Testing
======
1. Open Korean front page, the second link in the nav should be 2025 대선 and open /korean/topics/crldxe422e0t
2. Open a Telugu article the title of Most read at the bottom of the page should be పాపులర్
3. Open a Tigrinya article the title of Most read at the bottom of the page should be ዝያዳ ዝተነበ


<img width="497" alt="ko_nav" src="https://github.com/user-attachments/assets/b362c17b-adb0-4f4a-9529-7179d03f092e" />
<img width="201" alt="tei_most_read" src="https://github.com/user-attachments/assets/bddfaf46-29fa-4a97-abc5-4e4cda148129" />
<img width="214" alt="ti_most_read" src="https://github.com/user-attachments/assets/1ff78edf-b4a4-4bb0-86f7-d91fedae4fae" />


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

