### PR TITLE
Remove tests for discontinued live radio services

### DIFF
--- a/cypress/e2e/pages/liveRadio/index.cy.js
+++ b/cypress/e2e/pages/liveRadio/index.cy.js
@@ -30,12 +30,7 @@ const testSuites = [
     runforEnv: ['local', 'test', 'live'],
     tests,
   },
-  {
-    path: '/bengali/bbc_bangla_radio/liveradio',
-    service: 'bengali',
-    runforEnv: ['local', 'test', 'live'],
-    tests,
-  },
+
   {
     path: '/burmese/bbc_burmese_radio/liveradio',
     service: 'burmese',
@@ -55,20 +50,8 @@ const testSuites = [
     tests,
   },
   {
-    path: '/indonesia/bbc_indonesian_radio/liveradio',
-    service: 'hausa',
-    runforEnv: ['local', 'test', 'live'],
-    tests,
-  },
-  {
     path: '/korean/bbc_korean_radio/liveradio',
     service: 'korean',
-    runforEnv: ['local', 'test', 'live'],
-    tests,
-  },
-  {
-    path: '/kyrgyz/bbc_kyrgyz_radio/liveradio',
-    service: 'kyrgyz',
     runforEnv: ['local', 'test', 'live'],
     tests,
   },
@@ -103,20 +86,8 @@ const testSuites = [
     tests,
   },
   {
-    path: '/tamil/bbc_tamil_radio/liveradio',
-    service: 'tamil',
-    runforEnv: ['local', 'test', 'live'],
-    tests,
-  },
-  {
     path: '/tigrinya/bbc_tigrinya_radio/liveradio',
     service: 'tigrinya',
-    runforEnv: ['local', 'test', 'live'],
-    tests,
-  },
-  {
-    path: '/urdu/bbc_urdu_radio/liveradio',
-    service: 'urdu',
     runforEnv: ['local', 'test', 'live'],
     tests,
   },


### PR DESCRIPTION
Resolves failing cypress tests in alerts channel 
Summary
======

Editorial have discontinued the following live radio services in this [belfrage PR](https://github.com/bbc/belfrage/pull/3950):

- /bbc_bangla_radio/liveradio
- /bbc_indonesia_radio/liveradio 
- /bbc_kyrgyz_radio/liveradio 
- /bbc_tamil_radio/liveradio 
- /bbc_urdu_radio/liveradio 

This removes now redundant cypress tests for them.


Code changes
======
- _A bullet point list of key code changes that have been made._


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

