### PR TITLE
WS-413: Disable decision event in DecideAll() for page metrics

### DIFF
--- a/src/app/components/OptimizelyPageMetrics/index.test.tsx
+++ b/src/app/components/OptimizelyPageMetrics/index.test.tsx
@@ -281,6 +281,27 @@ describe('OptimizelyPageMetrics', () => {
     });
   });
 
+  it('should call decideAll with argument to disable decision impression activation event', async () => {
+    experimentsForPageMetrics.push(
+      ...[
+        {
+          pageType: ARTICLE_PAGE,
+          activeExperiments: ['mockExperiment1', 'mockExperiment2'],
+        },
+      ],
+    );
+    render(
+      <ContextWrap pageType={ARTICLE_PAGE} service="news">
+        <OptimizelyPageMetrics trackPageComplete trackPageDepth trackPageView />
+      </ContextWrap>,
+    );
+    await waitFor(() => {
+      expect(optimizely.decideAll).toHaveBeenCalledWith([
+        'DISABLE_DECISION_EVENT',
+      ]);
+    });
+  });
+
   describe('Multiple experiments on different page types', () => {
     it('should render correctly when a user is in an experiment on the current page type', async () => {
       experimentsForPageMetrics.push(

--- a/src/app/components/OptimizelyPageMetrics/index.tsx
+++ b/src/app/components/OptimizelyPageMetrics/index.tsx
@@ -1,5 +1,8 @@
 import React, { useState, useContext, useEffect } from 'react';
-import { OptimizelyContext } from '@optimizely/react-sdk';
+import {
+  OptimizelyContext,
+  OptimizelyDecideOption,
+} from '@optimizely/react-sdk';
 import { RequestContext } from '#contexts/RequestContext';
 import PageCompleteTracking from './PageCompleteTracking';
 import ScrollDepthTracking from './ScrollDepthTracking';
@@ -31,7 +34,9 @@ const OptimizelyPageMetrics = ({
   useEffect(() => {
     if (optimizelyExperimentsEnabled) {
       optimizely?.onReady().then(() => {
-        const decisions = optimizely.decideAll();
+        const decisions = optimizely.decideAll([
+          OptimizelyDecideOption.DISABLE_DECISION_EVENT,
+        ]);
         const isUserInAnyExperiments = experimentsForPageType.some(
           experimentName => {
             const decision = decisions[experimentName];


### PR DESCRIPTION
Resolves JIRA: WS-413

Summary
======
It was found that `decideAll()` was attributing impressions for pages where an experiment wasn't running. This disables sending events for the decideAll() function.

Code changes
======
- Adds enum option OptimizelyDecideOption.DISABLE_DECISION_EVENT argument
- Adds unit test to check for enum in `decideAll()`


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

