### PR TITLE
WS-1351 - Revert X to using original `metaImage` value

### DIFF
--- a/src/app/components/Metadata/index.tsx
+++ b/src/app/components/Metadata/index.tsx
@@ -265,7 +265,7 @@ const MetadataContainer = ({
       <meta name="twitter:creator" content={metaTwitterHandle} />
       <meta name="twitter:description" content={description} />
       <meta name="twitter:image:alt" content={metaImageAltText} />
-      <meta name="twitter:image:src" content={socialShareImage} />
+      <meta name="twitter:image:src" content={metaImage} />
       <meta name="twitter:site" content={twitterSite} />
       <meta name="twitter:title" content={socialTitle} />
       {!isAmp && (

--- a/src/integration/pages/articles/hausa/__snapshots__/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/hausa/__snapshots__/__snapshots__/amp.test.js.snap
@@ -316,7 +316,7 @@ exports[`AMP Articles SEO Twitter description 1`] = `"Wannan shine taken SEO na 
 
 exports[`AMP Articles SEO Twitter image alt 1`] = `"BBC News Hausa"`;
 
-exports[`AMP Articles SEO Twitter image src 1`] = `"http://localhost:7081/hausa/og/c2nr6xqmnewo"`;
+exports[`AMP Articles SEO Twitter image src 1`] = `"https://news.files.bbci.co.uk/ws/img/logos/og/hausa.png"`;
 
 exports[`AMP Articles SEO Twitter site 1`] = `"@bbchausa"`;
 

--- a/src/integration/pages/articles/hausa/__snapshots__/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/hausa/__snapshots__/__snapshots__/canonical.test.js.snap
@@ -341,7 +341,7 @@ exports[`Canonical Articles SEO Twitter description 1`] = `"Wannan shine taken S
 
 exports[`Canonical Articles SEO Twitter image alt 1`] = `"BBC News Hausa"`;
 
-exports[`Canonical Articles SEO Twitter image src 1`] = `"http://localhost:7081/hausa/og/c2nr6xqmnewo"`;
+exports[`Canonical Articles SEO Twitter image src 1`] = `"https://news.files.bbci.co.uk/ws/img/logos/og/hausa.png"`;
 
 exports[`Canonical Articles SEO Twitter site 1`] = `"@bbchausa"`;
 


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1351

Summary
======
- Reverts X to using the original `metaImage` value, as the domain used for the thumbnail experiment is more restrictive and X can't scrape the meta tag data from it


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

