### PR TITLE
WS 15 - Adds click and view tracking for Read More B Experiment

### DIFF
--- a/src/app/pages/ArticlePage/ContinueReadingButton/index.test.tsx
+++ b/src/app/pages/ArticlePage/ContinueReadingButton/index.test.tsx
@@ -132,6 +132,8 @@ describe('ContinueReadingButton', () => {
   describe('Event Tracking', () => {
     const eventTrackingData = {
       componentName: 'read-more-button',
+      experimentName: 'newswb_ws_read_more_b',
+      experimentVariant: 'read-more-b',
       sendOptimizelyEvents: true,
     };
 

--- a/src/app/pages/ArticlePage/ContinueReadingButton/index.tsx
+++ b/src/app/pages/ArticlePage/ContinueReadingButton/index.tsx
@@ -4,19 +4,19 @@ import { jsx } from '@emotion/react';
 import Text from '#app/components/Text';
 import { TriangleDown } from '#app/components/icons';
 import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
+import { EventTrackingData } from '#app/lib/analyticsUtils/types';
 import useViewTracker from '#app/hooks/useViewTracker';
 import { ServiceContext } from '#app/contexts/ServiceContext';
 import styles from './index.styles';
-import { EventTrackingData } from '#app/lib/analyticsUtils/types';
 
 export type Props = {
   showAllContent: boolean;
   setShowAllContent: () => void;
   variation:
-  | 'read-more-a'
-  | 'read-more-b'
-  | 'read-more-a-and-top-stories'
-  | null;
+    | 'read-more-a'
+    | 'read-more-b'
+    | 'read-more-a-and-top-stories'
+    | null;
   liteCTAShows?: boolean;
 };
 

--- a/src/app/pages/ArticlePage/ContinueReadingButton/index.tsx
+++ b/src/app/pages/ArticlePage/ContinueReadingButton/index.tsx
@@ -3,20 +3,20 @@ import React, { use, useEffect } from 'react';
 import { jsx } from '@emotion/react';
 import Text from '#app/components/Text';
 import { TriangleDown } from '#app/components/icons';
-import { EventTrackingMetadata } from '#app/models/types/eventTracking';
 import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import useViewTracker from '#app/hooks/useViewTracker';
 import { ServiceContext } from '#app/contexts/ServiceContext';
 import styles from './index.styles';
+import { EventTrackingData } from '#app/lib/analyticsUtils/types';
 
 export type Props = {
   showAllContent: boolean;
   setShowAllContent: () => void;
   variation:
-    | 'read-more-a'
-    | 'read-more-b'
-    | 'read-more-a-and-top-stories'
-    | null;
+  | 'read-more-a'
+  | 'read-more-b'
+  | 'read-more-a-and-top-stories'
+  | null;
   liteCTAShows?: boolean;
 };
 
@@ -26,9 +26,11 @@ const ContinueReadingButton = ({
   variation,
   liteCTAShows,
 }: Props) => {
-  const eventTrackingData: EventTrackingMetadata = {
+  const eventTrackingData: EventTrackingData = {
     componentName: 'read-more-button',
     sendOptimizelyEvents: true,
+    experimentName: 'newswb_ws_read_more_b',
+    experimentVariant: 'read-more-b',
   };
 
   const viewRef = useViewTracker(eventTrackingData);


### PR DESCRIPTION
Resolves JIRA: [WS 15](https://bbc.atlassian.net/browse/WS-15)

Fixes click and view tracking for this [PR](https://github.com/bbc/simorgh/pull/12956)
Passes in `experimentName` and `experimentVariant` to `EventTrackingData`

Summary
======
_A very high-level summary of easily-reproducible changes that can be understood by non-devs, and why these changes where made._

Code changes
======
- _A bullet point list of key code changes that have been made._


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

