### PR TITLE
WORLDSERVICE-898: Output Local IP address when running express server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@ const { merge } = require('webpack-merge');
 const fs = require('fs');
 const path = require('path');
 const DevServer = require('webpack-dev-server');
-const url = require('url');
 const { Chalk } = require('chalk');
 const MomentTimezoneInclude = require('./src/app/legacy/psammead/moment-timezone-include/src');
 const { webpackDirAlias } = require('./dirAlias');
@@ -50,17 +49,13 @@ const getBaseConfig = BUNDLE_TYPE => ({
       stats,
     },
     onListening() {
-      const hostname = DevServer.findIp('v4', false);
+      const host = DevServer.findIp('v4', false);
+      const port = process.env.PORT || 7080;
 
       // eslint-disable-next-line no-console
       console.info(
         new Chalk().green.bold(
-          `<i> [webpack-dev-server] Local IP: ${url.format({
-            protocol: 'http',
-            hostname,
-            port: 7080,
-            pathname: '/',
-          })}`,
+          `<i> [webpack-dev-server] Local IP: http://${host}:${port}/`,
         ),
       );
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,8 +54,9 @@ const getBaseConfig = BUNDLE_TYPE => ({
 
       // eslint-disable-next-line no-console
       console.info(
+        '<i>',
         new Chalk().green.bold(
-          `<i> [webpack-dev-server] Local IP: http://${host}:${port}/`,
+          `[webpack-dev-server] Local IP: http://${host}:${port}/`,
         ),
       );
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,9 @@
 const { merge } = require('webpack-merge');
 const fs = require('fs');
 const path = require('path');
+const DevServer = require('webpack-dev-server');
+const url = require('url');
+const { Chalk } = require('chalk');
 const MomentTimezoneInclude = require('./src/app/legacy/psammead/moment-timezone-include/src');
 const { webpackDirAlias } = require('./dirAlias');
 
@@ -45,6 +48,21 @@ const getBaseConfig = BUNDLE_TYPE => ({
   devServer: {
     devMiddleware: {
       stats,
+    },
+    onListening() {
+      const hostname = DevServer.findIp('v4', false);
+
+      // eslint-disable-next-line no-console
+      console.info(
+        new Chalk().green.bold(
+          `<i> [webpack-dev-server] Local IP: ${url.format({
+            protocol: 'http',
+            hostname,
+            port: 7080,
+            pathname: '/',
+          })}`,
+        ),
+      );
     },
   },
   stats,


### PR DESCRIPTION
Resolves JIRA: https://jira.dev.bbc.co.uk/browse/WORLDSERVICE-898

Summary
======
Outputs the Local IP address to the console, so that it can be used for testing on local devices 

Code changes
======
- Add log message to the console with local IP address, in the same format as the other log messages from webpack:
 
The new log message is the one at the bottom: **Local IP**
![Screenshot 2025-05-22 at 09 42 29](https://github.com/user-attachments/assets/5b5ef552-c596-472f-9272-c6d13b1bc94b)



Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

