### PR TITLE
Don't run unnecessary tests for portuguese topic page

### DIFF
--- a/cypress/e2e/pages/topicPage/index.cy.js
+++ b/cypress/e2e/pages/topicPage/index.cy.js
@@ -28,7 +28,7 @@ const testSuites = [
     path: '/portuguese/topics/cx2ggnx4j72t',
     service: 'portuguese',
     runforEnv: ['test', 'live'],
-    tests,
+    tests: [urlValidationTest],
   },
   {
     path: '/serbian/topics/c1gd303q6y6t/lat',


### PR DESCRIPTION
Resolves failing tests in our scheduled e2es

Summary
======

We added the asset `/portuguese/topics/cx2ggnx4j72t` to our topic page test suite in https://github.com/bbc/simorgh/pull/13137 so we could test it against our new url validation test. It is failing our scheduled e2es because it fails some of our other checks in the topic suite. We only care about it passing the url validation, so can remove these other checks.

Code changes
======
- Only check `/portuguese/topics/cx2ggnx4j72t` against `urlValidationTest` on test and live.


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

