### PR TITLE
WS-499: Renames parseAvRoute to parseRoute

### DIFF
--- a/src/app/components/MediaLoader/utils/urlConstructors.ts
+++ b/src/app/components/MediaLoader/utils/urlConstructors.ts
@@ -1,5 +1,5 @@
 import isLive from '#app/lib/utilities/isLive';
-import parseAvRoute from '#app/routes/utils/parseAvRoute';
+import parseAvRoute from '#app/routes/utils/parseRoute';
 
 const LIVE_BASE_URL = 'https://www.bbc.com';
 const TEST_BASE_URL = 'https://www.test.bbc.com';

--- a/src/app/components/MediaLoader/utils/urlConstructors.ts
+++ b/src/app/components/MediaLoader/utils/urlConstructors.ts
@@ -1,5 +1,5 @@
 import isLive from '#app/lib/utilities/isLive';
-import parseAvRoute from '#app/routes/utils/parseRoute';
+import parseRoute from '#app/routes/utils/parseRoute';
 
 const LIVE_BASE_URL = 'https://www.bbc.com';
 const TEST_BASE_URL = 'https://www.test.bbc.com';
@@ -16,7 +16,7 @@ type FuncProps = {
 export const getAmpIframeUrl = ({ id, versionID, lang }: FuncProps) => {
   if (!id) return null;
 
-  const { platform, service, variant, assetId } = parseAvRoute(id);
+  const { platform, service, variant, assetId } = parseRoute(id);
 
   const ampBaseUrl = isLive() ? LIVE_AMP_URL : TEST_AMP_URL;
 
@@ -34,7 +34,7 @@ export const getAmpIframeUrl = ({ id, versionID, lang }: FuncProps) => {
 export const getExternalEmbedUrl = ({ id, versionID, lang }: FuncProps) => {
   if (!id) return null;
 
-  const { platform, service, variant, assetId } = parseAvRoute(id);
+  const { platform, service, variant, assetId } = parseRoute(id);
 
   const baseUrl = isLive() ? LIVE_BASE_URL : TEST_BASE_URL;
 

--- a/src/app/routes/utils/constructPageFetchUrl/index.ts
+++ b/src/app/routes/utils/constructPageFetchUrl/index.ts
@@ -28,7 +28,7 @@ import {
   UGC_PAGE,
   LIVE_TV_PAGE,
 } from '../pageTypes';
-import parseAvRoute from '../parseAvRoute';
+import parseAvRoute from '../parseRoute';
 
 const removeLeadingSlash = (path: string) => path?.replace(/^\/+/g, '');
 const removeAmp = (path: string) => path.split('.')[0];

--- a/src/app/routes/utils/constructPageFetchUrl/index.ts
+++ b/src/app/routes/utils/constructPageFetchUrl/index.ts
@@ -28,7 +28,7 @@ import {
   UGC_PAGE,
   LIVE_TV_PAGE,
 } from '../pageTypes';
-import parseAvRoute from '../parseRoute';
+import parseRoute from '../parseRoute';
 
 const removeLeadingSlash = (path: string) => path?.replace(/^\/+/g, '');
 const removeAmp = (path: string) => path.split('.')[0];
@@ -112,7 +112,7 @@ const getId = ({ pageType, service, variant, env }: GetIdProps) => {
       break;
     case AV_EMBEDS:
       getIdFunction = (path: string) => {
-        const parsedRoute = parseAvRoute(path);
+        const parsedRoute = parseRoute(path);
 
         const isShortCpsId = parsedRoute?.assetId?.length === 8;
 
@@ -260,7 +260,7 @@ const constructPageFetchUrl = ({
         break;
       }
       case AV_EMBEDS: {
-        const parsedRoute = parseAvRoute(pathname);
+        const parsedRoute = parseRoute(pathname);
 
         if (parsedRoute.isWsRoute) {
           // handle /ws/av-embeds route

--- a/src/app/routes/utils/parseRoute/index.test.ts
+++ b/src/app/routes/utils/parseRoute/index.test.ts
@@ -1,4 +1,4 @@
-import parseAvRoute from '.';
+import parseRoute from '.';
 
 const EXAMPLE_ROUTES = [
   {
@@ -88,11 +88,11 @@ const EXAMPLE_ROUTES = [
   },
 ];
 
-describe('parseAvRoute', () => {
+describe('parseRoute', () => {
   it.each(EXAMPLE_ROUTES)(
     'should return valid route config for %s route',
     ({ route, expectedOutput }) => {
-      const result = parseAvRoute(route);
+      const result = parseRoute(route);
 
       expect(result).toMatchObject(expectedOutput);
     },
@@ -107,7 +107,7 @@ describe('parseAvRoute', () => {
       assetId: '67303123',
     };
 
-    const result = parseAvRoute(route);
+    const result = parseRoute(route);
 
     expect(result).toMatchObject(expectedOutput);
   });

--- a/src/app/routes/utils/parseRoute/index.test.ts
+++ b/src/app/routes/utils/parseRoute/index.test.ts
@@ -86,6 +86,17 @@ const EXAMPLE_ROUTES = [
       lang: 'pcm',
     },
   },
+  {
+    route: '/ws/av-embeds/live/c7p765ynk9qt/p01thw20/pcm/amp',
+    expectedOutput: {
+      service: null,
+      platform: 'tipo',
+      assetId: 'c7p765ynk9qt',
+      mediaId: 'p01thw20',
+      lang: 'pcm',
+      isAmp: true,
+    },
+  },
 ];
 
 describe('parseRoute', () => {

--- a/src/app/routes/utils/parseRoute/index.ts
+++ b/src/app/routes/utils/parseRoute/index.ts
@@ -147,7 +147,7 @@ const extractMediaDelimiter = (query: Query) => {
   return mediaDelimiter ?? null;
 };
 
-export default function parseAvRoute(resolvedUrl: string) {
+export default function parseRoute(resolvedUrl: string) {
   const resolvedUrlWithoutQuery = resolvedUrl.split('?')?.[0];
 
   const query = resolvedUrlWithoutQuery.split(/[/.]/).filter(Boolean);

--- a/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.ts
+++ b/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.ts
@@ -6,7 +6,7 @@ import certsRequired from '#app/routes/utils/certsRequired';
 import getEnvironment from '#app/routes/utils/getEnvironment';
 import { FetchError } from '#app/models/types/fetch';
 import constructPageFetchUrl from '#app/routes/utils/constructPageFetchUrl';
-import parseAvRoute from '#app/routes/utils/parseAvRoute';
+import parseAvRoute from '#app/routes/utils/parseRoute';
 import filterForBlockType from '#app/lib/utilities/blockHandlers';
 import nodeLogger from '#lib/logger.node';
 import { OK } from '#app/lib/statusCodes.const';

--- a/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.ts
+++ b/ws-nextjs-app/pages/[service]/av-embeds/handleAvRoute.ts
@@ -6,7 +6,7 @@ import certsRequired from '#app/routes/utils/certsRequired';
 import getEnvironment from '#app/routes/utils/getEnvironment';
 import { FetchError } from '#app/models/types/fetch';
 import constructPageFetchUrl from '#app/routes/utils/constructPageFetchUrl';
-import parseAvRoute from '#app/routes/utils/parseRoute';
+import parseRoute from '#app/routes/utils/parseRoute';
 import filterForBlockType from '#app/lib/utilities/blockHandlers';
 import nodeLogger from '#lib/logger.node';
 import { OK } from '#app/lib/statusCodes.const';
@@ -37,7 +37,7 @@ export default async (context: GetServerSidePropsContext) => {
   // Remove x-frame-options header to allow embedding
   context.res.removeHeader('x-frame-options');
 
-  const parsedRoute = parseAvRoute(resolvedUrl);
+  const parsedRoute = parseRoute(resolvedUrl);
 
   const avEmbedsUrl = constructPageFetchUrl({
     pageType: AV_EMBEDS,


### PR DESCRIPTION
Resolves JIRA: [WS-499](https://bbc.atlassian.net/browse/WS-499)

Summary
======
Renames parseAvRoute util to parseRoute to cater for article migration for Next.js

Code changes
======
- Renames parseAvRoute


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

