### PR TITLE
WS-1282: Add translations

### DIFF
--- a/src/app/components/Curation/CurationPromo/index.tsx
+++ b/src/app/components/Curation/CurationPromo/index.tsx
@@ -99,7 +99,7 @@ const CurationPromo = ({
         )}
       </Promo.Heading>
       {!isLive ? (
-        <Promo.Timestamp className="promo-timestamp">
+        <Promo.Timestamp className="promo-timestamp" showPrefix>
           {lastPublished}
         </Promo.Timestamp>
       ) : null}

--- a/src/app/components/Curation/HierarchicalGrid/index.test.tsx
+++ b/src/app/components/Curation/HierarchicalGrid/index.test.tsx
@@ -12,6 +12,15 @@ describe('Hierarchical Grid Curation', () => {
   suppressPropWarnings(['children', 'string', 'MediaIcon']);
 
   const headingLevel = 2;
+
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-09-16T11:34:20.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it('renders twelve promos when twelve items are provided', async () => {
     render(
       <HierarchicalGrid
@@ -117,6 +126,21 @@ describe('Hierarchical Grid Curation', () => {
     );
 
     expect(getByText('29 julio 2023')).toBeInTheDocument();
+  });
+
+  it('for articles pushed under 10 hours ago, it should render the last published date in a relative format', async () => {
+    const { container } = render(
+      <HierarchicalGrid
+        headingLevel={headingLevel}
+        summaries={mediaFixture}
+        eventTrackingData={minimalEventTrackingData}
+      />,
+      {
+        service: 'mundo',
+      },
+    );
+    const timestampText = container.querySelectorAll('time')?.[2].innerHTML;
+    expect(timestampText).toBe('Publicado hace 34 minutos');
   });
 
   it('should use role text when using nested spans', async () => {

--- a/src/app/components/Curation/HierarchicalGrid/index.tsx
+++ b/src/app/components/Curation/HierarchicalGrid/index.tsx
@@ -176,7 +176,7 @@ const HiearchicalGrid = ({
                 </Promo.Body>
                 {!isLive ? (
                   <div className="timestamp-read-time-container">
-                    <Promo.Timestamp className="promo-timestamp">
+                    <Promo.Timestamp className="promo-timestamp" showPrefix>
                       {promo.lastPublished}
                     </Promo.Timestamp>
                     {/* EXPERIMENT: Read Time */}

--- a/src/app/components/Curation/HierarchicalGrid/mediaFixtures.js
+++ b/src/app/components/Curation/HierarchicalGrid/mediaFixtures.js
@@ -26,6 +26,19 @@ const mundoPromos = [
     isLive: true,
   },
   {
+    type: 'article',
+    title: 'Recently published promo',
+    firstPublished: '2022-11-22T17:23:05.000Z',
+    lastPublished: '2025-09-16T11:00:20.000Z',
+    link: 'https://www.test.bbc.com/mundo/live/23539555',
+    imageUrl:
+      'https://ichef.test.bbci.co.uk/ace/ws/{width}/cpsdevpb/6847/test/_63959662_rogerio-toledo-redjtvanyh8-unsplash.jpg',
+    description: 'Testing image gallery for Tipo',
+    imageAlt: 'test',
+    id: '5756bb09-a257-455a-a5c3-622702785bff',
+    isLive: false,
+  },
+  {
     type: 'video',
     title: 'Test video article',
     firstPublished: '2022-05-12T10:41:14.000Z',

--- a/src/app/legacy/components/Promo/timestamp.jsx
+++ b/src/app/legacy/components/Promo/timestamp.jsx
@@ -22,6 +22,7 @@ const PromoTimestamp = ({
 
   const isRelative = isTenHoursAgo(new Date(children).getTime());
 
+  // EXPERIMENT: Homepage Read Time
   const prefix = timstampPrefix?.publishedAgo;
 
   return (

--- a/src/app/legacy/components/Promo/timestamp.jsx
+++ b/src/app/legacy/components/Promo/timestamp.jsx
@@ -7,9 +7,18 @@ const PromoTimestamp = ({
   children,
   serviceDatetimeLocale = '',
   className = '',
+  showPrefix,
 }) => {
-  const { altCalendar, script, datetimeLocale, service, timezone } =
-    use(ServiceContext);
+  const {
+    altCalendar,
+    script,
+    datetimeLocale,
+    service,
+    timezone,
+    translations: {
+      timstampPrefix: { publishedAgo },
+    },
+  } = use(ServiceContext);
 
   const locale = serviceDatetimeLocale || datetimeLocale;
 
@@ -28,6 +37,7 @@ const PromoTimestamp = ({
       timezone={timezone}
       isRelative={isRelative}
       className={className}
+      {...(isRelative && showPrefix && { prefix: publishedAgo })}
     />
   );
 };

--- a/src/app/legacy/components/Promo/timestamp.jsx
+++ b/src/app/legacy/components/Promo/timestamp.jsx
@@ -15,14 +15,14 @@ const PromoTimestamp = ({
     datetimeLocale,
     service,
     timezone,
-    translations: {
-      timstampPrefix: { publishedAgo },
-    },
+    translations: { timstampPrefix },
   } = use(ServiceContext);
 
   const locale = serviceDatetimeLocale || datetimeLocale;
 
   const isRelative = isTenHoursAgo(new Date(children).getTime());
+
+  const prefix = timstampPrefix?.publishedAgo;
 
   return (
     <Timestamp
@@ -37,7 +37,7 @@ const PromoTimestamp = ({
       timezone={timezone}
       isRelative={isRelative}
       className={className}
-      {...(isRelative && showPrefix && { prefix: publishedAgo })}
+      {...(isRelative && showPrefix && { prefix })}
     />
   );
 };

--- a/src/app/legacy/components/Promo/timestamp.jsx
+++ b/src/app/legacy/components/Promo/timestamp.jsx
@@ -7,7 +7,7 @@ const PromoTimestamp = ({
   children,
   serviceDatetimeLocale = '',
   className = '',
-  showPrefix,
+  showPrefix = false,
 }) => {
   const {
     altCalendar,

--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -73,6 +73,9 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      timstampPrefix: {
+        publishedAgo: 'Publicado hace',
+      },
       readTime: {
         readTimePrefix: 'Tiempo de lectura',
         quick: 'Lectura rápida',

--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -73,6 +73,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      // EXPERIMENT: Homepage Read Time
       timstampPrefix: {
         publishedAgo: 'Publicado hace',
       },

--- a/src/app/models/types/translations.ts
+++ b/src/app/models/types/translations.ts
@@ -54,6 +54,7 @@ export interface Translations {
     minute: string;
     minutes: string;
   }>;
+  // EXPERIMENT: Homepage Read Time
   timstampPrefix?: {
     publishedAgo?: string;
   };

--- a/src/app/models/types/translations.ts
+++ b/src/app/models/types/translations.ts
@@ -54,6 +54,9 @@ export interface Translations {
     minute: string;
     minutes: string;
   }>;
+  timstampPrefix?: {
+    publishedAgo?: string;
+  };
   byline?: {
     author?: string;
     articleInformation?: string;


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1282

Summary
======
Adds 'published ago' prefic to all relative time stamps on the Mundo hompage.

Code changes
======
- _Service config update._
- _Minor update to timestamp promo component._

Non relative timestamps will stay the same:
<img width="262" height="381" alt="Screenshot 2025-09-16 at 10 56 56" src="https://github.com/user-attachments/assets/ec997e70-67f5-4868-a925-f6530011c895" />

Relative timestamps will see the prefix added:
<img width="1047" height="700" alt="Screenshot 2025-09-16 at 10 56 51" src="https://github.com/user-attachments/assets/d65bdd16-f0a8-4d2a-a7d1-1008b3ad4b34" />

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

