### PR TITLE
WS-317 - Reorder pageview + article complete Optimizely tracking

### DIFF
--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -342,6 +342,12 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
                 liteCTAShows={liteCTAShows}
               />
             )}
+            {isInExperiment && (
+              <>
+                <OptimizelyArticleCompleteTracking />
+                <OptimizelyPageViewTracking />
+              </>
+            )}
           </main>
           {showTopics && (
             <RelatedTopics
@@ -376,12 +382,6 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
           mobileDivider={showTopics}
           sendOptimizelyEvents={false}
         />
-      )}
-      {isInExperiment && (
-        <>
-          <OptimizelyArticleCompleteTracking />
-          <OptimizelyPageViewTracking />
-        </>
       )}
     </div>
   );

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -342,13 +342,13 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
                 liteCTAShows={liteCTAShows}
               />
             )}
-            {isInExperiment && (
-              <>
-                <OptimizelyArticleCompleteTracking />
-                <OptimizelyPageViewTracking />
-              </>
-            )}
           </main>
+          {isInExperiment && (
+            <>
+              <OptimizelyArticleCompleteTracking />
+              <OptimizelyPageViewTracking />
+            </>
+          )}
           {showTopics && (
             <RelatedTopics
               css={[


### PR DESCRIPTION
Part of JIRA: https://bbc.atlassian.net/browse/WS-317

Summary
======
- Moves the `OptimizelyArticleCompleteTracking` and `OptimizelyPageViewTracking` components just below the `<main>` element in Article pages. This is more for the `OptimizelyArticleCompleteTracking` component, as its somewhat inaccurate having it outside of `<main>` as `<main>` contains the actual article content. Before hand, users would need to scroll _all the way_ to the bottom, past onward journeys and the secondary column to trigger the 'complete' event.


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

