### PR TITLE
Add `cypress:install` step to Github Action E2Es

### DIFF
--- a/.github/workflows/simorgh-e2e-application-nextjs.yml
+++ b/.github/workflows/simorgh-e2e-application-nextjs.yml
@@ -31,9 +31,16 @@ jobs:
       - name: Add bbc.com domain
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
+      - name: Install Cypress dependency
+        run: yarn add cypress --dev
+
+      - name: Install Cypress binary
+        run: yarn cypress:install
+
       - name: Run Simorgh E2Es (Application)
         uses: cypress-io/github-action@v6
         with:
+          install: false
           build: yarn build
           start: yarn start
           command: yarn cypress:application
@@ -41,6 +48,7 @@ jobs:
       - name: Run Simorgh NextJS E2Es
         uses: cypress-io/github-action@v6
         with:
+          install: false
           working-directory: ws-nextjs-app
           build: yarn build
           start: yarn start

--- a/.github/workflows/simorgh-e2e-application-nextjs.yml
+++ b/.github/workflows/simorgh-e2e-application-nextjs.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Cypress dependency (Next.js app)
         run: |
           chmod +x ./scripts/installCypress.sh
-          ./scripts/installCypress.sh /ws-nextjs-app
+          ./scripts/installCypress.sh ws-nextjs-app
 
       - name: Install Cypress binary (Next.js app)
         working-directory: ws-nextjs-app

--- a/.github/workflows/simorgh-e2e-application-nextjs.yml
+++ b/.github/workflows/simorgh-e2e-application-nextjs.yml
@@ -32,7 +32,7 @@ jobs:
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable --check-cache
 
       - name: Install Cypress binary
         run: yarn cypress:install
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install dependencies (Next.js app)
         working-directory: ws-nextjs-app
-        run: yarn install
+        run: yarn install --immutable --check-cache
 
       - name: Install Cypress binary (Next.js app)
         working-directory: ws-nextjs-app

--- a/.github/workflows/simorgh-e2e-application-nextjs.yml
+++ b/.github/workflows/simorgh-e2e-application-nextjs.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Add bbc.com domain
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
-      - name: Install Cypress dependency
-        run: yarn add cypress --dev
+      - name: Install dependencies
+        run: yarn install
 
       - name: Install Cypress binary
         run: yarn cypress:install
@@ -45,9 +45,9 @@ jobs:
           start: yarn start
           command: yarn cypress:application
 
-      - name: Install Cypress dependency (Next.js app)
+      - name: Install dependencies (Next.js app)
         working-directory: ws-nextjs-app
-        run: yarn add cypress --dev
+        run: yarn install
 
       - name: Install Cypress binary (Next.js app)
         working-directory: ws-nextjs-app

--- a/.github/workflows/simorgh-e2e-application-nextjs.yml
+++ b/.github/workflows/simorgh-e2e-application-nextjs.yml
@@ -45,6 +45,14 @@ jobs:
           start: yarn start
           command: yarn cypress:application
 
+      - name: Install Cypress dependency (Next.js app)
+        working-directory: ws-nextjs-app
+        run: yarn add cypress --dev
+
+      - name: Install Cypress binary (Next.js app)
+        working-directory: ws-nextjs-app
+        run: yarn cypress:install
+
       - name: Run Simorgh NextJS E2Es
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/simorgh-e2e-application-nextjs.yml
+++ b/.github/workflows/simorgh-e2e-application-nextjs.yml
@@ -31,8 +31,10 @@ jobs:
       - name: Add bbc.com domain
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
-      - name: Install dependencies
-        run: yarn install --immutable --check-cache
+      - name: Install Cypress dependency
+        run: |
+          chmod +x ./scripts/installCypress.sh
+          ./scripts/installCypress.sh
 
       - name: Install Cypress binary
         run: yarn cypress:install
@@ -45,9 +47,10 @@ jobs:
           start: yarn start
           command: yarn cypress:application
 
-      - name: Install dependencies (Next.js app)
-        working-directory: ws-nextjs-app
-        run: yarn install --immutable --check-cache
+      - name: Install Cypress dependency (Next.js app)
+        run: |
+          chmod +x ./scripts/installCypress.sh
+          ./scripts/installCypress.sh /ws-nextjs-app
 
       - name: Install Cypress binary (Next.js app)
         working-directory: ws-nextjs-app

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Add bbc.com domain
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
-      - name: Install dependencies
+      - name: Install Cypress dependency
         run: |
           chmod +x ./scripts/installCypress.sh
           ./scripts/installCypress.sh

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Add bbc.com domain
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
+      - name: Install Cypress
+        run: yarn cypress:install
+
       - name: Run Simorgh E2Es (Pages)
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Run Simorgh E2Es (Pages)
         uses: cypress-io/github-action@v6
         with:
+          install: false
           build: yarn build
           start: yarn start
           command: yarn cypress:pages

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -32,7 +32,7 @@ jobs:
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
       - name: Install dependencies
-        run: yarn install --immutable --check-cache
+        run: ./scripts/installCypress.sh
 
       - name: Install Cypress binary
         run: yarn cypress:install

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -32,9 +32,9 @@ jobs:
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
       - name: Install dependencies
-        run: |
-          chmod +x ./scripts/install-cypress.sh
-          ./scripts/install-cypress.sh
+      run: |
+          chmod +x ./scripts/installCypress.sh
+          ./scripts/installCypress.sh
 
       - name: Install Cypress binary
         run: yarn cypress:install

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Add bbc.com domain
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
-      - name: Install Cypress dependency
-        run: yarn add cypress --dev
+      - name: Install dependencies
+        run: yarn install
 
       - name: Install Cypress binary
         run: yarn cypress:install

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -39,6 +39,9 @@ jobs:
           restore-keys: |
             cypress-${{ runner.os }}-
 
+      - name: Install Cypress
+        run: yarn add cypress --dev
+
       - name: Run Simorgh E2Es (Pages)
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -36,11 +36,12 @@ jobs:
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-${{ hashFiles('yarn.lock', 'ws-nextjs-app/yarn.lock') }}
-          restore-keys: |
-            cypress-${{ runner.os }}-
+
+      - name: Install Cypress dependency
+        run: yarn add cypress --dev
 
       - name: Install Cypress
-        run: yarn add cypress --dev
+        run: yarn cypress:install
 
       - name: Run Simorgh E2Es (Pages)
         uses: cypress-io/github-action@v6

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -31,9 +31,13 @@ jobs:
       - name: Add bbc.com domain
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
-      - name: Install Node Modules
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: ./scripts/installNodeModules.sh
+      - name: Restore Cypress binary cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-${{ hashFiles('yarn.lock', 'ws-nextjs-app/yarn.lock') }}
+          restore-keys: |
+            cypress-${{ runner.os }}-
 
       - name: Run Simorgh E2Es (Pages)
         uses: cypress-io/github-action@v6

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -31,8 +31,9 @@ jobs:
       - name: Add bbc.com domain
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
-      - name: Install Cypress
-        run: yarn cypress:install
+      - name: Install Node Modules
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: ./scripts/installNodeModules.sh
 
       - name: Run Simorgh E2Es (Pages)
         uses: cypress-io/github-action@v6

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -32,7 +32,7 @@ jobs:
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable --check-cache
 
       - name: Install Cypress binary
         run: yarn cypress:install

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -32,7 +32,9 @@ jobs:
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
       - name: Install dependencies
-        run: ./scripts/installCypress.sh
+        run: |
+          chmod +x ./scripts/install-cypress.sh
+          ./scripts/install-cypress.sh
 
       - name: Install Cypress binary
         run: yarn cypress:install

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Cypress dependency
         run: yarn add cypress --dev
 
-      - name: Install Cypress
+      - name: Install Cypress binary
         run: yarn cypress:install
 
       - name: Run Simorgh E2Es (Pages)

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -31,12 +31,6 @@ jobs:
       - name: Add bbc.com domain
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
-      - name: Restore Cypress binary cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-${{ hashFiles('yarn.lock', 'ws-nextjs-app/yarn.lock') }}
-
       - name: Install Cypress dependency
         run: yarn add cypress --dev
 

--- a/.github/workflows/simorgh-e2e-pages.yml
+++ b/.github/workflows/simorgh-e2e-pages.yml
@@ -32,7 +32,7 @@ jobs:
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
       - name: Install dependencies
-      run: |
+        run: |
           chmod +x ./scripts/installCypress.sh
           ./scripts/installCypress.sh
 

--- a/.github/workflows/simorgh-e2e-special-features.yml
+++ b/.github/workflows/simorgh-e2e-special-features.yml
@@ -31,9 +31,16 @@ jobs:
       - name: Add bbc.com domain
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
+      - name: Install Cypress dependency
+        run: yarn add cypress --dev
+
+      - name: Install Cypress binary
+        run: yarn cypress:install
+
       - name: Run Simorgh E2Es (Special Features)
         uses: cypress-io/github-action@v6
         with:
+          install: false
           build: yarn build
           start: yarn start
           command: yarn cypress:special-features

--- a/.github/workflows/simorgh-e2e-special-features.yml
+++ b/.github/workflows/simorgh-e2e-special-features.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Add bbc.com domain
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
-      - name: Install Cypress dependency
-        run: yarn add cypress --dev
+      - name: Install dependencies
+        run: yarn install
 
       - name: Install Cypress binary
         run: yarn cypress:install

--- a/.github/workflows/simorgh-e2e-special-features.yml
+++ b/.github/workflows/simorgh-e2e-special-features.yml
@@ -31,8 +31,10 @@ jobs:
       - name: Add bbc.com domain
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
-      - name: Install dependencies
-        run: yarn install --immutable --check-cache
+      - name: Install Cypress dependency
+        run: |
+          chmod +x ./scripts/installCypress.sh
+          ./scripts/installCypress.sh
 
       - name: Install Cypress binary
         run: yarn cypress:install

--- a/.github/workflows/simorgh-e2e-special-features.yml
+++ b/.github/workflows/simorgh-e2e-special-features.yml
@@ -32,7 +32,7 @@ jobs:
         run: sudo echo "127.0.0.1 localhost.bbc.com" | sudo tee -a /etc/hosts
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable --check-cache
 
       - name: Install Cypress binary
         run: yarn cypress:install

--- a/scripts/installCypress.sh
+++ b/scripts/installCypress.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+# Get working directory from first argument, default to current directory
+WORKDIR="${1:-.}"
+
+# Check if package.json exists in the working directory
+if [ ! -f "$WORKDIR/package.json" ]; then
+  echo "Error: package.json not found in $WORKDIR."
+  exit 1
+fi
+
+# Extract Cypress version from devDependencies using jq
+CYPRESS_VERSION=$(jq -r '.devDependencies.cypress // empty' "$WORKDIR/package.json")
+
+if [ -z "$CYPRESS_VERSION" ]; then
+  echo "Error: Cypress version not found in devDependencies of $WORKDIR/package.json."
+  exit 1
+fi
+
+echo "Installing Cypress version $CYPRESS_VERSION in $WORKDIR"
+yarn --cwd "$WORKDIR" add "cypress@$CYPRESS_VERSION" --dev
+
+echo "Cypress $CYPRESS_VERSION installed successfully in $WORKDIR."


### PR DESCRIPTION
Summary
======
- Fixes E2E Github Actions following Cypress advisory on installing only Cypress as a dependency: https://github.com/cypress-io/github-action?tab=readme-ov-file#install-cypress-only
- I think under-the-hood Cypress uses a postinstall script to install its binary in its Action. So we need to set that to `install:false` and install it manually ourselves prior to running the e2e tests.


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

