### PR TITLE
Portrait Video - update `statsObject` on playlist change

### DIFF
--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -21,7 +21,7 @@ export type MediaPlayerEvents =
   | 'fullscreenExit';
 
 export type EventMapping = Partial<
-  Record<MediaPlayerEvents, (_e?: SMPEvent) => void>
+  Record<MediaPlayerEvents, (_e: SMPEvent) => void>
 >;
 
 export type Playlist = {
@@ -150,7 +150,7 @@ export type Player = {
   load: () => void;
   play: () => void;
   pause: () => void;
-  bind: (event: MediaPlayerEvents, callback: (e?: SMPEvent) => void) => void;
+  bind: (event: MediaPlayerEvents, callback: (e: SMPEvent) => void) => void;
   loadPlugin: (
     pluginName: { [key: string]: string },
     parameters?: {

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -66,8 +66,8 @@ export type PlayerConfig = {
   statsObject: {
     clipPID?: string | null;
     episodePID?: string | null;
-    destination: string;
-    producer: string | '';
+    destination?: string;
+    producer?: string | '';
   };
   mediator?: { host: string };
   ui: PlayerUiConfig;
@@ -161,8 +161,11 @@ export type Player = {
       };
     },
   ) => void;
-  queuePlaylist: (playlist: Playlist) => void;
-  setPreviousPlaylist: (playlist: Playlist) => void;
+  queuePlaylist: (playlist: Playlist, options?: Partial<PlayerConfig>) => void;
+  setPreviousPlaylist: (
+    playlist: Playlist,
+    options?: Partial<PlayerConfig>,
+  ) => void;
   player: { paused: () => boolean };
 };
 

--- a/src/app/components/PortraitVideoModal/fixture.ts
+++ b/src/app/components/PortraitVideoModal/fixture.ts
@@ -3,6 +3,8 @@ import { PortraitVideoModalProps } from '.';
 const items = [
   {
     id: 'urn:bbc:pips:pid:p01wjx7v',
+    title: '4 erros de quem estuda para concursos públicos',
+    versionId: 'p01wjx7v',
     images: [
       {
         url: 'https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx8g.jpg',
@@ -12,48 +14,11 @@ const items = [
           'A sensação de não saber por onde começar, a falta de uma rotina',
       },
     ],
-    headlines: {
-      promoHeadline: '1. 4 erros de quem estuda para concursos públicos (9x16)',
-    },
-    link: {
-      path: '/programmes/p01wjx7v',
-    },
-    video: {
-      id: 'p01wjx7v',
-      version: {
-        duration: 'PT13S',
-        kind: 'programme',
-        territories: ['uk', 'nonuk'],
-      },
-    },
-  },
-  {
-    id: 'urn:bbc:optimo:asset:cgp62emnrk5o',
-    images: [
-      {
-        url: 'https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx7z.jpg',
-        urlTemplate:
-          'https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx7z.jpg',
-        altText: 'Hoje nove países possuem armas nucleares',
-      },
-    ],
-    headlines: {
-      promoHeadline: '2. Article with portrait video embed (2)',
-    },
-    link: {
-      path: '/portuguese/articles/cgp62emnrk5o',
-    },
-    video: {
-      id: 'p01wjx6g',
-      version: {
-        duration: 'PT13S',
-        kind: 'programme',
-        territories: ['uk', 'nonuk'],
-      },
-    },
   },
   {
     id: 'urn:bbc:pips:pid:p01wjx5y',
+    title: 'Europa se armando para guerra?',
+    versionId: 'p01wjx5y',
     images: [
       {
         url: 'https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx8v.jpg',
@@ -62,23 +27,11 @@ const items = [
         altText: 'A Europa está em uma espécie de "corrida armamentista"',
       },
     ],
-    headlines: {
-      promoHeadline: '3. Europa se armando para guerra? (9x16)',
-    },
-    link: {
-      path: '/programmes/p01wjx5y',
-    },
-    video: {
-      id: 'p01wjx5y',
-      version: {
-        duration: 'PT13S',
-        kind: 'programme',
-        territories: ['uk', 'nonuk'],
-      },
-    },
   },
   {
     id: 'urn:bbc:pips:pid:p01wjx4r',
+    title: 'China: a Nova Rota da Seda',
+    versionId: 'p01wjx4r',
     images: [
       {
         url: 'https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx5j.jpg',
@@ -88,171 +41,6 @@ const items = [
         altText: 'A Nova Rota da Seda',
       },
     ],
-    headlines: {
-      promoHeadline: '4. China: a Nova Rota da Seda (9x16)',
-    },
-    link: {
-      path: '/programmes/p01wjx4r',
-    },
-    video: {
-      id: 'p01wjx4r',
-      version: {
-        duration: 'PT13S',
-        kind: 'programme',
-        territories: ['uk', 'nonuk'],
-      },
-    },
-  },
-  {
-    id: 'urn:bbc:pips:pid:p01wjx3q',
-    images: [
-      {
-        url: 'https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx51.jpg',
-        urlTemplate:
-          'https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx51.jpg',
-        altText: 'Estupradores em série no Reino Unido',
-      },
-    ],
-    headlines: {
-      promoHeadline: '5. O estudante acusado no Reino Unido (9x16)',
-    },
-    link: {
-      path: '/programmes/p01wjx3q',
-    },
-    video: {
-      id: 'p01wjx3q',
-      version: {
-        duration: 'PT13S',
-        kind: 'programme',
-        territories: ['uk', 'nonuk'],
-      },
-    },
-  },
-  {
-    id: 'urn:bbc:pips:pid:p01wjx3g',
-    images: [
-      {
-        url: 'https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx48.jpg',
-        urlTemplate:
-          'https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx48.jpg',
-        altText: 'Evitar picos de glicose',
-      },
-    ],
-    headlines: {
-      promoHeadline: '6. Por que evitar glicose para emagrecer (9x16)',
-    },
-    link: {
-      path: '/programmes/p01wjx3g',
-    },
-    video: {
-      id: 'p01wjx3g',
-      version: {
-        duration: 'PT13S',
-        kind: 'programme',
-        territories: ['uk', 'nonuk'],
-      },
-    },
-  },
-  {
-    id: 'urn:bbc:pips:pid:p01wjx35',
-    images: [
-      {
-        url: 'https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx3l.jpg',
-        urlTemplate:
-          'https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx3l.jpg',
-        altText: 'Papa Francisco recebe alta',
-      },
-    ],
-    headlines: {
-      promoHeadline: '7. Papa Francisco recebe alta (9x16)',
-    },
-    link: {
-      path: '/programmes/p01wjx35',
-    },
-    video: {
-      id: 'p01wjx35',
-      version: {
-        duration: 'PT13S',
-        kind: 'programme',
-        territories: ['uk', 'nonuk'],
-      },
-    },
-  },
-  {
-    id: 'urn:bbc:pips:pid:p01wjx7v1',
-    images: [
-      {
-        url: 'https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx8g.jpg',
-        urlTemplate:
-          'https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx8g.jpg',
-        altText:
-          'A sensação de não saber por onde começar, a falta de uma rotina',
-      },
-    ],
-    headlines: {
-      promoHeadline: '8. 4 erros de quem estuda (9x16)',
-    },
-    link: {
-      path: '/programmes/p01wjx7v',
-    },
-    video: {
-      id: 'p01wjx7v1',
-      version: {
-        duration: 'PT13S',
-        kind: 'programme',
-        territories: ['uk', 'nonuk'],
-      },
-    },
-  },
-  {
-    id: 'urn:bbc:optimo:asset:cgp62emnrk5o1',
-    images: [
-      {
-        url: 'https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx7z.jpg',
-        urlTemplate:
-          'https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx7z.jpg',
-        altText: 'Hoje nove países possuem armas nucleares',
-      },
-    ],
-    headlines: {
-      promoHeadline: '9. Armas nucleares (9x16)',
-    },
-    link: {
-      path: '/portuguese/articles/cgp62emnrk5o',
-    },
-    video: {
-      id: 'p01wjx6z',
-      version: {
-        duration: 'PT13S',
-        kind: 'programme',
-        territories: ['uk', 'nonuk'],
-      },
-    },
-  },
-  {
-    id: 'urn:bbc:pips:pid:p01wjx5y1',
-    images: [
-      {
-        url: 'https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx8v.jpg',
-        urlTemplate:
-          'https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx8v.jpg',
-        altText: 'Corrida armamentista na Europa',
-      },
-    ],
-    headlines: {
-      promoHeadline: '10. Corrida armamentista (9x16)',
-    },
-    link: {
-      path: '/programmes/p01wjx5y',
-    },
-    video: {
-      id: 'p01wjx5y1',
-      version: {
-        duration: 'PT13S',
-        kind: 'programme',
-        territories: ['uk', 'nonuk'],
-      },
-    },
   },
 ] as unknown as PortraitVideoModalProps['items'];
 

--- a/src/app/components/PortraitVideoModal/index.test.tsx
+++ b/src/app/components/PortraitVideoModal/index.test.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
-import Component from '.';
+import Component, { playlistLoadedCallback, getBlocks } from '.';
 import { screen, render } from '../react-testing-library-with-providers';
 import items from './fixture';
+import { Player, SMPEvent } from '../MediaLoader/types';
+import { setImageWidth } from '../MediaLoader/configs/portraitClipMedia';
 
 const mockClose = jest.fn();
+
+const mockPlayer = {
+  queuePlaylist: jest.fn(),
+  setPreviousPlaylist: jest.fn(),
+} as unknown as Player;
 
 describe('PortraitVideoModal', () => {
   beforeAll(() => {
@@ -27,5 +34,96 @@ describe('PortraitVideoModal', () => {
     closeButton.click();
 
     expect(mockClose).toHaveBeenCalled();
+  });
+
+  describe('playlistLoadedCallback', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      Object.defineProperty(window, 'embeddedMedia', {
+        writable: true,
+        value: {
+          api: {
+            players: () => ({ bbcMediaPlayer0: mockPlayer }),
+          },
+        },
+      });
+    });
+
+    it('should call the playlistLoadedCallback and call queuePlaylist for the next video', () => {
+      const blocks = getBlocks(items);
+
+      const mockSMPEvent = {
+        playlist: { items: [{ versionID: items[0].versionId }] },
+      } as SMPEvent;
+
+      playlistLoadedCallback(mockSMPEvent, blocks);
+
+      const [_currentVideo, nextVideo] = blocks;
+
+      expect(mockPlayer.setPreviousPlaylist).not.toHaveBeenCalled();
+
+      expect(mockPlayer.queuePlaylist).toHaveBeenCalledWith(
+        {
+          title: nextVideo.model.video.title,
+          holdingImageURL: setImageWidth(nextVideo.model.images[0].urlTemplate),
+          items: [{ versionID: nextVideo.model.video.version.id }],
+        },
+        { statsObject: { clipPID: nextVideo.model.video.id } },
+      );
+    });
+
+    it('should call the playlistLoadedCallback and call setPreviousPlaylist for the previous video and queuePlaylist for the next video', () => {
+      const blocks = getBlocks(items);
+
+      const mockSMPEvent = {
+        playlist: { items: [{ versionID: items[1].versionId }] },
+      } as SMPEvent;
+
+      playlistLoadedCallback(mockSMPEvent, blocks);
+
+      const [prevVideo, _current, nextVideo] = blocks;
+
+      expect(mockPlayer.setPreviousPlaylist).toHaveBeenCalledWith(
+        {
+          title: prevVideo.model.video.title,
+          holdingImageURL: setImageWidth(prevVideo.model.images[0].urlTemplate),
+          items: [{ versionID: prevVideo.model.video.version.id }],
+        },
+        { statsObject: { clipPID: prevVideo.model.video.id } },
+      );
+
+      expect(mockPlayer.queuePlaylist).toHaveBeenCalledWith(
+        {
+          title: nextVideo.model.video.title,
+          holdingImageURL: setImageWidth(nextVideo.model.images[0].urlTemplate),
+          items: [{ versionID: nextVideo.model.video.version.id }],
+        },
+        { statsObject: { clipPID: nextVideo.model.video.id } },
+      );
+    });
+
+    it('should call playlistLoadedCallback and setPreviousPlaylist if there are no next videos', () => {
+      const blocks = getBlocks(items);
+
+      const mockSMPEvent = {
+        playlist: { items: [{ versionID: items[items.length - 1].versionId }] },
+      } as SMPEvent;
+
+      playlistLoadedCallback(mockSMPEvent, blocks);
+
+      const [prevVideo] = blocks.slice(-2);
+
+      expect(mockPlayer.setPreviousPlaylist).toHaveBeenCalledWith(
+        {
+          title: prevVideo.model.video.title,
+          holdingImageURL: setImageWidth(prevVideo.model.images[0].urlTemplate),
+          items: [{ versionID: prevVideo.model.video.version.id }],
+        },
+        { statsObject: { clipPID: prevVideo.model.video.id } },
+      );
+
+      expect(mockPlayer.queuePlaylist).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -12,6 +12,92 @@ import styles from './index.styles';
 import { setImageWidth } from '../MediaLoader/configs/portraitClipMedia';
 import VisuallyHiddenText from '../VisuallyHiddenText';
 
+export const playlistLoadedCallback = (
+  e: SMPEvent,
+  blocks: PortraitClipMediaBlock[],
+) => {
+  const player = window?.embeddedMedia?.api?.players()?.bbcMediaPlayer0;
+
+  if (!player) return;
+
+  const { playlist } = e || {};
+
+  const [currentItem] = playlist?.items || [];
+
+  const currentId = currentItem?.vpid || currentItem?.versionID;
+
+  const currentIndex = blocks?.findIndex(
+    item =>
+      item.model.video.id === currentId ||
+      item.model.video.version.id === currentId,
+  );
+
+  const previous = blocks?.[currentIndex - 1]?.model;
+  const next = blocks?.[currentIndex + 1]?.model;
+
+  if (previous) {
+    const [fallbackImage, portraitImage] = previous?.images || [];
+
+    player.setPreviousPlaylist(
+      {
+        title: previous?.video?.title ?? '',
+        holdingImageURL: setImageWidth(
+          (portraitImage || fallbackImage)?.urlTemplate,
+        ),
+        items: [{ versionID: previous?.video?.version?.id }],
+      },
+      { statsObject: { clipPID: previous?.video?.id } },
+    );
+  }
+
+  if (next) {
+    const [fallbackImage, portraitImage] = next?.images || [];
+
+    player.queuePlaylist(
+      {
+        title: next?.video?.title ?? '',
+        holdingImageURL: setImageWidth(
+          (portraitImage || fallbackImage)?.urlTemplate,
+        ),
+        items: [{ versionID: next?.video?.version?.id }],
+      },
+      { statsObject: { clipPID: next?.video?.id } },
+    );
+  }
+};
+
+const pluginLoadedCallback = () => {
+  const player = window?.embeddedMedia?.api?.players()?.bbcMediaPlayer0;
+
+  player.dispatchEvent('fullScreenPlugin.launchFullscreen');
+};
+
+export const getBlocks = (
+  items: PortraitVideoModalProps['items'],
+): PortraitClipMediaBlock[] =>
+  items.map(item => ({
+    type: 'portraitClipMedia',
+    model: {
+      type: 'video',
+      images: item.images.map(img => ({
+        source: img.url,
+        urlTemplate: img.urlTemplate,
+      })),
+      video: {
+        id: item.id,
+        title: item.title,
+        version: {
+          id: item.versionId,
+          duration: item.duration,
+          kind: item.kind,
+          guidance: item.guidance,
+          territories: item.territories,
+        },
+        isEmbeddingAllowed: item.isEmbeddingAllowed,
+      },
+    },
+  }));
+
 export interface PortraitVideoModalProps {
   items: {
     id: string;
@@ -44,28 +130,7 @@ const PortraitVideoModal = ({
   const modalRef = useRef<HTMLDialogElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
-  const blocks: PortraitClipMediaBlock[] = items.map(item => ({
-    type: 'portraitClipMedia',
-    model: {
-      type: 'video',
-      images: item.images.map(img => ({
-        source: img.url,
-        urlTemplate: img.urlTemplate,
-      })),
-      video: {
-        id: item.id,
-        title: item.title,
-        version: {
-          id: item.versionId,
-          duration: item.duration,
-          kind: item.kind,
-          guidance: item.guidance,
-          territories: item.territories,
-        },
-        isEmbeddingAllowed: item.isEmbeddingAllowed,
-      },
-    },
-  }));
+  const blocks = getBlocks(items);
 
   useEffect(() => {
     if (modalRef.current) {
@@ -80,63 +145,6 @@ const PortraitVideoModal = ({
       document.body.removeAttribute('style');
     };
   }, []);
-
-  const playlistLoadedCallback = (e?: SMPEvent) => {
-    const player = window?.embeddedMedia?.api?.players()?.bbcMediaPlayer0;
-
-    if (!player) return;
-
-    const { playlist } = e || {};
-
-    const [currentItem] = playlist?.items || [];
-
-    const currentId = currentItem?.vpid || currentItem?.versionID;
-
-    const currentIndex = blocks?.findIndex(
-      item =>
-        item.model.video.id === currentId ||
-        item.model.video.version.id === currentId,
-    );
-
-    const previous = blocks?.[currentIndex - 1]?.model;
-    const next = blocks?.[currentIndex + 1]?.model;
-
-    if (previous) {
-      const [fallbackImage, portraitImage] = previous?.images || [];
-
-      player.setPreviousPlaylist(
-        {
-          title: previous?.video?.title ?? '',
-          holdingImageURL: setImageWidth(
-            (portraitImage || fallbackImage)?.urlTemplate,
-          ),
-          items: [{ versionID: previous?.video?.version?.id }],
-        },
-        { statsObject: { clipPID: previous?.video?.id } },
-      );
-    }
-
-    if (next) {
-      const [fallbackImage, portraitImage] = next?.images || [];
-
-      player.queuePlaylist(
-        {
-          title: next?.video?.title ?? '',
-          holdingImageURL: setImageWidth(
-            (portraitImage || fallbackImage)?.urlTemplate,
-          ),
-          items: [{ versionID: next?.video?.version?.id }],
-        },
-        { statsObject: { clipPID: next?.video?.id } },
-      );
-    }
-  };
-
-  const pluginLoadedCallback = () => {
-    const player = window?.embeddedMedia?.api?.players()?.bbcMediaPlayer0;
-
-    player.dispatchEvent('fullScreenPlugin.launchFullscreen');
-  };
 
   return (
     <dialog ref={modalRef} css={styles.dialog}>
@@ -155,7 +163,7 @@ const PortraitVideoModal = ({
         css={styles.mediaWrapper}
         blocks={[blocks?.[selectedVideoIndex]]}
         eventMapping={{
-          playlistLoaded: playlistLoadedCallback,
+          playlistLoaded: e => playlistLoadedCallback(e, blocks),
           pluginLoaded: pluginLoadedCallback,
           fullscreenExit: onClose,
         }}

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -104,25 +104,31 @@ const PortraitVideoModal = ({
     if (previous) {
       const [fallbackImage, portraitImage] = previous?.images || [];
 
-      player.setPreviousPlaylist({
-        title: previous?.video?.title ?? '',
-        holdingImageURL: setImageWidth(
-          (portraitImage || fallbackImage)?.urlTemplate,
-        ),
-        items: [{ versionID: previous?.video?.version?.id }],
-      });
+      player.setPreviousPlaylist(
+        {
+          title: previous?.video?.title ?? '',
+          holdingImageURL: setImageWidth(
+            (portraitImage || fallbackImage)?.urlTemplate,
+          ),
+          items: [{ versionID: previous?.video?.version?.id }],
+        },
+        { statsObject: { clipPID: previous?.video?.id } },
+      );
     }
 
     if (next) {
       const [fallbackImage, portraitImage] = next?.images || [];
 
-      player.queuePlaylist({
-        title: next?.video?.title ?? '',
-        holdingImageURL: setImageWidth(
-          (portraitImage || fallbackImage)?.urlTemplate,
-        ),
-        items: [{ versionID: next?.video?.version?.id }],
-      });
+      player.queuePlaylist(
+        {
+          title: next?.video?.title ?? '',
+          holdingImageURL: setImageWidth(
+            (portraitImage || fallbackImage)?.urlTemplate,
+          ),
+          items: [{ versionID: next?.video?.version?.id }],
+        },
+        { statsObject: { clipPID: next?.video?.id } },
+      );
     }
   };
 


### PR DESCRIPTION
Related to https://bbc.atlassian.net/browse/WS-20 and https://bbc.atlassian.net/browse/WS-33

Summary
======
- Passes in the `statsObject` to the previous/next playlist objects as second `options` argument to ensure we are sending the correct events for the video

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

