### PR TITLE
WS-972 - Curation grids `viewThreshold` update

### DIFF
--- a/src/app/components/Curation/index.tsx
+++ b/src/app/components/Curation/index.tsx
@@ -194,7 +194,10 @@ export default ({
     case HIERARCHICAL_CURATION_GRID:
     default:
       if (summaries.length > 0) {
-        const viewTracker = useViewTracker(eventTrackingData);
+        const viewTracker = useViewTracker({
+          ...eventTrackingData,
+          viewThreshold: 0.2,
+        });
 
         const curationSubheadingClickTracker =
           useClickTrackerHandler(eventTrackingData);

--- a/src/app/pages/HomePage/index.test.tsx
+++ b/src/app/pages/HomePage/index.test.tsx
@@ -442,6 +442,7 @@ describe('Home Page', () => {
           itemCount: 4, // if the fixture data changes this will fail
         },
         componentName: 'hierarchical-curation-grid',
+        viewThreshold: 0.2,
       };
 
       const { calls } = (useViewTracker as jest.Mock).mock;
@@ -473,6 +474,7 @@ describe('Home Page', () => {
           itemCount: seventhCuration.summaries?.length,
         },
         componentName: 'simple-curation-grid',
+        viewThreshold: 0.2,
       };
       const { calls } = (useViewTracker as jest.Mock).mock;
 


### PR DESCRIPTION
Part of https://bbc.atlassian.net/browse/WS-972

Summary
======
- Sets a custom `viewThreshold` for the Hierarchical and Simple Curation grids as the 50% default caused view events to not be sent if the curation was too big for the device viewport

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

