### PR TITLE
Add magyarul to list of psammead font-families so that correct fonts can be rendered on legacy components

### DIFF
--- a/src/app/components/ThemeProvider/fontFacesLazy.ts
+++ b/src/app/components/ThemeProvider/fontFacesLazy.ts
@@ -244,6 +244,7 @@ export default (service: Services, isPWA: boolean) => {
   switch (service) {
     case 'news':
     case 'newsround':
+    case 'magyarul':
     case 'mundo':
     case 'polska':
     case 'portuguese':

--- a/src/app/legacy/psammead/psammead-styles/src/__snapshots__/font-families.test.js.snap
+++ b/src/app/legacy/psammead/psammead-styles/src/__snapshots__/font-families.test.js.snap
@@ -500,6 +500,61 @@ exports[`Psammead Styles - Font Families should match learningenglish 1`] = `
 }
 `;
 
+exports[`Psammead Styles - Font Families should match magyarul 1`] = `
+{
+  "sansBold": "
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
+   font-weight: 700;
+   font-style: normal;
+  ",
+  "sansBoldItalic": "
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
+   font-weight: 700;
+   font-style: italic;
+  ",
+  "sansLight": "
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
+   font-weight: 300;
+   font-style: normal;
+  ",
+  "sansRegular": "
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
+   font-weight: 400;
+   font-style: normal;
+  ",
+  "sansRegularItalic": "
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
+   font-weight: 400;
+   font-style: italic;
+  ",
+  "serifBold": "
+    font-family: ReithSerif, Helvetica, Arial, sans-serif;
+    font-weight: 700;
+   font-style: normal;
+  ",
+  "serifLight": "
+   font-family: ReithSerif, Helvetica, Arial, sans-serif;
+   font-weight: 300;
+   font-style: normal;
+  ",
+  "serifMedium": "
+   font-family: ReithSerif, Helvetica, Arial, sans-serif;
+   font-weight: 500;
+   font-style: normal;
+  ",
+  "serifMediumItalic": "
+   font-family: ReithSerif, Helvetica, Arial, sans-serif;
+   font-weight: 500;
+   font-style: italic;
+  ",
+  "serifRegular": "
+   font-family: ReithSerif, Helvetica, Arial, sans-serif;
+   font-weight: 400;
+   font-style: normal;
+  ",
+}
+`;
+
 exports[`Psammead Styles - Font Families should match marathi 1`] = `
 {
   "sansBold": "

--- a/src/app/legacy/psammead/psammead-styles/src/__snapshots__/font-styles.test.js.snap
+++ b/src/app/legacy/psammead/psammead-styles/src/__snapshots__/font-styles.test.js.snap
@@ -160,6 +160,14 @@ exports[`should render SansBold correctly for learningenglish 1`] = `
   "
 `;
 
+exports[`should render SansBold correctly for magyarul 1`] = `
+"
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
+   font-weight: 700;
+   font-style: normal;
+  "
+`;
+
 exports[`should render SansBold correctly for marathi 1`] = `
 "
     font-family: "Noto Sans Devanagari", Hind, "Mukta Vaani", Gautami, "Kohinoor Devanagari", sans-serif;
@@ -577,6 +585,14 @@ exports[`should render SansBoldItalic correctly for kyrgyz 1`] = `
 `;
 
 exports[`should render SansBoldItalic correctly for learningenglish 1`] = `
+"
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
+   font-weight: 700;
+   font-style: italic;
+  "
+`;
+
+exports[`should render SansBoldItalic correctly for magyarul 1`] = `
 "
    font-family: ReithSans, Helvetica, Arial, sans-serif;
    font-weight: 700;
@@ -1008,6 +1024,14 @@ exports[`should render SansLight correctly for learningenglish 1`] = `
   "
 `;
 
+exports[`should render SansLight correctly for magyarul 1`] = `
+"
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
+   font-weight: 300;
+   font-style: normal;
+  "
+`;
+
 exports[`should render SansLight correctly for marathi 1`] = `
 "
     font-family: "Noto Sans Devanagari", Hind, "Mukta Vaani", Gautami, "Kohinoor Devanagari", sans-serif;
@@ -1425,6 +1449,14 @@ exports[`should render SansRegular correctly for kyrgyz 1`] = `
 `;
 
 exports[`should render SansRegular correctly for learningenglish 1`] = `
+"
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
+   font-weight: 400;
+   font-style: normal;
+  "
+`;
+
+exports[`should render SansRegular correctly for magyarul 1`] = `
 "
    font-family: ReithSans, Helvetica, Arial, sans-serif;
    font-weight: 400;
@@ -1856,6 +1888,14 @@ exports[`should render SansRegularItalic correctly for learningenglish 1`] = `
   "
 `;
 
+exports[`should render SansRegularItalic correctly for magyarul 1`] = `
+"
+   font-family: ReithSans, Helvetica, Arial, sans-serif;
+   font-weight: 400;
+   font-style: italic;
+  "
+`;
+
 exports[`should render SansRegularItalic correctly for marathi 1`] = `
 "
     font-family: "Noto Sans Devanagari", Hind, "Mukta Vaani", Gautami, "Kohinoor Devanagari", sans-serif;
@@ -2273,6 +2313,14 @@ exports[`should render SerifBold correctly for kyrgyz 1`] = `
 `;
 
 exports[`should render SerifBold correctly for learningenglish 1`] = `
+"
+    font-family: ReithSerif, Helvetica, Arial, sans-serif;
+    font-weight: 700;
+   font-style: normal;
+  "
+`;
+
+exports[`should render SerifBold correctly for magyarul 1`] = `
 "
     font-family: ReithSerif, Helvetica, Arial, sans-serif;
     font-weight: 700;
@@ -2704,6 +2752,14 @@ exports[`should render SerifLight correctly for learningenglish 1`] = `
   "
 `;
 
+exports[`should render SerifLight correctly for magyarul 1`] = `
+"
+   font-family: ReithSerif, Helvetica, Arial, sans-serif;
+   font-weight: 300;
+   font-style: normal;
+  "
+`;
+
 exports[`should render SerifLight correctly for marathi 1`] = `
 "
     font-family: "Noto Sans Devanagari", Hind, "Mukta Vaani", Gautami, "Kohinoor Devanagari", sans-serif;
@@ -3121,6 +3177,14 @@ exports[`should render SerifMedium correctly for kyrgyz 1`] = `
 `;
 
 exports[`should render SerifMedium correctly for learningenglish 1`] = `
+"
+   font-family: ReithSerif, Helvetica, Arial, sans-serif;
+   font-weight: 500;
+   font-style: normal;
+  "
+`;
+
+exports[`should render SerifMedium correctly for magyarul 1`] = `
 "
    font-family: ReithSerif, Helvetica, Arial, sans-serif;
    font-weight: 500;
@@ -3552,6 +3616,14 @@ exports[`should render SerifMediumItalic correctly for learningenglish 1`] = `
   "
 `;
 
+exports[`should render SerifMediumItalic correctly for magyarul 1`] = `
+"
+   font-family: ReithSerif, Helvetica, Arial, sans-serif;
+   font-weight: 500;
+   font-style: italic;
+  "
+`;
+
 exports[`should render SerifMediumItalic correctly for marathi 1`] = `
 "
     font-family: "Noto Sans Devanagari", Hind, "Mukta Vaani", Gautami, "Kohinoor Devanagari", sans-serif;
@@ -3969,6 +4041,14 @@ exports[`should render SerifRegular correctly for kyrgyz 1`] = `
 `;
 
 exports[`should render SerifRegular correctly for learningenglish 1`] = `
+"
+   font-family: ReithSerif, Helvetica, Arial, sans-serif;
+   font-weight: 400;
+   font-style: normal;
+  "
+`;
+
+exports[`should render SerifRegular correctly for magyarul 1`] = `
 "
    font-family: ReithSerif, Helvetica, Arial, sans-serif;
    font-weight: 400;

--- a/src/app/legacy/psammead/psammead-styles/src/font-families.js
+++ b/src/app/legacy/psammead/psammead-styles/src/font-families.js
@@ -382,6 +382,7 @@ export const japanese = japaneseStyles;
 export const korean = koreanStyles;
 export const kyrgyz = helmetFontStyles;
 export const learningenglish = latinReithFontStyles;
+export const magyarul = latinReithFontStyles;
 export const marathi = marathiStyles;
 export const mundo = latinReithFontStyles;
 export const naidheachdan = latinReithFontStyles;


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1492

Summary
======
Ensure legacy components can support magyarul fonts

Code changes
======
Add magyarul to list of fontFaces + font-families

Testing
======

- [ ] Manual Testing required?

http://localhost:7080/magyarul/articles/cwywderkzy2o?renderer_env=live

Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

