### PR TITLE
Retry failing cypress tests up to 3 times

### DIFF
--- a/ws-nextjs-app/cypress/support/helpers/runTestsForPage.ts
+++ b/ws-nextjs-app/cypress/support/helpers/runTestsForPage.ts
@@ -21,27 +21,31 @@ export default ({
     const cypressEnv = Cypress.env('APP_ENV');
 
     if (runforEnv.includes(cypressEnv)) {
-      describe(`${Cypress.config().baseUrl}${path}`, { testIsolation }, () => {
-        before(() => {
-          beforeAll.forEach(runBeforeAll => runBeforeAll());
-          cy.visit(path);
-        });
+      describe(
+        `${Cypress.config().baseUrl}${path}`,
+        { testIsolation, retries: 3 },
+        () => {
+          before(() => {
+            beforeAll.forEach(runBeforeAll => runBeforeAll());
+            cy.visit(path);
+          });
 
-        beforeEach(() => {
-          cy.intercept(
-            {
-              url: `https://cdn.optimizely.com/datafiles/${getOptimizelyKey()}.json`,
-            },
-            request => {
-              request.reply({ statusCode: 404 });
-            },
-          ).as('disable-optimizely');
-        });
+          beforeEach(() => {
+            cy.intercept(
+              {
+                url: `https://cdn.optimizely.com/datafiles/${getOptimizelyKey()}.json`,
+              },
+              request => {
+                request.reply({ statusCode: 404 });
+              },
+            ).as('disable-optimizely');
+          });
 
-        tests.forEach(test => {
-          test({ path, pageType, ...params });
-        });
-      });
+          tests.forEach(test => {
+            test({ path, pageType, ...params });
+          });
+        },
+      );
     }
   });
 };


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Attempt to stabilise the cypress tests by retrying the failing test up to 3 times

Code changes
======
- Add `retries: 3` to the cypress test runner options