### PR TITLE
WS-317 - Re-position article complete + page view tracking

### DIFF
--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -342,13 +342,9 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
                 liteCTAShows={liteCTAShows}
               />
             )}
+            {isInExperiment && <OptimizelyArticleCompleteTracking />}
           </main>
-          {isInExperiment && (
-            <>
-              <OptimizelyArticleCompleteTracking />
-              <OptimizelyPageViewTracking />
-            </>
-          )}
+          {isInExperiment && <OptimizelyPageViewTracking />}
           {showTopics && (
             <RelatedTopics
               css={[


### PR DESCRIPTION
Part of JIRA: https://bbc.atlassian.net/browse/WS-317

Summary
======
- Another reorder!
- Moves article completes into `main` element for this experiment. This means that it will only fire if users are bucketed into the 'read more' variation and have expanded the article fully. Other variations will fire always.
- Moves the page view and scroll depth tracking _outside_ of `main` as we want to track this always, regardless of whether the user has expanded the article fully if they are in one of those variations

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

