### PR TITLE
Update Polish Features box title and Korean navigation

### DIFF
--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -331,10 +331,6 @@ export const service: DefaultServiceConfig = {
         url: '/korean',
       },
       {
-        title: '2025 대선',
-        url: '/korean/topics/crldxe422e0t',
-      },
-      {
         title: '비디오',
         url: '/korean/topics/cnwng7v0e54t',
       },

--- a/src/app/lib/config/services/polska.ts
+++ b/src/app/lib/config/services/polska.ts
@@ -272,7 +272,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'Najważniejsze Wiadomości',
       latestMediaTitle: 'Najnowsze wideo',
-      featuresAnalysisTitle: 'Zobacz więcej',
+      featuresAnalysisTitle: 'Polecane przez redakcję',
       ugc: {
         noJsHeading: 'Nie można załadować tej strony.',
         noJsDescription:

--- a/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
@@ -126,33 +126,26 @@ exports[`Canonical Korean Live Radio Page Header Navigation link should match te
 
 exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 2`] = `
 {
-  "text": "2025 대선",
-  "url": "/korean/topics/crldxe422e0t",
-}
-`;
-
-exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 3`] = `
-{
   "text": "비디오",
   "url": "/korean/topics/cnwng7v0e54t",
 }
 `;
 
-exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 3`] = `
 {
   "text": "라디오",
   "url": "/korean/bbc_korean_radio/programmes/w13xttll",
 }
 `;
 
-exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 4`] = `
 {
   "text": "다운로드",
   "url": "/korean/downloads",
 }
 `;
 
-exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 5`] = `
 {
   "text": "TOP 뉴스",
   "url": "/korean/popular/read",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Updates the Feature box title for Polska
- Removes Election link from Korean

Code changes
======

- Updated featuresAnalysisTitle on src/app/lib/config/services/polska.ts 
- Updated navigation section of src/app/lib/config/services/korean.ts 


![image](https://github.com/user-attachments/assets/06b21e26-486e-4978-a5ba-8f7fd75c6335)
![image](https://github.com/user-attachments/assets/0d3d314b-10a9-4207-b21e-7c32c2163866)





Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

