### PR TITLE
Don't display cookie banner on chromatic snapshots

### DIFF
--- a/src/app/legacy/containers/ConsentBanner/useConsentBanners/index.js
+++ b/src/app/legacy/containers/ConsentBanner/useConsentBanners/index.js
@@ -139,7 +139,8 @@ const useConsentBanner = (
     const userHasExplicitCookie =
       EXPLICIT_COOKIE_ACCEPTED_VALUES.includes(explicitCookie);
     const shouldShowCookieBanner =
-      (!userHasExplicitCookie && showCookieBannerBasedOnCountry) ||
+      !userHasExplicitCookie &&
+      showCookieBannerBasedOnCountry &&
       !isChromatic();
     const shouldShowPrivacyBanner =
       privacyToggle &&

--- a/src/app/legacy/containers/ConsentBanner/useConsentBanners/index.js
+++ b/src/app/legacy/containers/ConsentBanner/useConsentBanners/index.js
@@ -139,7 +139,8 @@ const useConsentBanner = (
     const userHasExplicitCookie =
       EXPLICIT_COOKIE_ACCEPTED_VALUES.includes(explicitCookie);
     const shouldShowCookieBanner =
-      !userHasExplicitCookie && showCookieBannerBasedOnCountry;
+      (!userHasExplicitCookie && showCookieBannerBasedOnCountry) ||
+      !isChromatic();
     const shouldShowPrivacyBanner =
       privacyToggle &&
       (!userHasPrivacyCookie ||


### PR DESCRIPTION
Resolves JIRA: 

Summary
======
Don't display cookie banner on chromatic, as it interferes with full page snapshots 

Code changes
======
- Add a check to the cookie banner logic - do not display if chromatic detected

See UI Tests build for new snapshots (all page types excluding cookie banner at bottom of initial viewport) 


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

