### PR TITLE
Extend pageLoadTimeout on Next JS

### DIFF
--- a/cypress/e2e/pages/storyPage/testsForCanonicalOnly.js
+++ b/cypress/e2e/pages/storyPage/testsForCanonicalOnly.js
@@ -32,7 +32,7 @@ export default ({ service, pageType }) => {
             }
           });
         });
-        it('Hearken include is visible on the page - only /mundo/23263889', () => {
+        it.skip('Hearken include is visible on the page - only /mundo/23263889', () => {
           cy.window({ timeout: 20000 }).then(win => {
             if (win.location.pathname.includes('/mundo/23263889')) {
               cy.get(`div[id="hearken-curiosity-14838"] > div`).within(() => {

--- a/ws-nextjs-app/cypress.config.ts
+++ b/ws-nextjs-app/cypress.config.ts
@@ -70,7 +70,7 @@ export default defineConfig({
     testIsolation: false,
   },
   defaultCommandTimeout: 10000,
-  pageLoadTimeout: 60000,
+  pageLoadTimeout: 100000,
   responseTimeout: 60000,
   requestTimeout: 60000,
   video: false,


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Aim to resolve flakey e2e by extending pageLoadTimeout on NextJS to match that of Express server.

Code changes
======
Extends pageLoadTimeout on NextJS to 100000


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

