### PR TITLE
Disable picture-in-picture for portrait videos

### DIFF
--- a/src/app/components/MediaLoader/configs/portraitClipMedia.ts
+++ b/src/app/components/MediaLoader/configs/portraitClipMedia.ts
@@ -97,6 +97,9 @@ export default ({
           enabled: isMobile,
           useCloseIconForExitFullscreen: true,
         },
+        pictureInPicture: {
+          enabled: false,
+        },
       },
       statsObject: {
         ...basePlayerConfig.statsObject,

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -100,6 +100,9 @@ export type PlayerUiConfig = {
   poster?: {
     availableWhenSettingUp: boolean;
   };
+  pictureInPicture?: {
+    enabled: boolean;
+  };
 };
 
 export type ConfigBuilderProps = {

--- a/src/app/components/MediaLoader/utils/buildSettings.test.ts
+++ b/src/app/components/MediaLoader/utils/buildSettings.test.ts
@@ -230,6 +230,9 @@ describe('buildSettings', () => {
             poster: {
               availableWhenSettingUp: true,
             },
+            pictureInPicture: {
+              enabled: false,
+            },
           },
           superResponsive: true,
           supportFakeFullscreen: true,
@@ -300,6 +303,9 @@ describe('buildSettings', () => {
             swipable: { direction: 'Y', enabled: true },
             poster: {
               availableWhenSettingUp: true,
+            },
+            pictureInPicture: {
+              enabled: false,
             },
           },
           superResponsive: true,


### PR DESCRIPTION
Summary
======
- Disables the picture-in-picture control for portrait video media, as it can lead to an undesirable experience as the videos are intended to be viewed fullscreen or in the modal


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

