### PR TITLE
WS-889: Fix E2E test - don't check value of `x1` (content ID) for /ws/languages

### DIFF
--- a/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
@@ -52,7 +52,7 @@ const assertATIPageViewEventParamsExist = ({
     expect(params).to.have.property('idclient');
   }
 
-  if (contentType !== 'list-datadriven') {
+  if (!['list-datadriven', 'static'].includes(contentType)) {
     expect(params).to.have.property('x1'); // content ID
   }
 


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-889

Summary
======
Content ID is not available for the static /ws/languages page, therefore the E2E analytics test should not run assertions for it

Code changes
======
- Don't assert that the `x1` parameter exists for static pages

## Additional Testing Steps
```
cd ws-nextjs-app
CYPRESS_APP_ENV=live yarn cypress:interactive
```

Select the ATI analytics tests from the runner - this should now pass for https://www.bbc.com/ws/languages

Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

