### PR TITLE
WS - Read Time Experiment: Send view event for control variation

### DIFF
--- a/src/app/components/ReadTime/index.styles.ts
+++ b/src/app/components/ReadTime/index.styles.ts
@@ -1,4 +1,5 @@
 import { css, Theme } from '@emotion/react';
+import pixelsToRem from '../../utilities/pixelsToRem';
 
 export default {
   readTimeText: ({ palette }: Theme) =>
@@ -14,5 +15,9 @@ export default {
       [mq.GROUP_4_MIN_WIDTH]: {
         margin: `0 0 ${spacings.DOUBLE}rem`,
       },
+    }),
+  readTimePlaceholderControl: () =>
+    css({
+      margin: `0 0 ${pixelsToRem(34.5)}rem`,
     }),
 };

--- a/src/app/components/ReadTime/index.tsx
+++ b/src/app/components/ReadTime/index.tsx
@@ -69,7 +69,6 @@ const ReadTime = ({
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const viewRef = useViewTracker(eventTrackingData);
 
-  // EXPERIMENT: Read Time
   const renderControlVariant = readTimeVariant === 'control';
 
   if (renderControlVariant)

--- a/src/app/components/ReadTime/index.tsx
+++ b/src/app/components/ReadTime/index.tsx
@@ -66,9 +66,14 @@ const ReadTime = ({
     },
   };
 
-  // Can remove disable-next-line when we remove isLive check
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const viewRef = useViewTracker(eventTrackingData);
+
+  // EXPERIMENT: Read Time
+  const renderControlVariant = readTimeVariant === 'control';
+
+  if (renderControlVariant)
+    return <div {...viewRef} css={styles.readTimePlaceholderControl} />;
 
   return (
     <div

--- a/src/app/components/ReadTime/index.tsx
+++ b/src/app/components/ReadTime/index.tsx
@@ -69,9 +69,9 @@ const ReadTime = ({
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const viewRef = useViewTracker(eventTrackingData);
 
-  const renderControlVariant = readTimeVariant === 'control';
+  const isControlVariant = readTimeVariant === 'control';
 
-  if (renderControlVariant)
+  if (isControlVariant)
     return <div {...viewRef} css={styles.readTimePlaceholderControl} />;
 
   return (

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -183,8 +183,10 @@ const getPodcastPromoComponent = (podcastPromoEnabled: boolean) => () =>
 const getHeadlineComponent =
   (readTimeData: ReadTimeData) => (props: ComponentToRenderProps) => {
     const { readTimeValue, readTimeLocation, readTimeVariant } = readTimeData;
+    // Ensures we send view event for control variant
     const showReadTimeBelowHeadline =
-      readTimeValue && readTimeLocation === 'headline';
+      (readTimeValue && readTimeLocation === 'headline') ||
+      (readTimeValue && readTimeLocation === 'control');
     return (
       <>
         <ArticleHeadline
@@ -267,7 +269,7 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
       return 'timestamp';
     }
     if (readTimeExperimentVariant.includes('control')) {
-      return 'off';
+      return 'control';
     }
     return 'off';
   })();

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -185,8 +185,8 @@ const getHeadlineComponent =
     const { readTimeValue, readTimeLocation, readTimeVariant } = readTimeData;
     // Ensures we send view event for control variant
     const showReadTimeBelowHeadline =
-      (readTimeValue && readTimeLocation === 'headline') ||
-      (readTimeValue && readTimeLocation === 'control');
+      !!readTimeValue && ['headline', 'control'].includes(readTimeLocation);
+
     return (
       <>
         <ArticleHeadline


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Sends view event for the Read Time for the Control Variation (e.g. the users that's don't see the Read Time)

Code changes
======
- Checks for Control variation
- If user is in Control variation - replaces ReadTime component with div with view tracking & appropriate padding
- (Uses location underneath headline for convenience)

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

