### PR TITLE
WS-467 - PV modal no css fix

### DIFF
--- a/cypress/e2e/pages/homePage/testsForCanonicalOnly.js
+++ b/cypress/e2e/pages/homePage/testsForCanonicalOnly.js
@@ -56,7 +56,7 @@ export default ({ service }) => {
               cy.get('[data-testid="promo-button"]').first().click();
             });
 
-          cy.get('dialog[open]')
+          cy.get('div[role="dialog"]')
             .should('exist')
             .and('be.visible')
             .within(() => {
@@ -73,7 +73,7 @@ export default ({ service }) => {
                 .click();
             });
 
-          cy.get('dialog[open]').should('not.exist');
+          cy.get('div[role="dialog"]').should('not.exist');
         } else {
           cy.log('No portrait video carousel found on the page');
         }
@@ -89,12 +89,12 @@ export default ({ service }) => {
               cy.get('[data-testid="promo-button"]').first().click();
             });
 
-          cy.get('dialog[open]').should('exist').and('be.visible');
+          cy.get('div[role="dialog"]').should('exist').and('be.visible');
 
           // cy.root() gets the root element of the current subject (in this case, the open modal dialog).
           cy.root().click('top');
 
-          cy.get('dialog[open]').should('not.exist');
+          cy.get('div[role="dialog"]').should('not.exist');
         } else {
           cy.log('No portrait video carousel found on the page');
         }
@@ -110,11 +110,11 @@ export default ({ service }) => {
               cy.get('[data-testid="promo-button"]').first().click();
             });
 
-          cy.get('dialog[open]').should('exist').and('be.visible');
+          cy.get('div[role="dialog"]').should('exist').and('be.visible');
 
           cy.get('body').type('{esc}');
 
-          cy.get('dialog[open]').should('not.exist');
+          cy.get('div[role="dialog"]').should('not.exist');
         } else {
           cy.log('No portrait video carousel found on the page');
         }

--- a/src/app/components/PortraitVideoModal/index.styles.tsx
+++ b/src/app/components/PortraitVideoModal/index.styles.tsx
@@ -2,9 +2,10 @@ import pixelsToRem from '#app/utilities/pixelsToRem';
 import { css, Theme } from '@emotion/react';
 
 const styles = {
-  dialog: () =>
+  modal: () =>
     css({
       position: 'fixed',
+      inset: 0,
       overflow: 'hidden',
       width: '100%',
       maxWidth: '100%',
@@ -18,8 +19,12 @@ const styles = {
       flexDirection: 'column',
       alignItems: 'center',
       justifyContent: 'center',
+      zIndex: 2,
 
-      '&::backdrop': {
+      '&::after': {
+        content: '""',
+        position: 'absolute',
+        inset: 0,
         backgroundColor: 'rgba(20, 20, 20, 0.9)',
         backdropFilter: 'blur(0.2rem)',
       },
@@ -35,6 +40,7 @@ const styles = {
       border: `${pixelsToRem(2)}rem solid ${palette.WHITE}`,
       cursor: 'pointer',
       padding: 0,
+      zIndex: 1,
 
       '&:hover, &:focus-visible': {
         backgroundColor: palette.POSTBOX,
@@ -66,6 +72,7 @@ const styles = {
         maxHeight: '100%',
         margin: 0,
         marginInline: 0,
+        zIndex: 1,
       },
 
       [mq.GROUP_3_MIN_WIDTH]: {

--- a/src/app/components/PortraitVideoModal/index.styles.tsx
+++ b/src/app/components/PortraitVideoModal/index.styles.tsx
@@ -19,7 +19,7 @@ const styles = {
       flexDirection: 'column',
       alignItems: 'center',
       justifyContent: 'center',
-      zIndex: 2,
+      zIndex: 100,
 
       '&::after': {
         content: '""',

--- a/src/app/components/PortraitVideoModal/index.styles.tsx
+++ b/src/app/components/PortraitVideoModal/index.styles.tsx
@@ -19,7 +19,7 @@ const styles = {
       flexDirection: 'column',
       alignItems: 'center',
       justifyContent: 'center',
-      zIndex: 100,
+      zIndex: 2147483647,
 
       '&::after': {
         content: '""',

--- a/src/app/components/PortraitVideoModal/index.styles.tsx
+++ b/src/app/components/PortraitVideoModal/index.styles.tsx
@@ -27,6 +27,7 @@ const styles = {
         inset: 0,
         backgroundColor: 'rgba(20, 20, 20, 0.9)',
         backdropFilter: 'blur(0.2rem)',
+        zIndex: 0,
       },
     }),
 

--- a/src/app/components/PortraitVideoModal/index.test.tsx
+++ b/src/app/components/PortraitVideoModal/index.test.tsx
@@ -28,6 +28,18 @@ describe('PortraitVideoModal', () => {
     expect(modal).toBeInTheDocument();
   });
 
+  it('should set the root React element to "inert" when the modal is open', () => {
+    render(
+      <div id="root">
+        <Component selectedVideoIndex={0} items={items} onClose={mockClose} />
+      </div>,
+    );
+
+    const rootElement = document.getElementById('root');
+
+    expect(rootElement).toHaveAttribute('inert');
+  });
+
   it('should close the modal when the close button is clicked', () => {
     render(
       <Component selectedVideoIndex={0} items={items} onClose={mockClose} />,

--- a/src/app/components/PortraitVideoModal/index.test.tsx
+++ b/src/app/components/PortraitVideoModal/index.test.tsx
@@ -18,20 +18,13 @@ const mockPlayer = {
 } satisfies Partial<Player>;
 
 describe('PortraitVideoModal', () => {
-  beforeAll(() => {
-    HTMLDialogElement.prototype.show = jest.fn();
-    HTMLDialogElement.prototype.showModal = jest.fn();
-    HTMLDialogElement.prototype.close = jest.fn();
-  });
-
   it('should render the modal when active', () => {
     render(
       <Component selectedVideoIndex={0} items={items} onClose={mockClose} />,
     );
 
-    const modal = screen.getByRole<HTMLDialogElement>('dialog');
+    const modal = screen.getByRole('dialog');
 
-    expect(modal.showModal).toHaveBeenCalled();
     expect(modal).toBeInTheDocument();
   });
 
@@ -93,7 +86,7 @@ describe('PortraitVideoModal', () => {
       <Component selectedVideoIndex={0} items={items} onClose={mockClose} />,
     );
 
-    const dialog = screen.getByRole<HTMLDialogElement>('dialog');
+    const dialog = screen.getByRole('dialog');
     const removeEventListenerSpy = jest.spyOn(dialog, 'removeEventListener');
 
     unmount();

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -130,7 +130,7 @@ const PortraitVideoModal = ({
       media: { closeVideo = 'Close' },
     },
   } = use(ServiceContext);
-  const modalRef = useRef<HTMLDialogElement>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   const blocks = getBlocks(items);
@@ -148,25 +148,24 @@ const PortraitVideoModal = ({
       }
     };
 
-    const dialog = modalRef.current;
+    const modal = modalRef.current;
 
-    if (dialog) {
-      dialog.showModal?.();
-      dialog.scrollTop = 0;
+    if (modal) {
+      modal.scrollTop = 0;
       closeButtonRef.current?.focus();
       document.body.style.overflow = 'hidden';
 
-      dialog.addEventListener('mousedown', handleBackdropClick);
-      dialog.addEventListener('touchstart', handleBackdropClick);
-      dialog.addEventListener('keydown', handleKeyDown);
+      modal.addEventListener('mousedown', handleBackdropClick);
+      modal.addEventListener('touchstart', handleBackdropClick);
+      modal.addEventListener('keydown', handleKeyDown);
     }
 
     return () => {
       document.body.removeAttribute('style');
 
-      dialog?.removeEventListener('mousedown', handleBackdropClick);
-      dialog?.removeEventListener('touchstart', handleBackdropClick);
-      dialog?.removeEventListener('keydown', handleKeyDown);
+      modal?.removeEventListener('mousedown', handleBackdropClick);
+      modal?.removeEventListener('touchstart', handleBackdropClick);
+      modal?.removeEventListener('keydown', handleKeyDown);
 
       const player = getPlayerInstance();
 
@@ -177,7 +176,7 @@ const PortraitVideoModal = ({
   }, []);
 
   return (
-    <dialog ref={modalRef} css={styles.dialog}>
+    <div role="dialog" aria-modal ref={modalRef} css={styles.modal}>
       <button
         ref={closeButtonRef}
         type="button"
@@ -198,7 +197,7 @@ const PortraitVideoModal = ({
           fullscreenExit: onClose,
         }}
       />
-    </dialog>
+    </div>
   );
 };
 

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -149,11 +149,13 @@ const PortraitVideoModal = ({
     };
 
     const modal = modalRef.current;
+    const reactRootElement = document.getElementById('root');
 
     if (modal) {
       modal.scrollTop = 0;
       closeButtonRef.current?.focus();
       document.body.style.overflow = 'hidden';
+      reactRootElement?.setAttribute('inert', 'true');
 
       modal.addEventListener('mousedown', handleBackdropClick);
       modal.addEventListener('touchstart', handleBackdropClick);
@@ -162,6 +164,7 @@ const PortraitVideoModal = ({
 
     return () => {
       document.body.removeAttribute('style');
+      reactRootElement?.removeAttribute('inert');
 
       modal?.removeEventListener('mousedown', handleBackdropClick);
       modal?.removeEventListener('touchstart', handleBackdropClick);

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -127,7 +127,7 @@ const PortraitVideoModal = ({
 }: PortraitVideoModalProps) => {
   const {
     translations: {
-      media: { closeVideo = 'Close' },
+      media: { closeVideo = 'Close', modalLabel = 'Media modal' },
     },
   } = use(ServiceContext);
   const modalRef = useRef<HTMLDivElement>(null);
@@ -176,7 +176,13 @@ const PortraitVideoModal = ({
   }, []);
 
   return (
-    <div role="dialog" aria-modal="true" ref={modalRef} css={styles.modal}>
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={modalLabel}
+      ref={modalRef}
+      css={styles.modal}
+    >
       <button
         ref={closeButtonRef}
         type="button"

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -176,7 +176,7 @@ const PortraitVideoModal = ({
   }, []);
 
   return (
-    <div role="dialog" aria-modal ref={modalRef} css={styles.modal}>
+    <div role="dialog" aria-modal="true" ref={modalRef} css={styles.modal}>
       <button
         ref={closeButtonRef}
         type="button"

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -127,7 +127,7 @@ const PortraitVideoModal = ({
 }: PortraitVideoModalProps) => {
   const {
     translations: {
-      media: { closeVideo = 'Close', modalLabel = 'Media modal' },
+      media: { closeVideo = 'Close', modalLabel = 'Media player' },
     },
   } = use(ServiceContext);
   const modalRef = useRef<HTMLDivElement>(null);

--- a/src/app/models/types/translations.ts
+++ b/src/app/models/types/translations.ts
@@ -165,6 +165,7 @@ export interface Translations {
     podcastExternalLinks?: string;
     download?: string;
     closeVideo?: string;
+    modalLabel?: string;
   };
 
   socialEmbed: {


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-467

Summary
======
- Allows the media player to be displayed in a better fashion when CSS is turned off. This is achieved by moving away from the native `dialog` element, instead using a standard `div` with `role=dialog` to maintain the same accessiblity `dialog` offers. This does mean we need to set the `z-index` to the highest value possible unfortunately, something `dialog` would have been able to handle itself.
- The player renders at the very bottom of the page since it sits outside of the `root` React element, but the content is still at least viewable. This follows PS approach to this problem. 
- Sets the root React element to be `inert` when the modal is open so that elements behind the modal cannot be focused into until the modal is closed
<img width="1627" alt="Screenshot 2025-06-18 at 09 05 00" src="https://github.com/user-attachments/assets/5a85a9b4-5e61-43c8-b671-ddd4944c4353" />

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

