### PR TITLE
WS-467 - No CSS overflow fix

### DIFF
--- a/src/app/components/PortraitVideoModal/index.styles.tsx
+++ b/src/app/components/PortraitVideoModal/index.styles.tsx
@@ -2,6 +2,12 @@ import pixelsToRem from '#app/utilities/pixelsToRem';
 import { css, Theme } from '@emotion/react';
 
 const styles = {
+  bodyOverflowHidden: () =>
+    css({
+      body: {
+        overflow: 'hidden',
+      },
+    }),
   modal: () =>
     css({
       position: 'fixed',

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -153,10 +153,9 @@ const PortraitVideoModal = ({
     const reactRootElement = document.getElementById('root');
 
     if (modal) {
-      document.body.classList.add('body-overflow-hidden');
-      reactRootElement?.setAttribute('inert', 'true');
-
       closeButtonRef.current?.focus();
+
+      reactRootElement?.setAttribute('inert', 'true');
 
       modal.addEventListener('mousedown', handleBackdropClick);
       modal.addEventListener('touchstart', handleBackdropClick);
@@ -164,7 +163,6 @@ const PortraitVideoModal = ({
     }
 
     return () => {
-      document.body.classList.remove('body-overflow-hidden');
       reactRootElement?.removeAttribute('inert');
 
       modal?.removeEventListener('mousedown', handleBackdropClick);
@@ -181,7 +179,7 @@ const PortraitVideoModal = ({
 
   return (
     <>
-      <Global styles={{ '.body-overflow-hidden': { overflow: 'hidden' } }} />
+      <Global styles={styles.bodyOverflowHidden} />
       <div
         role="dialog"
         aria-modal="true"

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -189,15 +189,6 @@ const PortraitVideoModal = ({
         ref={modalRef}
         css={styles.modal}
       >
-        <MediaLoader
-          css={styles.mediaWrapper}
-          blocks={[blocks?.[selectedVideoIndex]]}
-          eventMapping={{
-            playlistLoaded: e => playlistLoadedCallback(e, blocks),
-            pluginLoaded: pluginLoadedCallback,
-            fullscreenExit: onClose,
-          }}
-        />
         <button
           ref={closeButtonRef}
           type="button"
@@ -209,6 +200,15 @@ const PortraitVideoModal = ({
           {navigationIcons.cross}
           <VisuallyHiddenText>{closeVideo}</VisuallyHiddenText>
         </button>
+        <MediaLoader
+          css={styles.mediaWrapper}
+          blocks={[blocks?.[selectedVideoIndex]]}
+          eventMapping={{
+            playlistLoaded: e => playlistLoadedCallback(e, blocks),
+            pluginLoaded: pluginLoadedCallback,
+            fullscreenExit: onClose,
+          }}
+        />
       </div>
     </>
   );

--- a/src/app/components/PortraitVideoModal/index.tsx
+++ b/src/app/components/PortraitVideoModal/index.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
-import { jsx } from '@emotion/react';
-import { use, useEffect, useRef } from 'react';
+/* @jsxFrag React.Fragment */
+import { Global, jsx } from '@emotion/react';
+import React, { use, useEffect, useRef } from 'react';
 import MediaLoader from '#app/components/MediaLoader';
 import {
   PortraitClipMediaBlock,
@@ -152,10 +153,10 @@ const PortraitVideoModal = ({
     const reactRootElement = document.getElementById('root');
 
     if (modal) {
-      modal.scrollTop = 0;
-      closeButtonRef.current?.focus();
-      document.body.style.overflow = 'hidden';
+      document.body.classList.add('body-overflow-hidden');
       reactRootElement?.setAttribute('inert', 'true');
+
+      closeButtonRef.current?.focus();
 
       modal.addEventListener('mousedown', handleBackdropClick);
       modal.addEventListener('touchstart', handleBackdropClick);
@@ -163,7 +164,7 @@ const PortraitVideoModal = ({
     }
 
     return () => {
-      document.body.removeAttribute('style');
+      document.body.classList.remove('body-overflow-hidden');
       reactRootElement?.removeAttribute('inert');
 
       modal?.removeEventListener('mousedown', handleBackdropClick);
@@ -179,34 +180,37 @@ const PortraitVideoModal = ({
   }, []);
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label={modalLabel}
-      ref={modalRef}
-      css={styles.modal}
-    >
-      <button
-        ref={closeButtonRef}
-        type="button"
-        data-testid="close-modal-button"
-        css={styles.closeButton}
-        className="focusIndicatorInvert"
-        onClick={onClose}
+    <>
+      <Global styles={{ '.body-overflow-hidden': { overflow: 'hidden' } }} />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={modalLabel}
+        ref={modalRef}
+        css={styles.modal}
       >
-        {navigationIcons.cross}
-        <VisuallyHiddenText>{closeVideo}</VisuallyHiddenText>
-      </button>
-      <MediaLoader
-        css={styles.mediaWrapper}
-        blocks={[blocks?.[selectedVideoIndex]]}
-        eventMapping={{
-          playlistLoaded: e => playlistLoadedCallback(e, blocks),
-          pluginLoaded: pluginLoadedCallback,
-          fullscreenExit: onClose,
-        }}
-      />
-    </div>
+        <MediaLoader
+          css={styles.mediaWrapper}
+          blocks={[blocks?.[selectedVideoIndex]]}
+          eventMapping={{
+            playlistLoaded: e => playlistLoadedCallback(e, blocks),
+            pluginLoaded: pluginLoadedCallback,
+            fullscreenExit: onClose,
+          }}
+        />
+        <button
+          ref={closeButtonRef}
+          type="button"
+          data-testid="close-modal-button"
+          css={styles.closeButton}
+          className="focusIndicatorInvert"
+          onClick={onClose}
+        >
+          {navigationIcons.cross}
+          <VisuallyHiddenText>{closeVideo}</VisuallyHiddenText>
+        </button>
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
Part of JIRA: https://bbc.atlassian.net/browse/WS-467

Summary
======
- Uses a className to set the `body: { overflow: hidden }` style, rather than the `style` attribute. This is because the `style` attribute was being added _after_ the modal opened, and so still rendered the CSS when CSS was disabled and caused the page to be unscrollable. Using a className adds it to the global stylesheet, so will not allow that to happen and so allows scrolling when CSS is disabled and the modal is open

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

