### PR TITLE
WS-325 - Adds fullscreen SMP plugin to static assets

### DIFF
--- a/public/smpPlugins/fullscreen.js
+++ b/public/smpPlugins/fullscreen.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-unused-vars */
+
+class FullScreenPlugin {
+  pluginInitialisation(pluginUtils) {
+    this.playerInterface = pluginUtils.playerInterface;
+
+    this.playerInterface.addEventListener(
+      'fullScreenPlugin.launchFullscreen',
+      () => {
+        if (!this.playerInterface.uiInfo.isFullscreen) {
+          this.playerInterface.toggleFullscreen();
+        }
+      },
+    );
+  }
+}
+
+const runPlugin = () => {
+  const fullScreenPlugin = new FullScreenPlugin();
+
+  return fullScreenPlugin;
+};


### PR DESCRIPTION
Part of JIRA: https://bbc.atlassian.net/browse/WS-325

Summary
======
- Adds fullscreen plugin to our static assets location so that it can be referenced and used in the portrait video player config
- This will be used in https://github.com/bbc/simorgh/pull/12888

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

