### PR TITLE
WS-1107 - RadioSchedule Viewability model

### DIFF
--- a/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
@@ -137,7 +137,7 @@ const getViewClickDetailsRegex = ({ contentType, component, pageIdentifier }) =>
   );
 
 const fieldIsValidString = field =>
-  typeof field === 'string' && /^[^"]+$/.test(field);
+  typeof field === 'string' && /^[\S\s]+$/.test(field);
 
 const validateViewabilityEventDetails = ({ payload, actionType }) => {
   const arr = JSON.parse(payload);

--- a/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
@@ -137,7 +137,7 @@ const getViewClickDetailsRegex = ({ contentType, component, pageIdentifier }) =>
   );
 
 const fieldIsValidString = field =>
-  typeof field === 'string' && /^[\S\s]+$/.test(field);
+  typeof field === 'string' && field.trim().length > 0;
 
 const validateViewabilityEventDetails = ({ payload, actionType }) => {
   const arr = JSON.parse(payload);

--- a/src/app/components/Curation/index.tsx
+++ b/src/app/components/Curation/index.tsx
@@ -160,6 +160,7 @@ export default ({
         <RadioSchedule
           initialData={radioSchedule}
           toggleName="homePageRadioSchedule"
+          eventTrackingData={eventTrackingData}
         />
       );
     case EMBED:

--- a/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
+++ b/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
@@ -107,6 +107,7 @@ const ScheduleItemHeader = ({
 
   const eventTrackingDataExtended = {
     ...eventTrackingData,
+    componentName: `radio-schedule-${state}`,
     itemTracker: {
       type: 'radio-schedule-promo',
       text: episodeTitle,

--- a/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
+++ b/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
@@ -113,7 +113,7 @@ const ScheduleItemHeader = ({
       text: episodeTitle,
       mediaType: 'audio',
       position: position + 1,
-      duration: moment.duration(duration).asSeconds(),
+      duration: moment.duration(duration).asMilliseconds(),
       resourceId: id,
     },
   };

--- a/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
+++ b/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
@@ -1,6 +1,7 @@
 import React, { use } from 'react';
 import styled from '@emotion/styled';
 import pathOr from 'ramda/src/pathOr';
+import moment from 'moment';
 import { formatUnixTimestamp } from '#psammead/psammead-timestamp-container/src/utilities';
 import detokenise from '#psammead/psammead-detokeniser/src';
 import LiveLabel from '#app/components/LiveLabel';
@@ -50,22 +51,22 @@ const ScheduleItemHeader = ({
   startTime,
   duration,
   id = '1',
+  position,
   ...props
 }) => {
   const {
     linkComponent = 'a',
     linkComponentAttr = 'href',
     durationLabel,
+    eventTrackingData,
   } = props;
+
   const { script, locale, service, timezone, dir, translations } =
     use(ServiceContext);
   const nextLabel = pathOr('NEXT', ['media', 'nextLabel'], translations);
   const isLive = state === 'live';
   const isNext = state === 'next';
-  const eventTrackingData = {
-    componentName: `radio-schedule-${state}`,
-  };
-  const clickTrackerHandler = useClickTrackerHandler(eventTrackingData);
+
   const listenLive = pathOr(
     'Listen Live',
     ['media', 'listenLive'],
@@ -103,6 +104,20 @@ const ScheduleItemHeader = ({
   });
 
   const listenLabel = listenLabelTranslations[state];
+
+  const eventTrackingDataExtended = {
+    ...eventTrackingData,
+    componentName: `radio-schedule-${state}`,
+    itemTracker: {
+      type: 'radio-schedule-promo',
+      text: episodeTitle,
+      mediaType: 'audio',
+      position: position + 1,
+      duration: moment.duration(duration).asSeconds(),
+      resourceId: id,
+    },
+  };
+  const clickTrackerHandler = useClickTrackerHandler(eventTrackingDataExtended);
 
   const content = (
     // This is a temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652

--- a/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
+++ b/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
@@ -107,7 +107,6 @@ const ScheduleItemHeader = ({
 
   const eventTrackingDataExtended = {
     ...eventTrackingData,
-    componentName: `radio-schedule-${state}`,
     itemTracker: {
       type: 'radio-schedule-promo',
       text: episodeTitle,

--- a/src/app/legacy/components/RadioSchedule/index.jsx
+++ b/src/app/legacy/components/RadioSchedule/index.jsx
@@ -103,6 +103,7 @@ const RadioSchedule = ({ schedule, ...props }) => {
           </StartTimeWrapper>
           <ProgramCard
             {...props}
+            eventTrackingData={eventTrackingDataExtended}
             position={index}
             program={program}
             id={id} // This ID is a temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652

--- a/src/app/legacy/components/RadioSchedule/index.jsx
+++ b/src/app/legacy/components/RadioSchedule/index.jsx
@@ -67,11 +67,17 @@ const programGridProps = {
 const RadioSchedule = ({ schedule, ...props }) => {
   const { dir } = use(ServiceContext);
 
-  const eventTrackingData = {
-    componentName: 'radio-schedule',
+  const { eventTrackingData } = props;
+
+  const eventTrackingDataExtended = {
+    ...eventTrackingData,
+    groupTracker: {
+      ...eventTrackingData?.groupTracker,
+      itemCount: schedule.length,
+    },
   };
 
-  const viewTracker = useViewTracker(eventTrackingData);
+  const viewTracker = useViewTracker(eventTrackingDataExtended);
 
   return (
     <StyledGrid
@@ -81,7 +87,7 @@ const RadioSchedule = ({ schedule, ...props }) => {
       role="list"
       {...viewTracker}
     >
-      {schedule.map(({ id, ...program }) => (
+      {schedule.map(({ id, ...program }, index) => (
         <StyledFlexGrid
           dir={dir}
           parentColumns={schedulesGridProps.columns}
@@ -97,6 +103,7 @@ const RadioSchedule = ({ schedule, ...props }) => {
           </StartTimeWrapper>
           <ProgramCard
             {...props}
+            position={index}
             program={program}
             id={id} // This ID is a temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
           />

--- a/src/app/legacy/components/RadioSchedule/index.jsx
+++ b/src/app/legacy/components/RadioSchedule/index.jsx
@@ -67,7 +67,11 @@ const programGridProps = {
 const RadioSchedule = ({ schedule, ...props }) => {
   const { dir } = use(ServiceContext);
 
-  const { eventTrackingData } = props;
+  const {
+    eventTrackingData = {
+      componentName: 'radio-schedule',
+    },
+  } = props;
 
   const eventTrackingDataExtended = {
     ...eventTrackingData,

--- a/src/app/legacy/components/RadioSchedule/index.test.jsx
+++ b/src/app/legacy/components/RadioSchedule/index.test.jsx
@@ -73,7 +73,7 @@ describe('RadioSchedule', () => {
       );
 
       expect(clickTrackerSpy).toHaveBeenNthCalledWith(1, {
-        componentName: 'radio-schedule',
+        componentName: 'radio-schedule-live',
         groupTracker: {
           itemCount: 4,
         },
@@ -87,7 +87,7 @@ describe('RadioSchedule', () => {
         },
       });
       expect(clickTrackerSpy).toHaveBeenNthCalledWith(2, {
-        componentName: 'radio-schedule',
+        componentName: 'radio-schedule-onDemand',
         groupTracker: {
           itemCount: 4,
         },

--- a/src/app/legacy/components/RadioSchedule/index.test.jsx
+++ b/src/app/legacy/components/RadioSchedule/index.test.jsx
@@ -73,7 +73,7 @@ describe('RadioSchedule', () => {
       );
 
       expect(clickTrackerSpy).toHaveBeenNthCalledWith(1, {
-        componentName: 'radio-schedule-live',
+        componentName: 'radio-schedule',
         groupTracker: {
           itemCount: 4,
         },
@@ -87,7 +87,7 @@ describe('RadioSchedule', () => {
         },
       });
       expect(clickTrackerSpy).toHaveBeenNthCalledWith(2, {
-        componentName: 'radio-schedule-onDemand',
+        componentName: 'radio-schedule',
         groupTracker: {
           itemCount: 4,
         },

--- a/src/app/legacy/components/RadioSchedule/index.test.jsx
+++ b/src/app/legacy/components/RadioSchedule/index.test.jsx
@@ -40,6 +40,9 @@ describe('RadioSchedule', () => {
   describe('Event Tracking', () => {
     const eventTrackingData = {
       componentName: 'radio-schedule',
+      groupTracker: {
+        itemCount: 4,
+      },
     };
 
     it('should call the view tracking hook with the correct params', () => {
@@ -71,9 +74,31 @@ describe('RadioSchedule', () => {
 
       expect(clickTrackerSpy).toHaveBeenNthCalledWith(1, {
         componentName: 'radio-schedule-live',
+        groupTracker: {
+          itemCount: 4,
+        },
+        itemTracker: {
+          duration: 3600,
+          mediaType: 'audio',
+          position: 1,
+          resourceId: 'p0',
+          text: '27 August 2019',
+          type: 'radio-schedule-promo',
+        },
       });
       expect(clickTrackerSpy).toHaveBeenNthCalledWith(2, {
         componentName: 'radio-schedule-onDemand',
+        groupTracker: {
+          itemCount: 4,
+        },
+        itemTracker: {
+          duration: 3600,
+          mediaType: 'audio',
+          position: 2,
+          resourceId: 'p1',
+          text: '27 August 2019',
+          type: 'radio-schedule-promo',
+        },
       });
     });
   });

--- a/src/app/legacy/components/RadioSchedule/index.test.jsx
+++ b/src/app/legacy/components/RadioSchedule/index.test.jsx
@@ -78,7 +78,7 @@ describe('RadioSchedule', () => {
           itemCount: 4,
         },
         itemTracker: {
-          duration: 3600,
+          duration: 3600000,
           mediaType: 'audio',
           position: 1,
           resourceId: 'p0',
@@ -92,7 +92,7 @@ describe('RadioSchedule', () => {
           itemCount: 4,
         },
         itemTracker: {
-          duration: 3600,
+          duration: 3600000,
           mediaType: 'audio',
           position: 2,
           resourceId: 'p1',

--- a/src/app/legacy/containers/RadioSchedule/Canonical/index.jsx
+++ b/src/app/legacy/containers/RadioSchedule/Canonical/index.jsx
@@ -90,6 +90,7 @@ const CanonicalRadioSchedule = ({
   radioSchedule,
   lang = null,
   className = '',
+  eventTrackingData,
 }) => {
   const {
     service,
@@ -128,7 +129,11 @@ const CanonicalRadioSchedule = ({
         {header}
       </RadioScheduleSectionLabel>
       <RadioScheduleWrapper data-e2e="radio-schedule">
-        <RadioSchedule schedule={radioSchedule} durationLabel={durationLabel} />
+        <RadioSchedule
+          schedule={radioSchedule}
+          durationLabel={durationLabel}
+          eventTrackingData={eventTrackingData}
+        />
         {frequenciesPageUrl && (
           <RadioFrequencyLink
             href={frequenciesPageUrl}

--- a/src/app/legacy/containers/RadioSchedule/index.jsx
+++ b/src/app/legacy/containers/RadioSchedule/index.jsx
@@ -10,6 +10,9 @@ const RadioSchedule = ({
   lang = null,
   className = '',
   toggleName,
+  eventTrackingData = {
+    componentName: 'radio-schedule',
+  },
 }) => {
   const { enabled } = useToggle(toggleName);
   const { isAmp } = use(RequestContext);
@@ -22,7 +25,12 @@ const RadioSchedule = ({
   }
 
   return (
-    <Canonical className={className} radioSchedule={initialData} lang={lang} />
+    <Canonical
+      className={className}
+      radioSchedule={initialData}
+      lang={lang}
+      eventTrackingData={eventTrackingData}
+    />
   );
 };
 

--- a/src/app/legacy/containers/RadioSchedule/index.jsx
+++ b/src/app/legacy/containers/RadioSchedule/index.jsx
@@ -10,9 +10,7 @@ const RadioSchedule = ({
   lang = null,
   className = '',
   toggleName,
-  eventTrackingData = {
-    componentName: 'radio-schedule',
-  },
+  eventTrackingData,
 }) => {
   const { enabled } = useToggle(toggleName);
   const { isAmp } = use(RequestContext);

--- a/src/app/pages/HomePage/index.test.tsx
+++ b/src/app/pages/HomePage/index.test.tsx
@@ -761,5 +761,40 @@ describe('Home Page', () => {
         expectedTrackingData,
       );
     });
+
+    it('Radio Schedule promo - click tracking', () => {
+      render(<HomePage pageData={afriqueHomePageData} />, {
+        service: 'afrique',
+        toggles: {
+          homePageRadioSchedule: { enabled: true },
+        },
+      });
+
+      const radioSchedule = afriqueHomePageData.curations.find(
+        curation => curation.radioSchedule,
+      );
+
+      const radioSchedulePromo = document.querySelector(
+        '[aria-labelledby^="scheduleItem-"]',
+      ) as HTMLAnchorElement;
+
+      expect(radioSchedulePromo).toBeInTheDocument();
+
+      fireEvent.click(radioSchedulePromo);
+
+      const expectedTrackingData = expect.objectContaining({
+        componentName: 'radio-schedule-next',
+        groupTracker: expect.objectContaining({
+          name: radioSchedule?.title,
+          type: 'radio-schedule',
+          position: (radioSchedule?.position ?? 0) + 1,
+          resourceId: radioSchedule?.curationId,
+        }),
+      });
+
+      expect(useClickTrackerHandler as jest.Mock).toHaveBeenCalledWith(
+        expectedTrackingData,
+      );
+    });
   });
 });

--- a/src/app/pages/HomePage/index.test.tsx
+++ b/src/app/pages/HomePage/index.test.tsx
@@ -521,6 +521,43 @@ describe('Home Page', () => {
         expect(matchingCall).toBeTruthy();
       });
     });
+
+    it('Radio Schedule - calls useViewTracker with correct viewability event tracking data for each radio schedule', () => {
+      render(<HomePage pageData={afriqueHomePageData} />, {
+        service: 'afrique',
+        toggles: {
+          homePageRadioSchedule: { enabled: true },
+        },
+      });
+
+      const radioSchedules = afriqueHomePageData.curations.filter(
+        curation => curation.radioSchedule,
+      );
+
+      const expectedTrackingData = radioSchedules.map(schedule => ({
+        componentName: 'radio-schedule',
+        groupTracker: {
+          name: schedule.title,
+          type: 'radio-schedule',
+          position: schedule.position + 1,
+          resourceId: schedule.curationId,
+          itemCount: schedule.radioSchedule?.length,
+        },
+      }));
+
+      const { calls } = (useViewTracker as jest.Mock).mock;
+
+      expectedTrackingData.forEach(expected => {
+        const matchingCall = calls.find(
+          ([arg]) =>
+            arg.componentName === expected.componentName &&
+            JSON.stringify(arg.groupTracker) ===
+              JSON.stringify(expected.groupTracker),
+        );
+        expect(matchingCall).toBeTruthy();
+      });
+    });
+
     describe('Hierarchical curation - click tracking', () => {
       it.each([
         {

--- a/src/app/pages/LiveRadioPage/LiveRadioPage.tsx
+++ b/src/app/pages/LiveRadioPage/LiveRadioPage.tsx
@@ -103,6 +103,7 @@ const LiveRadioPage = ({ pageData }: { pageData: LiveRadioPageData }) => {
         <RadioScheduleContainer
           initialData={radioScheduleData}
           toggleName="liveRadioSchedule"
+          eventTrackingData={{ componentName: 'radio-schedule' }}
         />
       )}
     </>

--- a/src/app/pages/OnDemandAudioPage/OnDemandAudioPage.tsx
+++ b/src/app/pages/OnDemandAudioPage/OnDemandAudioPage.tsx
@@ -204,6 +204,7 @@ const OnDemandAudioPage = ({
         <RadioScheduleContainer
           initialData={radioScheduleData}
           toggleName="onDemandRadioSchedule"
+          eventTrackingData={{ componentName: 'radio-schedule' }}
         />
       )}
     </>


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1107

Summary
======
- Adds Viewability view/click tracking to the RadioSchedule component on homepages

Code changes
======
- Sets viewability data model on the RadioSchedule components for view and individual schedule item click tracking


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

