### PR TITLE
Revert "WS 1184 - Go live with updated og:meta images"

### DIFF
--- a/src/app/components/Metadata/index.test.tsx
+++ b/src/app/components/Metadata/index.test.tsx
@@ -1253,13 +1253,10 @@ describe('Metadata', () => {
           env        | pageType              | pathName                      | expectedUrl
           ${'local'} | ${ARTICLE_PAGE}       | ${`/${service}/c0000000001o`} | ${`http://localhost:7081/${service}/og/c0000000001o`}
           ${'test'}  | ${ARTICLE_PAGE}       | ${`/${service}/c0000000001o`} | ${`https://web-cdn.test.api.bbci.co.uk/${service}/og/c0000000001o`}
-          ${'live'}  | ${ARTICLE_PAGE}       | ${`/${service}/c0000000001o`} | ${`https://web-cdn.api.bbci.co.uk/${service}/og/c0000000001o`}
           ${'local'} | ${MEDIA_ARTICLE_PAGE} | ${`/${service}/c0000000001o`} | ${`http://localhost:7081/${service}/og/c0000000001o`}
           ${'test'}  | ${MEDIA_ARTICLE_PAGE} | ${`/${service}/c0000000001o`} | ${`https://web-cdn.test.api.bbci.co.uk/${service}/og/c0000000001o`}
-          ${'live'}  | ${MEDIA_ARTICLE_PAGE} | ${`/${service}/c0000000001o`} | ${`https://web-cdn.api.bbci.co.uk/${service}/og/c0000000001o`}
           ${'local'} | ${LIVE_PAGE}          | ${`/${service}/c0000000001t`} | ${`http://localhost:7081/${service}/og/c0000000001t`}
           ${'test'}  | ${LIVE_PAGE}          | ${`/${service}/c0000000001t`} | ${`https://web-cdn.test.api.bbci.co.uk/${service}/og/c0000000001t`}
-          ${'live'}  | ${LIVE_PAGE}          | ${`/${service}/c0000000001t`} | ${`https://web-cdn.api.bbci.co.uk/${service}/og/c0000000001t`}
         `(
           `should return the Opengraph image API url for $pageType page on $env Env`,
           ({ env, pageType, pathName, expectedUrl }) => {
@@ -1280,6 +1277,26 @@ describe('Metadata', () => {
             expect(ogImageTag?.content).toEqual(expectedUrl);
           },
         );
+
+        it(`should return the default image if on Live Env`, () => {
+          process.env.SIMORGH_APP_ENV = 'live';
+
+          render(
+            // @ts-expect-error - testing with subset of data
+            <MetadataWithContext
+              service={service as Services}
+              bbcOrigin={dotCoDotUKOrigin}
+              pageType={ARTICLE_PAGE}
+              pathname={`/${service}/c0000000001o`}
+            />,
+          );
+
+          const ogImageTag = getOgImageTag();
+
+          expect(ogImageTag?.content).toEqual(
+            `https://news.files.bbci.co.uk/ws/img/logos/og/${service}.png`,
+          );
+        });
 
         it(`should return the default image if the id cannot be determined from the pathname`, () => {
           process.env.SIMORGH_APP_ENV = 'test';

--- a/src/app/components/Metadata/index.tsx
+++ b/src/app/components/Metadata/index.tsx
@@ -8,6 +8,7 @@ import {
   getArticleId,
   getTipoId,
 } from '#app/routes/utils/constructPageFetchUrl';
+import isLive from '#app/lib/utilities/isLive';
 import {
   ARTICLE_PAGE,
   LIVE_PAGE,
@@ -79,6 +80,9 @@ const getSocialShareImage = ({
   pathname: string;
   service: Services;
 }) => {
+  // TODO: Remove to release experiment
+  if (isLive()) return metaImage;
+
   if (!OG_EXPERIMENT_SERVICES.includes(service)) return metaImage;
   if (!OG_EXPERIMENT_PAGETYPES.includes(pageType)) return metaImage;
 

--- a/src/app/components/Metadata/index.tsx
+++ b/src/app/components/Metadata/index.tsx
@@ -80,7 +80,7 @@ const getSocialShareImage = ({
   pathname: string;
   service: Services;
 }) => {
-  // TODO: Remove to release experiment
+  // Remove to release to Production
   if (isLive()) return metaImage;
 
   if (!OG_EXPERIMENT_SERVICES.includes(service)) return metaImage;


### PR DESCRIPTION
Reverts bbc/simorgh#13193

We are reverting this PR in order to stop the Whatsapp Thumbnail images trial that has been running.

Jira [WS-1407](https://bbc.atlassian.net/browse/WS-1407)