### PR TITLE
WS-33- Portrait video modal desktop styling

### DIFF
--- a/src/app/components/PortraitVideoModal/index.styles.tsx
+++ b/src/app/components/PortraitVideoModal/index.styles.tsx
@@ -27,7 +27,7 @@ const styles = {
 
   closeButton: ({ mq, spacings, palette }: Theme) =>
     css({
-      display: 'flex',
+      display: 'none',
       position: 'absolute',
       top: `${spacings.DOUBLE}rem`,
       right: `${spacings.DOUBLE}rem`,
@@ -35,6 +35,10 @@ const styles = {
       border: `${pixelsToRem(2)}rem solid ${palette.WHITE}`,
       cursor: 'pointer',
       padding: 0,
+
+      [mq.GROUP_2_MIN_WIDTH]: {
+        display: 'flex',
+      },
 
       [mq.FORCED_COLOURS]: {
         border: `${pixelsToRem(2)}rem solid canvasText`,
@@ -54,14 +58,14 @@ const styles = {
         width: 'auto',
         height: '100%',
         maxWidth: '100%',
-        maxHeight: '85%',
+        maxHeight: '100%',
         margin: 0,
         marginInline: 0,
       },
 
-      [mq.GROUP_5_MIN_WIDTH]: {
+      [mq.GROUP_2_MIN_WIDTH]: {
         '&.media-container': {
-          maxHeight: '90%',
+          maxHeight: '80%',
         },
       },
     }),

--- a/src/app/components/PortraitVideoModal/index.styles.tsx
+++ b/src/app/components/PortraitVideoModal/index.styles.tsx
@@ -35,6 +35,7 @@ const styles = {
       border: `${pixelsToRem(2)}rem solid ${palette.WHITE}`,
       cursor: 'pointer',
       padding: 0,
+      zIndex: 2,
 
       [mq.GROUP_2_MIN_WIDTH]: {
         display: 'flex',
@@ -61,11 +62,12 @@ const styles = {
         maxHeight: '100%',
         margin: 0,
         marginInline: 0,
+        zIndex: 1,
       },
 
       [mq.GROUP_2_MIN_WIDTH]: {
         '&.media-container': {
-          maxHeight: '80%',
+          maxHeight: '90%',
         },
       },
     }),

--- a/src/app/components/PortraitVideoModal/index.styles.tsx
+++ b/src/app/components/PortraitVideoModal/index.styles.tsx
@@ -37,6 +37,10 @@ const styles = {
       padding: 0,
       zIndex: 2,
 
+      '&:hover, &:focus-visible': {
+        backgroundColor: palette.POSTBOX,
+      },
+
       [mq.GROUP_2_MIN_WIDTH]: {
         display: 'flex',
       },
@@ -46,10 +50,11 @@ const styles = {
       },
 
       svg: {
+        color: palette.WHITE,
+
         [mq.FORCED_COLOURS]: {
           fill: 'canvasText',
         },
-        color: palette.WHITE,
       },
     }),
 

--- a/src/app/components/PortraitVideoModal/index.styles.tsx
+++ b/src/app/components/PortraitVideoModal/index.styles.tsx
@@ -1,41 +1,49 @@
+import pixelsToRem from '#app/utilities/pixelsToRem';
 import { css, Theme } from '@emotion/react';
 
 const styles = {
-  dialog: css({
-    overflow: 'hidden',
-    width: '100%',
-    maxWidth: '100%',
-    height: '100%',
-    maxHeight: '100%',
-    position: 'relative',
-    backgroundColor: 'transparent',
-    border: 'none',
-    margin: 0,
-    padding: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
+  dialog: () =>
+    css({
+      overflow: 'hidden',
+      width: '100%',
+      maxWidth: '100%',
+      height: '100%',
+      maxHeight: '100%',
+      position: 'relative',
+      backgroundColor: 'transparent',
+      border: 'none',
+      margin: 0,
+      padding: 0,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
 
-    '&::backdrop': {
-      backgroundColor: 'rgba(0, 0, 0, 0.9)',
-    },
-  }),
+      '&::backdrop': {
+        backgroundColor: 'rgba(20, 20, 20, 0.9)',
+        backdropFilter: 'blur(0.2rem)',
+      },
+    }),
 
-  closeButton: ({ palette }: Theme) =>
+  closeButton: ({ mq, spacings, palette }: Theme) =>
     css({
       display: 'flex',
       position: 'absolute',
-      top: '1rem',
-      right: '1rem',
-      fontSize: '1.5rem',
+      top: `${spacings.DOUBLE}rem`,
+      right: `${spacings.DOUBLE}rem`,
       background: 'transparent',
-      border: 'none',
+      border: `${pixelsToRem(2)}rem solid ${palette.WHITE}`,
       cursor: 'pointer',
-      zIndex: 2,
+      padding: 0,
+
+      [mq.FORCED_COLOURS]: {
+        border: `${pixelsToRem(2)}rem solid canvasText`,
+      },
 
       svg: {
-        fill: 'currentcolor',
+        [mq.FORCED_COLOURS]: {
+          fill: 'canvasText',
+        },
         color: palette.WHITE,
       },
     }),

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -1,11 +1,13 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react';
-import { useEffect, useRef } from 'react';
+import { use, useEffect, useRef } from 'react';
 import MediaLoader from '#app/components/MediaLoader';
 import { PortraitClipMediaBlock } from '#app/components/MediaLoader/types';
 import { navigationIcons } from '#psammead/psammead-assets/src/svgs';
+import { ServiceContext } from '#app/contexts/ServiceContext';
 import styles from './index.styles';
 import { setImageWidth } from '../MediaLoader/configs/portraitClipMedia';
+import VisuallyHiddenText from '../VisuallyHiddenText';
 
 export interface PortraitVideoModalProps {
   items: {
@@ -31,7 +33,13 @@ const PortraitVideoModal = ({
   onClose,
   selectedVideoIndex,
 }: PortraitVideoModalProps) => {
+  const {
+    translations: {
+      media: { closeVideo = 'Close' },
+    },
+  } = use(ServiceContext);
   const modalRef = useRef<HTMLDialogElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   const blocks: PortraitClipMediaBlock[] = items.map(item => ({
     type: 'portraitClipMedia',
@@ -59,6 +67,9 @@ const PortraitVideoModal = ({
   useEffect(() => {
     if (modalRef.current) {
       modalRef.current.showModal();
+      modalRef.current.scrollTop = 0;
+      closeButtonRef.current?.focus();
+
       document.body.style.overflow = 'hidden';
     }
 
@@ -116,13 +127,15 @@ const PortraitVideoModal = ({
   return (
     <dialog ref={modalRef} css={styles.dialog}>
       <button
-        data-testid="close-modal-button"
+        ref={closeButtonRef}
         type="button"
+        data-testid="close-modal-button"
         css={styles.closeButton}
+        className="focusIndicatorInvert"
         onClick={onClose}
-        aria-label="Close modal"
       >
         {navigationIcons.cross}
+        <VisuallyHiddenText>{closeVideo}</VisuallyHiddenText>
       </button>
 
       <MediaLoader


### PR DESCRIPTION
Resolves JIRA:  https://bbc.atlassian.net/browse/WS-33

Summary
======
Amends styling for desktop only for the Portrait video modal as per https://www.figma.com/design/26MnWrrbJ3sBuiDKGaTBaa/Curation-PV---Handoff?node-id=753-1720&t=O5LptxJWBUOAGVZZ-0

- Adds border to the close button
- Hides the close button on mobile breakpoint
- Fixes display of close button on forced colours
- Ensures video container is scrolled to top when opened in rare scenarios that it would be scrolled out of view
- Adds 'close' translations
- A11y related tasks will be tackled and actioned in a separate ticket

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

