### PR TITLE
NOTICKET - `/og/` api add `content-length` header

### DIFF
--- a/ws-nextjs-app/app/api/[service]/og/[id]/route.api.test.ts
+++ b/ws-nextjs-app/app/api/[service]/og/[id]/route.api.test.ts
@@ -5,6 +5,15 @@
 import * as fetchPageData from '#app/routes/utils/fetchPageData';
 import { GET as api } from './route.api';
 
+// mock ImageResponse
+jest.mock('next/og', () => {
+  return {
+    ImageResponse: jest.fn().mockImplementation(() => {
+      return new Response('mocked image response', { status: 200 });
+    }),
+  };
+});
+
 describe('GET /api/og', () => {
   beforeEach(() => {
     jest.restoreAllMocks();

--- a/ws-nextjs-app/app/api/[service]/og/[id]/route.api.tsx
+++ b/ws-nextjs-app/app/api/[service]/og/[id]/route.api.tsx
@@ -12,6 +12,10 @@ import {
 } from '#app/routes/utils/constructPageFetchUrl';
 import { INTERNAL_SERVER_ERROR, NOT_FOUND } from '#app/lib/statusCodes.const';
 import defaultServiceVariants from '#app/lib/config/services/defaultServiceVariants';
+import sendCustomMetric from '#src/server/utilities/customMetrics';
+import { NON_200_RESPONSE } from '#src/server/utilities/customMetrics/metrics.const';
+import nodeLogger from '#lib/logger.node';
+import { SERVER_SIDE_REQUEST_FAILED } from '#app/lib/logger.const';
 import Badge from '../Badge';
 import {
   extractArticleData,
@@ -25,6 +29,9 @@ import {
   ArabicTopStoriesSVG,
   RTLLiveSVG,
 } from '../RTLBadges';
+
+const logger = nodeLogger(__filename);
+const pageTypeToLog = 'og-image';
 
 const REITH_SANS_MEDIUM_FONT_URL = `${REITH_FONTS_DIR}BBCReithSans_W_Md.woff`;
 const REITH_SANS_BOLD_FONT_URL = `${REITH_FONTS_DIR}BBCReithSans_W_Bd.woff`;
@@ -168,7 +175,7 @@ export async function GET(
       badge = null; // No badge for RTL services other than Arabic for initial experiment
     }
 
-    return new ImageResponse(
+    const imageResponse = new ImageResponse(
       (
         <div
           style={{
@@ -201,8 +208,34 @@ export async function GET(
         fonts,
       },
     );
+
+    const buffer = Buffer.from(await imageResponse.arrayBuffer());
+
+    return new Response(buffer, {
+      headers: {
+        'Content-Type': 'image/png',
+        'Content-Length': buffer.length.toString(),
+        'Cache-Control':
+          'public, stale-if-error=3600, stale-while-revalidate=3600, max-age=600',
+      },
+    });
   } catch (error: unknown) {
     const { message } = error as FetchError;
+
+    sendCustomMetric({
+      metricName: NON_200_RESPONSE,
+      statusCode: 500,
+      // @ts-expect-error - Not a real pageType yet
+      pageType: pageTypeToLog,
+      requestUrl: req.url,
+    });
+
+    logger.error(SERVER_SIDE_REQUEST_FAILED, {
+      status: 500,
+      message: { message, url: req.url },
+      url: req.url,
+      pageType: pageTypeToLog,
+    });
 
     return new Response(message, { status: 500 });
   }


### PR DESCRIPTION
Summary
======
- Adds `Content-Length` header to see if fixes errors with Load Balancer throwing 5xx errors
- Adds `Cache-Control` to the new `/og/` API route as Route Handlers are not cached by default: https://nextjs.org/docs/app/getting-started/route-handlers-and-middleware#caching
- Sets `max-age` to 10 minutes and `stale-while-revalidating` and `stale-if-error` to 1 hour
- This may need some adjusting to find a balance between serving cached Opengraph images and hitting origin, but this is better than no caching at all
- Adds error logging to help debug non-200 issues


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

