### PR TITLE
WS-1513 - Add `marginBottom` to MPU Ad slot

### DIFF
--- a/src/app/components/Ad/Canonical/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Ad/Canonical/__snapshots__/index.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`CanonicalAds Ads Snapshots should correctly render a Canonical mpu ad w
   display: none;
   visibility: hidden;
   padding: 0;
+  margin-bottom: 1.5rem;
 }
 
 @media (min-width: 18.75rem) {

--- a/src/app/components/Ad/MPU/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Ad/MPU/__snapshots__/index.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`MPU should render without gel margins at all breakpoints and gel paddin
   display: none;
   visibility: hidden;
   padding: 0;
+  margin-bottom: 1.5rem;
 }
 
 @media (min-width: 18.75rem) {

--- a/src/app/components/Ad/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Ad/__snapshots__/index.test.tsx.snap
@@ -624,6 +624,7 @@ exports[`Ad Container Snapshots Canonical should correctly render an mpu ad 1`] 
   display: none;
   visibility: hidden;
   padding: 0;
+  margin-bottom: 1.5rem;
 }
 
 @media (min-width: 18.75rem) {

--- a/src/app/components/Ad/utilities/adSlot.styles.ts
+++ b/src/app/components/Ad/utilities/adSlot.styles.ts
@@ -101,6 +101,8 @@ const styles = {
       display: 'none',
       visibility: 'hidden',
       padding: 0,
+      marginBottom: `${spacings.TRIPLE}rem`,
+
       [`@media (min-width: ${MPU_WIDTH_MIN})`]: {
         minHeight: MPU_HEIGHTS.GROUP_1,
         display: 'flex',


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1513

Summary
======
- Adds `marginBottom: 1.5rem` to the MPU Ad slot so that the spacing between it and the next bit of content (typically a paragraph) is spaced correctly

Before:
<img width="726" height="582" alt="Screenshot 2025-10-16 at 11 07 50" src="https://github.com/user-attachments/assets/903d5f56-ec5e-4ee4-95f3-407928bc17de" />

After:
<img width="726" height="606" alt="Screenshot 2025-10-16 at 11 07 19" src="https://github.com/user-attachments/assets/f6fc7f51-9d81-4dd9-aed8-13239393a876" />

Developer Checklist
======
- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

