### PR TITLE
WS-917 - Use `getEnvConfig` for CDN url lookup

### DIFF
--- a/src/app/components/Metadata/index.tsx
+++ b/src/app/components/Metadata/index.tsx
@@ -3,7 +3,7 @@ import { jsx, useTheme } from '@emotion/react';
 import { use } from 'react';
 import { Helmet } from 'react-helmet';
 import { RequestContext } from '#contexts/RequestContext';
-import { PageTypes, Services } from '#app/models/types/global';
+import { Environments, PageTypes, Services } from '#app/models/types/global';
 import {
   getArticleId,
   getTipoId,
@@ -14,6 +14,7 @@ import {
   LIVE_PAGE,
   MEDIA_ARTICLE_PAGE,
 } from '#app/routes/utils/pageTypes';
+import { getEnvConfig } from '#app/lib/utilities/getEnvConfig';
 import { ServiceContext } from '../../contexts/ServiceContext';
 import {
   getIconAssetUrl,
@@ -62,6 +63,12 @@ const OG_EXPERIMENT_PAGETYPES: PageTypes[] = [
   LIVE_PAGE,
 ];
 
+const CDN_URLS: Record<Environments, string> = {
+  local: 'http://localhost:7081',
+  test: 'https://web-cdn.test.api.bbci.co.uk',
+  live: 'https://web-cdn.api.bbci.co.uk',
+};
+
 const getSocialShareImage = ({
   metaImage,
   pageType,
@@ -84,11 +91,7 @@ const getSocialShareImage = ({
   // Fallback to 'metaImage' if no id can be determined
   if (!id) return metaImage;
 
-  const CDN_URL = {
-    local: 'http://localhost:7081',
-    test: 'https://web-cdn.test.api.bbci.co.uk',
-    live: 'https://web-cdn.api.bbci.co.uk',
-  }[process.env.SIMORGH_APP_ENV as string];
+  const CDN_URL = CDN_URLS[getEnvConfig().SIMORGH_APP_ENV];
 
   return `${CDN_URL}/${service}/og/${id}`;
 };


### PR DESCRIPTION
Part of https://bbc.atlassian.net/browse/WS-917

Summary
======
- Uses the `getEnvConfig()` utility to extract the `process.env.SIMORGH_APP_ENV` variable, otherwise it will be `undefined`

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

