### PR TITLE
NOTICKET - `/og/` API cache-control

### DIFF
--- a/ws-nextjs-app/app/api/[service]/og/[id]/route.api.tsx
+++ b/ws-nextjs-app/app/api/[service]/og/[id]/route.api.tsx
@@ -201,7 +201,7 @@ export async function GET(
         fonts,
         headers: {
           'Cache-Control':
-            'public, stale-if-error=300, stale-while-revalidate=120, max-age=30',
+            'public, stale-if-error=3600, stale-while-revalidate=3600, max-age=600',
         },
       },
     );

--- a/ws-nextjs-app/app/api/[service]/og/[id]/route.api.tsx
+++ b/ws-nextjs-app/app/api/[service]/og/[id]/route.api.tsx
@@ -199,6 +199,10 @@ export async function GET(
         width: 1024,
         height: 576,
         fonts,
+        headers: {
+          'Cache-Control':
+            'public, stale-if-error=300, stale-while-revalidate=120, max-age=30',
+        },
       },
     );
   } catch (error: unknown) {


### PR DESCRIPTION
Summary
======
- Adds `Cache-Control` to the new `/og/` API route as Route Handlers are not cached by default: https://nextjs.org/docs/app/getting-started/route-handlers-and-middleware#caching
- Sets `max-age` to 10 minutes and `stale-while-revalidating` and `stale-if-error` to 1 hour
- This may need some adjusting to find a balance between serving cached Opengraph images and hitting origin, but this is better than no caching at all

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

