### PR TITLE
Mundo nav: add Centroamérica cuenta

### DIFF
--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -421,10 +421,6 @@ export const service: DefaultServiceConfig = {
         url: '/mundo/topics/cdr5613yzwqt',
       },
       {
-        title: 'Hay Festival',
-        url: '/mundo/topics/cr50y7p7qyqt',
-      },
-      {
         title: 'Economía',
         url: '/mundo/topics/c06gq9v4xp3t',
       },

--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -444,6 +444,14 @@ export const service: DefaultServiceConfig = {
         title: 'Tecnología',
         url: '/mundo/topics/cyx5krnw38vt',
       },
+      {
+        title: 'Hay Festival',
+        url: '/mundo/topics/cr50y7p7qyqt',
+      },
+      {
+        title: 'Centroamérica cuenta',
+        url: '/mundo/topics/c404v5z1k8wt',
+      },
     ],
   },
 };

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
@@ -236,6 +236,20 @@ exports[`AMP Most Read Page Header Navigation link should match text and url 10`
 }
 `;
 
+exports[`AMP Most Read Page Header Navigation link should match text and url 11`] = `
+{
+  "text": "Hay Festival",
+  "url": "/mundo/topics/cr50y7p7qyqt",
+}
+`;
+
+exports[`AMP Most Read Page Header Navigation link should match text and url 12`] = `
+{
+  "text": "Centroamérica cuenta",
+  "url": "/mundo/topics/c404v5z1k8wt",
+}
+`;
+
 exports[`AMP Most Read Page I can see the headline 1`] = `"Lecturas más populares"`;
 
 exports[`AMP Most Read Page I can see the list items 1`] = `"1"Sabes que tienen cosas muy diferentes y te angustia no saber por qué": la odisea de una madre hasta descubrir que sus hijos tienen altas capacidadesÚltima actualización: 19 junio 2023"`;

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
@@ -196,54 +196,47 @@ exports[`AMP Most Read Page Header Navigation link should match text and url 4`]
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 5`] = `
 {
-  "text": "Hay Festival",
-  "url": "/mundo/topics/cr50y7p7qyqt",
-}
-`;
-
-exports[`AMP Most Read Page Header Navigation link should match text and url 6`] = `
-{
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 11`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 12`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 11`] = `
 {
   "text": "Centroamérica cuenta",
   "url": "/mundo/topics/c404v5z1k8wt",

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
@@ -150,54 +150,47 @@ exports[`Canonical Most Read Page Header Navigation link should match text and u
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 5`] = `
 {
-  "text": "Hay Festival",
-  "url": "/mundo/topics/cr50y7p7qyqt",
-}
-`;
-
-exports[`Canonical Most Read Page Header Navigation link should match text and url 6`] = `
-{
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 12`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 11`] = `
 {
   "text": "Centroamérica cuenta",
   "url": "/mundo/topics/c404v5z1k8wt",

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
@@ -190,6 +190,20 @@ exports[`Canonical Most Read Page Header Navigation link should match text and u
 }
 `;
 
+exports[`Canonical Most Read Page Header Navigation link should match text and url 11`] = `
+{
+  "text": "Hay Festival",
+  "url": "/mundo/topics/cr50y7p7qyqt",
+}
+`;
+
+exports[`Canonical Most Read Page Header Navigation link should match text and url 12`] = `
+{
+  "text": "Centroamérica cuenta",
+  "url": "/mundo/topics/c404v5z1k8wt",
+}
+`;
+
 exports[`Canonical Most Read Page I can see the headline 1`] = `"Lecturas más populares"`;
 
 exports[`Canonical Most Read Page I can see the list items 1`] = `"1"Sabes que tienen cosas muy diferentes y te angustia no saber por qué": la odisea de una madre hasta descubrir que sus hijos tienen altas capacidadesÚltima actualización: 19 junio 2023"`;

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
@@ -239,6 +239,20 @@ exports[`AMP Photo Gallery Page Header Navigation link should match text and url
 }
 `;
 
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 11`] = `
+{
+  "text": "Hay Festival",
+  "url": "/mundo/topics/cr50y7p7qyqt",
+}
+`;
+
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 12`] = `
+{
+  "text": "Centroamérica cuenta",
+  "url": "/mundo/topics/c404v5z1k8wt",
+}
+`;
+
 exports[`AMP Photo Gallery Page Image Caption should match text 1`] = `"Pie de foto, En tenis, las competidoras en los juegos de principios del siglo XX utilizaban vestidos y medias largas, algo impensable para los estándares de la actualidad. Fue hasta 1920 en Amberes cuando las mujeres tuvieron participación reconocida oficialmente."`;
 
 exports[`AMP Photo Gallery Page Image should match snapshot 1`] = `

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
@@ -199,54 +199,47 @@ exports[`AMP Photo Gallery Page Header Navigation link should match text and url
 
 exports[`AMP Photo Gallery Page Header Navigation link should match text and url 5`] = `
 {
-  "text": "Hay Festival",
-  "url": "/mundo/topics/cr50y7p7qyqt",
-}
-`;
-
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 6`] = `
-{
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 11`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 12`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 11`] = `
 {
   "text": "Centroamérica cuenta",
   "url": "/mundo/topics/c404v5z1k8wt",

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
@@ -153,54 +153,47 @@ exports[`Canonical Photo Gallery Page Header Navigation link should match text a
 
 exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 5`] = `
 {
-  "text": "Hay Festival",
-  "url": "/mundo/topics/cr50y7p7qyqt",
-}
-`;
-
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 6`] = `
-{
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 12`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 11`] = `
 {
   "text": "Centroamérica cuenta",
   "url": "/mundo/topics/c404v5z1k8wt",

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
@@ -193,6 +193,20 @@ exports[`Canonical Photo Gallery Page Header Navigation link should match text a
 }
 `;
 
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 11`] = `
+{
+  "text": "Hay Festival",
+  "url": "/mundo/topics/cr50y7p7qyqt",
+}
+`;
+
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 12`] = `
+{
+  "text": "Centroamérica cuenta",
+  "url": "/mundo/topics/c404v5z1k8wt",
+}
+`;
+
 exports[`Canonical Photo Gallery Page Image Caption should match text 1`] = `"Pie de foto, En tenis, las competidoras en los juegos de principios del siglo XX utilizaban vestidos y medias largas, algo impensable para los estándares de la actualidad. Fue hasta 1920 en Amberes cuando las mujeres tuvieron participación reconocida oficialmente."`;
 
 exports[`Canonical Photo Gallery Page Image should match snapshot 1`] = `

--- a/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
@@ -246,6 +246,20 @@ exports[`AMP Story Page Header Navigation link should match text and url 10`] = 
 }
 `;
 
+exports[`AMP Story Page Header Navigation link should match text and url 11`] = `
+{
+  "text": "Hay Festival",
+  "url": "/mundo/topics/cr50y7p7qyqt",
+}
+`;
+
+exports[`AMP Story Page Header Navigation link should match text and url 12`] = `
+{
+  "text": "Centroamérica cuenta",
+  "url": "/mundo/topics/c404v5z1k8wt",
+}
+`;
+
 exports[`AMP Story Page Image Caption should match text 1`] = `"Pie de foto, Llegó el día de la salida de Reino Unido de la UE."`;
 
 exports[`AMP Story Page Image should match snapshot 1`] = `

--- a/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
@@ -206,54 +206,47 @@ exports[`AMP Story Page Header Navigation link should match text and url 4`] = `
 
 exports[`AMP Story Page Header Navigation link should match text and url 5`] = `
 {
-  "text": "Hay Festival",
-  "url": "/mundo/topics/cr50y7p7qyqt",
-}
-`;
-
-exports[`AMP Story Page Header Navigation link should match text and url 6`] = `
-{
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 11`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 12`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 11`] = `
 {
   "text": "Centroamérica cuenta",
   "url": "/mundo/topics/c404v5z1k8wt",

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -206,6 +206,20 @@ exports[`Canonical Story Page Header Navigation link should match text and url 1
 }
 `;
 
+exports[`Canonical Story Page Header Navigation link should match text and url 11`] = `
+{
+  "text": "Hay Festival",
+  "url": "/mundo/topics/cr50y7p7qyqt",
+}
+`;
+
+exports[`Canonical Story Page Header Navigation link should match text and url 12`] = `
+{
+  "text": "Centroamérica cuenta",
+  "url": "/mundo/topics/c404v5z1k8wt",
+}
+`;
+
 exports[`Canonical Story Page Image Caption should match text 1`] = `"Pie de foto, Llegó el día de la salida de Reino Unido de la UE."`;
 
 exports[`Canonical Story Page Image should match snapshot 1`] = `

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -166,54 +166,47 @@ exports[`Canonical Story Page Header Navigation link should match text and url 4
 
 exports[`Canonical Story Page Header Navigation link should match text and url 5`] = `
 {
-  "text": "Hay Festival",
-  "url": "/mundo/topics/cr50y7p7qyqt",
-}
-`;
-
-exports[`Canonical Story Page Header Navigation link should match text and url 6`] = `
-{
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 8`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 10`] = `
 {
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 12`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 11`] = `
 {
   "text": "Centroamérica cuenta",
   "url": "/mundo/topics/c404v5z1k8wt",

--- a/ws-nextjs-app/integration/pages/send/mundo/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/send/mundo/__snapshots__/canonical.test.ts.snap
@@ -141,6 +141,20 @@ exports[`Canonical Send Header Navigation link should match text and url 10`] = 
 }
 `;
 
+exports[`Canonical Send Header Navigation link should match text and url 11`] = `
+{
+  "text": "Hay Festival",
+  "url": "/mundo/topics/cr50y7p7qyqt",
+}
+`;
+
+exports[`Canonical Send Header Navigation link should match text and url 12`] = `
+{
+  "text": "Centroamérica cuenta",
+  "url": "/mundo/topics/c404v5z1k8wt",
+}
+`;
+
 exports[`Canonical Send UGC form should render a heading 1`] = `"Escríbenos"`;
 
 exports[`Canonical Send UGC form should render a submit button 1`] = `"Enviar"`;

--- a/ws-nextjs-app/integration/pages/send/mundo/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/send/mundo/__snapshots__/canonical.test.ts.snap
@@ -101,54 +101,47 @@ exports[`Canonical Send Header Navigation link should match text and url 4`] = `
 
 exports[`Canonical Send Header Navigation link should match text and url 5`] = `
 {
-  "text": "Hay Festival",
-  "url": "/mundo/topics/cr50y7p7qyqt",
-}
-`;
-
-exports[`Canonical Send Header Navigation link should match text and url 6`] = `
-{
   "text": "Economía",
   "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 7`] = `
+exports[`Canonical Send Header Navigation link should match text and url 6`] = `
 {
   "text": "Ciencia",
   "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 8`] = `
+exports[`Canonical Send Header Navigation link should match text and url 7`] = `
 {
   "text": "Salud",
   "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 9`] = `
+exports[`Canonical Send Header Navigation link should match text and url 8`] = `
 {
   "text": "Cultura",
   "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 10`] = `
+exports[`Canonical Send Header Navigation link should match text and url 9`] = `
 {
   "text": "Tecnología",
   "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 11`] = `
+exports[`Canonical Send Header Navigation link should match text and url 10`] = `
 {
   "text": "Hay Festival",
   "url": "/mundo/topics/cr50y7p7qyqt",
 }
 `;
 
-exports[`Canonical Send Header Navigation link should match text and url 12`] = `
+exports[`Canonical Send Header Navigation link should match text and url 11`] = `
 {
   "text": "Centroamérica cuenta",
   "url": "/mundo/topics/c404v5z1k8wt",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Moves Hay Festival link and Adds Centroamérica cuenta topic link to the navigation of Mundo

Code changes
======

- Edited Navigation section of src/app/lib/config/services/mundo.ts
- Updated snapshots


Testing
======
1. Open Mundo's front page, the last link in the nav should be Centroamérica cuenta and second to last should be Hay Festival 

![image](https://github.com/user-attachments/assets/b806cbe0-a888-4831-83eb-8f72abfb544f)


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

