### PR TITLE
WORLDSERVICE-898: Dynamically import chalk instead of require

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@ const { merge } = require('webpack-merge');
 const fs = require('fs');
 const path = require('path');
 const DevServer = require('webpack-dev-server');
-const { Chalk } = require('chalk');
 const MomentTimezoneInclude = require('./src/app/legacy/psammead/moment-timezone-include/src');
 const { webpackDirAlias } = require('./dirAlias');
 
@@ -48,7 +47,8 @@ const getBaseConfig = BUNDLE_TYPE => ({
     devMiddleware: {
       stats,
     },
-    onListening() {
+    async onListening() {
+      const { Chalk } = await import('chalk');
       const host = DevServer.findIp('v4', false);
       const port = process.env.PORT || 7080;
 


### PR DESCRIPTION
Resolves JIRA: https://jira.dev.bbc.co.uk/browse/WORLDSERVICE-898

Summary
======
Fix failing build in CD pipeline by dynamically importing the chalk library

Code changes
======
- Update webpack config to use a dynamic import for chalk

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

