### PR TITLE
WS: Removes cy.getToggles from atiAnalytics to try reduce flakey-e2es

### DIFF
--- a/cypress/e2e/specialFeatures/atiAnalytics/assertions/mostRead.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/assertions/mostRead.js
@@ -1,6 +1,5 @@
 import { interceptATIAnalyticsBeacons, COMPONENTS } from '../helpers';
 import { assertATIComponentClickEvent, assertATIComponentViewEvent } from '.';
-import runIfToggleEnabled from '../../../../support/helpers/runIfToggleEnabled';
 
 const { MOST_READ } = COMPONENTS;
 
@@ -9,16 +8,9 @@ export const assertMostReadComponentView = ({
   contentType,
   useReverb,
   path,
-  service,
   applicationType,
 }) => {
-  it(`should send a view event for the Most Read component`, function test() {
-    runIfToggleEnabled({
-      service,
-      toggleName: 'mostRead',
-      testContext: this,
-    });
-
+  it(`should send a view event for the Most Read component`, () => {
     interceptATIAnalyticsBeacons();
     cy.visit(path);
 
@@ -39,16 +31,9 @@ export const assertMostReadComponentClick = ({
   contentType,
   useReverb,
   path,
-  service,
   applicationType,
 }) => {
-  it('should send a click event for the Most Read component', function test() {
-    runIfToggleEnabled({
-      service,
-      toggleName: 'mostRead',
-      testContext: this,
-    });
-
+  it('should send a click event for the Most Read component', () => {
     interceptATIAnalyticsBeacons();
     cy.visit(path);
 


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Assuming removing this and assuming Toggles won't change is better than flakes
Maybe a better approach to find out why we get an error on and off

Code changes
======
- _A bullet point list of key code changes that have been made._


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

