### PR TITLE
Debugging cy.getToggles to investigate flaky E2E tests

### DIFF
--- a/cypress/support/helpers/runIfToggleEnabled.js
+++ b/cypress/support/helpers/runIfToggleEnabled.js
@@ -1,11 +1,19 @@
 export default ({ service, toggleName, testContext }) => {
   if (service === 'scotland') return;
-  cy.getToggles(service);
 
-  cy.fixture(`toggles/${service}.json`).then(toggles => {
-    const { enabled } = toggles[toggleName];
-    if (!enabled) {
-      testContext.skip();
-    }
-  });
+  cy.log(`DEBUG cy.getToggles: type = ${typeof cy.getToggles}`);
+  cy.log(`DEBUG cy.getToggles: ${cy.getToggles}`);
+
+  if (typeof cy.getToggles === 'function') {
+    cy.getToggles(service);
+
+    cy.fixture(`toggles/${service}.json`).then(toggles => {
+      const { enabled } = toggles[toggleName];
+      if (!enabled) {
+        testContext.skip();
+      }
+    });
+  } else {
+    testContext.skip();
+  }
 };


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Help stabilise E2E Tests

Code changes
======
- Debug logging to determine if cy.getToggles is a function
- If cy.getToggles not a function, skip the test