### PR TITLE
FIX: small tweak

### DIFF
--- a/src/server/utilities/cspHeader/directives.js
+++ b/src/server/utilities/cspHeader/directives.js
@@ -312,7 +312,7 @@ export const generateFontSrc = ({
   isLive,
   shouldServeLimitedCsp = false,
 }) => {
-  if (shouldServeLimitedCsp) return ['https:  data:'];
+  if (shouldServeLimitedCsp) return ["https:  data: 'self'"];
   if (!isLive && isAmp) return directives.fontSrc.ampNonLive.sort();
   if (!isLive && !isAmp) return directives.fontSrc.canonicalNonLive.sort();
   if (isLive && isAmp) return directives.fontSrc.ampLive.sort();
@@ -344,7 +344,7 @@ export const generateImgSrc = ({
 };
 
 export const generateMediaSrc = ({ shouldServeLimitedCsp = false }) => {
-  if (shouldServeLimitedCsp) return ["'self' blob: data: https:"];
+  if (shouldServeLimitedCsp) return ["'self' blob: data: https: "];
   return ["'self' blob: https:"];
 };
 
@@ -355,7 +355,7 @@ export const generateScriptSrc = ({
   shouldServeLimitedCsp = false,
 }) => {
   if (shouldServeLimitedCsp)
-    return ["https: 'unsafe-inline' 'unsafe-eval' blob:"];
+    return ["https: 'unsafe-inline' 'unsafe-eval' blob: data: 'self'"];
   const insertedNonce = nonce ? [`'nonce-${nonce}'`, "'unsafe-eval'"] : [];
   if (!isLive && isAmp) return directives.scriptSrc.ampNonLive.sort();
   if (!isLive && !isAmp)

--- a/src/server/utilities/cspHeader/directives.js
+++ b/src/server/utilities/cspHeader/directives.js
@@ -312,7 +312,7 @@ export const generateFontSrc = ({
   isLive,
   shouldServeLimitedCsp = false,
 }) => {
-  if (shouldServeLimitedCsp) return ["https:  data: 'self'"];
+  if (shouldServeLimitedCsp) return ["https:  data: blob: 'self'"];
   if (!isLive && isAmp) return directives.fontSrc.ampNonLive.sort();
   if (!isLive && !isAmp) return directives.fontSrc.canonicalNonLive.sort();
   if (isLive && isAmp) return directives.fontSrc.ampLive.sort();

--- a/src/server/utilities/cspHeader/directives.js
+++ b/src/server/utilities/cspHeader/directives.js
@@ -344,7 +344,7 @@ export const generateImgSrc = ({
 };
 
 export const generateMediaSrc = ({ shouldServeLimitedCsp = false }) => {
-  if (shouldServeLimitedCsp) return ["'self' blob: data: https: "];
+  if (shouldServeLimitedCsp) return ["'self' blob: data: https:"];
   return ["'self' blob: https:"];
 };
 


### PR DESCRIPTION
After https://github.com/bbc/simorgh/pull/13260 CSP violations dropped for japanese, but not to 0, with `script-src-elem` and `script-src-attr` being the main culprits (which should fall back to `script-src` directives.

Font-src was also showing a few violations.

Based on these comments https://stackoverflow.com/questions/64322419/why-is-script-src-elem-not-using-values-from-script-src-as-a-fallback I think adding `data:` would be a good next step