### PR TITLE
Track scroll depth in Optimizely for homepage experiment

### DIFF
--- a/cypress/e2e/pages/topicPage/tests.js
+++ b/cypress/e2e/pages/topicPage/tests.js
@@ -39,6 +39,7 @@ export default ({ service, pageType, variant = 'default', path }) => {
             cy.on('uncaught:exception', ({ message }) => {
               if (
                 [
+                  `Cannot read properties of undefined (reading 'count')`,
                   'ResizeObserver loop completed with undelivered notifications',
                 ].some(error => message.includes(error))
               ) {

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -42,6 +42,7 @@ const KNOWN_ERRORS = [
   `Cannot read properties of null (reading 'postMessage')`,
   'Error emitting event to page/plugin, swallowed by Toucan',
   `Cannot read properties of undefined (reading 'exitPictureInPicture')`,
+  `Cannot read properties of undefined (reading 'count')`,
 ];
 
 // eslint-disable-next-line consistent-return

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -152,7 +152,9 @@ const HomePage = ({ pageData }: HomePageProps) => {
           </div>
         </div>
       </main>
-      {timeOfDayVariant && <OptimizelyPageMetrics trackPageView />}
+      {timeOfDayVariant && (
+        <OptimizelyPageMetrics trackPageView trackPageDepth />
+      )}
     </>
   );
 };


### PR DESCRIPTION
Part of https://bbc.atlassian.net/browse/WS-937

Summary
======
- Adds scroll depth tracking to homepage for time-of-day experiment

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

