### PR TITLE
Add in-article promo for BBC Mundo

### DIFF
--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -47,6 +47,24 @@ export const service: DefaultServiceConfig = {
     iTunesAppId: 515255747,
     showAdPlaceholder: true,
     showRelatedTopics: true,
+    podcastPromo: {
+      title: 'WhatsApp',
+      brandTitle: 'Únete a nuestro WhatsApp',
+      brandDescription:
+        'Recibe el mejor contenido de BBC News Mundo en tu celular',
+      image: {
+        src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0lrtll8.png',
+        alt: 'Redes sociales - Únete a nuestro WhatsApp',
+      },
+      linkLabel: {
+        text: 'Suscríbete aquí',
+        href: 'https://www.bbc.com/portuguese/podcasts/p07r3r3t',
+      },
+      skipLink: {
+        text: 'Saltar %title% y continuar leyendo',
+        endTextVisuallyHidden: 'Fin de %title%',
+      },
+    },
     translations: {
       pagination: {
         page: 'Página',

--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -58,7 +58,7 @@ export const service: DefaultServiceConfig = {
       },
       linkLabel: {
         text: 'Suscríbete aquí',
-        href: 'https://www.bbc.com/portuguese/podcasts/p07r3r3t',
+        href: 'https://whatsapp.com/channel/0029VaUm1Ss3WHTbgIXrjw3D',
       },
       skipLink: {
         text: 'Saltar %title% y continuar leyendo',


### PR DESCRIPTION
Resolves JIRA: 

Summary
======
Adds object to the Mundo configuration file to start using the in-article promotion for the WhatsApp channel.

Code changes
======
Adds podcastPromo object to the config file. 

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

