### PR TITLE
WS-24 - PV escape key + backdrop click binding

### DIFF
--- a/src/app/components/PortraitVideoModal/index.test.tsx
+++ b/src/app/components/PortraitVideoModal/index.test.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import Component, { playlistLoadedCallback, getBlocks } from '.';
-import {
-  screen,
-  render,
-  fireEvent,
-} from '../react-testing-library-with-providers';
+import { render } from '../react-testing-library-with-providers';
 import items from './fixture';
 import { Player, SMPEvent } from '../MediaLoader/types';
 import { setImageWidth } from '../MediaLoader/configs/portraitClipMedia';
@@ -20,7 +16,7 @@ describe('PortraitVideoModal', () => {
   beforeAll(() => {
     HTMLDialogElement.prototype.show = jest.fn();
     HTMLDialogElement.prototype.showModal = jest.fn();
-    // HTMLDialogElement.prototype.close = jest.fn();
+    HTMLDialogElement.prototype.close = jest.fn();
   });
 
   it('should render the modal when active', () => {

--- a/src/app/components/PortraitVideoModal/index.test.tsx
+++ b/src/app/components/PortraitVideoModal/index.test.tsx
@@ -40,6 +40,17 @@ describe('PortraitVideoModal', () => {
     expect(mockClose).toHaveBeenCalled();
   });
 
+  it('should close the modal when the escape key is pressed', () => {
+    render(
+      <Component selectedVideoIndex={0} items={items} onClose={mockClose} />,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.keyDown(dialog, { key: 'Escape', code: 'Escape' });
+
+    expect(mockClose).toHaveBeenCalled();
+  });
+
   it('should not close the modal when clicking outside the modal with a mouse', () => {
     render(
       <Component selectedVideoIndex={0} items={items} onClose={mockClose} />,
@@ -48,7 +59,7 @@ describe('PortraitVideoModal', () => {
     const dialog = screen.getByRole('dialog');
     fireEvent.mouseDown(dialog);
 
-    expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
+    expect(mockClose).toHaveBeenCalled();
   });
 
   it('should not close the modal when clicking outside the modal with touch', () => {
@@ -59,7 +70,7 @@ describe('PortraitVideoModal', () => {
     const dialog = screen.getByRole('dialog');
     fireEvent.touchStart(dialog);
 
-    expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
+    expect(mockClose).toHaveBeenCalled();
   });
 
   describe('playlistLoadedCallback', () => {

--- a/src/app/components/PortraitVideoModal/index.test.tsx
+++ b/src/app/components/PortraitVideoModal/index.test.tsx
@@ -14,7 +14,8 @@ const mockClose = jest.fn();
 const mockPlayer = {
   queuePlaylist: jest.fn(),
   setPreviousPlaylist: jest.fn(),
-} as unknown as Player;
+  pause: jest.fn(),
+} satisfies Partial<Player>;
 
 describe('PortraitVideoModal', () => {
   beforeAll(() => {
@@ -73,6 +74,40 @@ describe('PortraitVideoModal', () => {
     expect(mockClose).toHaveBeenCalled();
   });
 
+  it('should perform clean-up when component is unmounted', () => {
+    Object.defineProperty(window, 'embeddedMedia', {
+      writable: true,
+      value: {
+        api: {
+          players: () => ({ bbcMediaPlayer0: mockPlayer }),
+        },
+      },
+    });
+
+    const { unmount } = render(
+      <Component selectedVideoIndex={0} items={items} onClose={mockClose} />,
+    );
+
+    const dialog = screen.getByRole<HTMLDialogElement>('dialog');
+    const removeEventListenerSpy = jest.spyOn(dialog, 'removeEventListener');
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'mousedown',
+      expect.any(Function),
+    );
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'touchstart',
+      expect.any(Function),
+    );
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'keydown',
+      expect.any(Function),
+    );
+    expect(mockPlayer.pause).toHaveBeenCalled();
+  });
+
   describe('playlistLoadedCallback', () => {
     beforeEach(() => {
       jest.clearAllMocks();
@@ -90,9 +125,9 @@ describe('PortraitVideoModal', () => {
     it('should call the playlistLoadedCallback and call queuePlaylist for the next video', () => {
       const blocks = getBlocks(items);
 
-      const mockSMPEvent = {
+      const mockSMPEvent: SMPEvent = {
         playlist: { items: [{ versionID: items[0].versionId }] },
-      } as SMPEvent;
+      };
 
       playlistLoadedCallback(mockSMPEvent, blocks);
 
@@ -113,9 +148,9 @@ describe('PortraitVideoModal', () => {
     it('should call the playlistLoadedCallback and call setPreviousPlaylist for the previous video and queuePlaylist for the next video', () => {
       const blocks = getBlocks(items);
 
-      const mockSMPEvent = {
+      const mockSMPEvent: SMPEvent = {
         playlist: { items: [{ versionID: items[1].versionId }] },
-      } as SMPEvent;
+      };
 
       playlistLoadedCallback(mockSMPEvent, blocks);
 
@@ -143,9 +178,9 @@ describe('PortraitVideoModal', () => {
     it('should call playlistLoadedCallback and setPreviousPlaylist if there are no next videos', () => {
       const blocks = getBlocks(items);
 
-      const mockSMPEvent = {
+      const mockSMPEvent: SMPEvent = {
         playlist: { items: [{ versionID: items[items.length - 1].versionId }] },
-      } as SMPEvent;
+      };
 
       playlistLoadedCallback(mockSMPEvent, blocks);
 

--- a/src/app/components/PortraitVideoModal/index.test.tsx
+++ b/src/app/components/PortraitVideoModal/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Component, { playlistLoadedCallback, getBlocks } from '.';
-import { render } from '../react-testing-library-with-providers';
+import { screen, render } from '../react-testing-library-with-providers';
 import items from './fixture';
 import { Player, SMPEvent } from '../MediaLoader/types';
 import { setImageWidth } from '../MediaLoader/configs/portraitClipMedia';
@@ -26,11 +26,12 @@ describe('PortraitVideoModal', () => {
   });
 
   it('should close the modal when the close button is clicked', () => {
-    const { container } = render(
+    render(
       <Component selectedVideoIndex={0} items={items} onClose={mockClose} />,
     );
 
-    container.dispatchEvent(new Event('close'));
+    const closeButton = screen.getByTestId('close-modal-button');
+    closeButton.click();
 
     expect(mockClose).toHaveBeenCalled();
   });

--- a/src/app/components/PortraitVideoModal/index.test.tsx
+++ b/src/app/components/PortraitVideoModal/index.test.tsx
@@ -28,6 +28,11 @@ describe('PortraitVideoModal', () => {
     render(
       <Component selectedVideoIndex={0} items={items} onClose={mockClose} />,
     );
+
+    const modal = screen.getByRole<HTMLDialogElement>('dialog');
+
+    expect(modal.showModal).toHaveBeenCalled();
+    expect(modal).toBeInTheDocument();
   });
 
   it('should close the modal when the close button is clicked', () => {

--- a/src/app/components/PortraitVideoModal/index.test.tsx
+++ b/src/app/components/PortraitVideoModal/index.test.tsx
@@ -36,6 +36,28 @@ describe('PortraitVideoModal', () => {
     expect(mockClose).toHaveBeenCalled();
   });
 
+  it('should not close the modal when clicking outside the modal with a mouse', () => {
+    render(
+      <Component selectedVideoIndex={0} items={items} onClose={mockClose} />,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    dialog.dispatchEvent(new MouseEvent('mousedown'));
+
+    expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
+  });
+
+  it('should not close the modal when clicking outside the modal with touch', () => {
+    render(
+      <Component selectedVideoIndex={0} items={items} onClose={mockClose} />,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    dialog.dispatchEvent(new TouchEvent('touchstart'));
+
+    expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
+  });
+
   describe('playlistLoadedCallback', () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/src/app/components/PortraitVideoModal/index.test.tsx
+++ b/src/app/components/PortraitVideoModal/index.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import Component, { playlistLoadedCallback, getBlocks } from '.';
-import { screen, render } from '../react-testing-library-with-providers';
+import {
+  screen,
+  render,
+  fireEvent,
+} from '../react-testing-library-with-providers';
 import items from './fixture';
 import { Player, SMPEvent } from '../MediaLoader/types';
 import { setImageWidth } from '../MediaLoader/configs/portraitClipMedia';
@@ -32,6 +36,16 @@ describe('PortraitVideoModal', () => {
 
     const closeButton = screen.getByTestId('close-modal-button');
     closeButton.click();
+
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it('should close the modal when the Escape key is pressed', () => {
+    const { container } = render(
+      <Component selectedVideoIndex={0} items={items} onClose={mockClose} />,
+    );
+
+    fireEvent.keyDown(container, { key: 'Escape', code: 'Escape' });
 
     expect(mockClose).toHaveBeenCalled();
   });

--- a/src/app/components/PortraitVideoModal/index.test.tsx
+++ b/src/app/components/PortraitVideoModal/index.test.tsx
@@ -20,7 +20,7 @@ describe('PortraitVideoModal', () => {
   beforeAll(() => {
     HTMLDialogElement.prototype.show = jest.fn();
     HTMLDialogElement.prototype.showModal = jest.fn();
-    HTMLDialogElement.prototype.close = jest.fn();
+    // HTMLDialogElement.prototype.close = jest.fn();
   });
 
   it('should render the modal when active', () => {
@@ -30,22 +30,11 @@ describe('PortraitVideoModal', () => {
   });
 
   it('should close the modal when the close button is clicked', () => {
-    render(
-      <Component selectedVideoIndex={0} items={items} onClose={mockClose} />,
-    );
-
-    const closeButton = screen.getByTestId('close-modal-button');
-    closeButton.click();
-
-    expect(mockClose).toHaveBeenCalled();
-  });
-
-  it('should close the modal when the Escape key is pressed', () => {
     const { container } = render(
       <Component selectedVideoIndex={0} items={items} onClose={mockClose} />,
     );
 
-    fireEvent.keyDown(container, { key: 'Escape', code: 'Escape' });
+    container.dispatchEvent(new Event('close'));
 
     expect(mockClose).toHaveBeenCalled();
   });

--- a/src/app/components/PortraitVideoModal/index.test.tsx
+++ b/src/app/components/PortraitVideoModal/index.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import Component, { playlistLoadedCallback, getBlocks } from '.';
-import { screen, render } from '../react-testing-library-with-providers';
+import {
+  screen,
+  render,
+  fireEvent,
+} from '../react-testing-library-with-providers';
 import items from './fixture';
 import { Player, SMPEvent } from '../MediaLoader/types';
 import { setImageWidth } from '../MediaLoader/configs/portraitClipMedia';
@@ -42,7 +46,7 @@ describe('PortraitVideoModal', () => {
     );
 
     const dialog = screen.getByRole('dialog');
-    dialog.dispatchEvent(new MouseEvent('mousedown'));
+    fireEvent.mouseDown(dialog);
 
     expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
   });
@@ -53,7 +57,7 @@ describe('PortraitVideoModal', () => {
     );
 
     const dialog = screen.getByRole('dialog');
-    dialog.dispatchEvent(new TouchEvent('touchstart'));
+    fireEvent.touchStart(dialog);
 
     expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
   });

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -146,6 +146,21 @@ const PortraitVideoModal = ({
     };
   }, []);
 
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <dialog ref={modalRef} css={styles.dialog}>
       <button

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -144,12 +144,19 @@ const PortraitVideoModal = ({
 
       const handleBackdropClick = (event: MouseEvent | TouchEvent) => {
         if (event.target === event.currentTarget) {
-          modalRef.current?.close();
+          onClose();
+        }
+      };
+
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          onClose();
         }
       };
 
       modalRef.current.addEventListener('mousedown', handleBackdropClick);
       modalRef.current.addEventListener('touchstart', handleBackdropClick);
+      modalRef.current.addEventListener('keydown', handleKeyDown);
     }
 
     return () => {
@@ -160,10 +167,11 @@ const PortraitVideoModal = ({
       // Pause any player if the modal is closed instantly
       if (player) player.pause();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
-    <dialog ref={modalRef} css={styles.dialog} onClose={onClose}>
+    <dialog ref={modalRef} css={styles.dialog}>
       <button
         ref={closeButtonRef}
         type="button"

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -137,17 +137,16 @@ const PortraitVideoModal = ({
       modalRef.current.showModal();
       modalRef.current.scrollTop = 0;
       closeButtonRef.current?.focus();
+      document.body.style.overflow = 'hidden';
 
       const handleBackdropClick = (event: MouseEvent | TouchEvent) => {
         if (event.target === event.currentTarget) {
-          onClose();
+          modalRef.current?.close();
         }
       };
 
       modalRef.current.addEventListener('mousedown', handleBackdropClick);
       modalRef.current.addEventListener('touchstart', handleBackdropClick);
-
-      document.body.style.overflow = 'hidden';
     }
 
     return () => {

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -138,19 +138,16 @@ const PortraitVideoModal = ({
       modalRef.current.scrollTop = 0;
       closeButtonRef.current?.focus();
 
-      modalRef.current.addEventListener('close', onClose);
-
       document.body.style.overflow = 'hidden';
     }
 
     return () => {
       document.body.removeAttribute('style');
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
-    <dialog ref={modalRef} css={styles.dialog}>
+    <dialog ref={modalRef} css={styles.dialog} onClose={onClose}>
       <button
         ref={closeButtonRef}
         type="button"

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -12,11 +12,14 @@ import styles from './index.styles';
 import { setImageWidth } from '../MediaLoader/configs/portraitClipMedia';
 import VisuallyHiddenText from '../VisuallyHiddenText';
 
+const getPlayerInstance = () =>
+  window?.embeddedMedia?.api?.players()?.bbcMediaPlayer0;
+
 export const playlistLoadedCallback = (
   e: SMPEvent,
   blocks: PortraitClipMediaBlock[],
 ) => {
-  const player = window?.embeddedMedia?.api?.players()?.bbcMediaPlayer0;
+  const player = getPlayerInstance();
 
   if (!player) return;
 
@@ -67,7 +70,7 @@ export const playlistLoadedCallback = (
 };
 
 const pluginLoadedCallback = () => {
-  const player = window?.embeddedMedia?.api?.players()?.bbcMediaPlayer0;
+  const player = getPlayerInstance();
 
   player.dispatchEvent('fullScreenPlugin.launchFullscreen');
 };
@@ -152,7 +155,7 @@ const PortraitVideoModal = ({
     return () => {
       document.body.removeAttribute('style');
 
-      const player = window?.embeddedMedia?.api?.players()?.bbcMediaPlayer0;
+      const player = getPlayerInstance();
 
       // Pause any player if the modal is closed instantly
       if (player) player.pause();

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -151,6 +151,11 @@ const PortraitVideoModal = ({
 
     return () => {
       document.body.removeAttribute('style');
+
+      const player = window?.embeddedMedia?.api?.players()?.bbcMediaPlayer0;
+
+      // Pause any players if the modal is closed instantly
+      if (player) player.pause();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -136,31 +136,37 @@ const PortraitVideoModal = ({
   const blocks = getBlocks(items);
 
   useEffect(() => {
-    if (modalRef.current) {
-      modalRef.current.showModal();
-      modalRef.current.scrollTop = 0;
+    const handleBackdropClick = (event: MouseEvent | TouchEvent) => {
+      if (event.target === event.currentTarget) {
+        onClose();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    const dialog = modalRef.current;
+
+    if (dialog) {
+      dialog.showModal?.();
+      dialog.scrollTop = 0;
       closeButtonRef.current?.focus();
       document.body.style.overflow = 'hidden';
 
-      const handleBackdropClick = (event: MouseEvent | TouchEvent) => {
-        if (event.target === event.currentTarget) {
-          onClose();
-        }
-      };
-
-      const handleKeyDown = (event: KeyboardEvent) => {
-        if (event.key === 'Escape') {
-          onClose();
-        }
-      };
-
-      modalRef.current.addEventListener('mousedown', handleBackdropClick);
-      modalRef.current.addEventListener('touchstart', handleBackdropClick);
-      modalRef.current.addEventListener('keydown', handleKeyDown);
+      dialog.addEventListener('mousedown', handleBackdropClick);
+      dialog.addEventListener('touchstart', handleBackdropClick);
+      dialog.addEventListener('keydown', handleKeyDown);
     }
 
     return () => {
       document.body.removeAttribute('style');
+
+      dialog?.removeEventListener('mousedown', handleBackdropClick);
+      dialog?.removeEventListener('touchstart', handleBackdropClick);
+      dialog?.removeEventListener('keydown', handleKeyDown);
 
       const player = getPlayerInstance();
 

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -154,10 +154,9 @@ const PortraitVideoModal = ({
 
       const player = window?.embeddedMedia?.api?.players()?.bbcMediaPlayer0;
 
-      // Pause any players if the modal is closed instantly
+      // Pause any player if the modal is closed instantly
       if (player) player.pause();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -138,25 +138,13 @@ const PortraitVideoModal = ({
       modalRef.current.scrollTop = 0;
       closeButtonRef.current?.focus();
 
+      modalRef.current.addEventListener('close', onClose);
+
       document.body.style.overflow = 'hidden';
     }
 
     return () => {
       document.body.removeAttribute('style');
-    };
-  }, []);
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onClose();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -138,12 +138,22 @@ const PortraitVideoModal = ({
       modalRef.current.scrollTop = 0;
       closeButtonRef.current?.focus();
 
+      const handleBackdropClick = (event: MouseEvent | TouchEvent) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      };
+
+      modalRef.current.addEventListener('mousedown', handleBackdropClick);
+      modalRef.current.addEventListener('touchstart', handleBackdropClick);
+
       document.body.style.overflow = 'hidden';
     }
 
     return () => {
       document.body.removeAttribute('style');
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (


### PR DESCRIPTION
Part of https://bbc.atlassian.net/browse/WS-24

Summary
======
- Fixes missed a11y AC to close the modal properly using the escape key or by clicking/tapping on the backdrop of the modal


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

