### PR TITLE
Click tracker `touch` and `key` event handling

### DIFF
--- a/src/app/hooks/useClickTrackerHandler/clickTypes.js
+++ b/src/app/hooks/useClickTrackerHandler/clickTypes.js
@@ -39,7 +39,17 @@ export const isNotModifiedLeftClick = event =>
   isLeftClick(event.button) &&
   !(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
 
-export const isValidClick = event =>
-  isMiddleClick(event.button) ||
-  isNotModifiedLeftClick(event) ||
-  isOpenClicked(event);
+const isEnterKey = key => key === 'Enter' || key === 'Return';
+
+const isTouchEvent = event =>
+  event.type === 'touchstart' || event.type === 'touchend';
+
+export const isValidClick = event => {
+  return (
+    isTouchEvent(event) ||
+    isEnterKey(event.key) ||
+    isMiddleClick(event.button) ||
+    isNotModifiedLeftClick(event) ||
+    isOpenClicked(event)
+  );
+};

--- a/src/app/hooks/useClickTrackerHandler/clickTypes.js
+++ b/src/app/hooks/useClickTrackerHandler/clickTypes.js
@@ -1,6 +1,3 @@
-import pathSatisfies from 'ramda/src/pathSatisfies';
-import startsWith from 'ramda/src/startsWith';
-
 const isLeftClick = button => button === 0;
 const isMiddleClick = button => button === 1 || button === 4; // middle click for IE is 4
 
@@ -25,11 +22,7 @@ const isMacOsOpenClicked = event =>
 const isWindowsOpenClicked = event =>
   isLeftClick(event.button) && isSupportedClickModifier(event, event.ctrlKey); // ctrl
 
-const isMacOs = () =>
-  pathSatisfies(startsWith('Mac'), ['navigator', 'platform'], window);
-
-export const isSafari = () =>
-  pathSatisfies(startsWith('Apple'), ['navigator', 'vendor'], window);
+const isMacOs = () => window?.navigator?.platform?.startsWith('Mac');
 
 export const isOpenClicked = event =>
   (isMacOs() ? isMacOsOpenClicked(event) : isWindowsOpenClicked(event)) ||
@@ -44,12 +37,9 @@ const isEnterKey = key => key === 'Enter' || key === 'Return';
 const isTouchEvent = event =>
   event.type === 'touchstart' || event.type === 'touchend';
 
-export const isValidClick = event => {
-  return (
-    isTouchEvent(event) ||
-    isEnterKey(event.key) ||
-    isMiddleClick(event.button) ||
-    isNotModifiedLeftClick(event) ||
-    isOpenClicked(event)
-  );
-};
+export const isValidClick = event =>
+  isMiddleClick(event.button) ||
+  isNotModifiedLeftClick(event) ||
+  isOpenClicked(event) ||
+  isTouchEvent(event) ||
+  isEnterKey(event.key);

--- a/src/app/hooks/useClickTrackerHandler/clickTypes.test.js
+++ b/src/app/hooks/useClickTrackerHandler/clickTypes.test.js
@@ -22,6 +22,22 @@ describe('Click Types', () => {
     expect(isValidClick(middleClickIE)).toBe(true);
   });
 
+  it('should allow clicks with the Enter key', () => {
+    const enterKeyEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+    const returnKeyEvent = new KeyboardEvent('keydown', { key: 'Return' });
+
+    expect(isValidClick(enterKeyEvent)).toBe(true);
+    expect(isValidClick(returnKeyEvent)).toBe(true);
+  });
+
+  it('should allow touch events', () => {
+    const touchStartEvent = new TouchEvent('touchstart');
+    const touchEndEvent = new TouchEvent('touchend');
+
+    expect(isValidClick(touchStartEvent)).toBe(true);
+    expect(isValidClick(touchEndEvent)).toBe(true);
+  });
+
   it.each`
     platform     | functionKey | shiftKey | altKey   | expected
     ${'Windows'} | ${false}    | ${false} | ${true}  | ${false}


### PR DESCRIPTION
Part of https://bbc.atlassian.net/browse/WS-317

Summary
======
- Updates the `clickTypes` checker to account for `onKey` and `onTouch` event handlers


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

