### PR TITLE
WS-889: Do not use reverb for tracking page views for /ws/languages

### DIFF
--- a/src/app/lib/config/services/ws.ts
+++ b/src/app/lib/config/services/ws.ts
@@ -13,7 +13,6 @@ export const service: DefaultServiceConfig = {
     atiAnalyticsAppName: 'news',
     atiAnalyticsProducerId: '64',
     atiAnalyticsProducerName: 'NEWS',
-    useReverb: true,
     chartbeatDomain: 'bbc.co.uk',
     brandName: 'BBC News',
     product: 'BBC News',

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/index.cy.ts
@@ -44,12 +44,20 @@ const canonicalTestSuites = [
   },
   {
     path: '/ws/languages',
-    runforEnv: ['local', 'test', 'live'],
+    runforEnv: ['local', 'test'],
     service: 'ws',
     pageIdentifier: 'ws.languages.page',
     applicationType: 'responsive',
     contentType: 'index-home',
-    useReverb: true,
+    tests: [assertPageView],
+  },
+  {
+    path: '/ws/languages',
+    runforEnv: ['live'],
+    service: 'ws',
+    pageIdentifier: 'ws.languages.page',
+    applicationType: 'responsive',
+    contentType: 'static',
     tests: [assertPageView],
   },
 ];


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-889

Summary
======
Do not use Reverb for `ws`

Code changes
======
- Remove `useReverb` from `ws` service config
- Update cypress tests
