### PR TITLE
WS-1550: Add Component tracking for opera mini

### DIFF
--- a/src/app/components/ATIAnalytics/canonical/sendPageViewBeaconOperaMini/index.ts
+++ b/src/app/components/ATIAnalytics/canonical/sendPageViewBeaconOperaMini/index.ts
@@ -1,12 +1,13 @@
 import isOperaProxy from '#app/lib/utilities/isOperaProxy';
 
 export default (atiPageViewUrlString: string) => `
+    console.log("CHECK IS OPERA", ${isOperaProxy.toString()}())
     if (${isOperaProxy.toString()}() && !Boolean(window.hasOperaMiniScriptRan)) {
       window.hasOperaMiniScriptRan = true;
 
       var atiPageViewUrl = "${atiPageViewUrlString}";
       atiPageViewUrl += document.referrer ? "&ref=" + document.referrer : '';
-
+      console.log("CHECK", atiPageViewUrlString);
       window.sendStaticBeacon(atiPageViewUrl);
     }
 `;

--- a/src/app/components/ATIAnalytics/canonical/sendPageViewBeaconOperaMini/index.ts
+++ b/src/app/components/ATIAnalytics/canonical/sendPageViewBeaconOperaMini/index.ts
@@ -7,7 +7,7 @@ export default (atiPageViewUrlString: string) => `
 
       var atiPageViewUrl = "${atiPageViewUrlString}";
       atiPageViewUrl += document.referrer ? "&ref=" + document.referrer : '';
-      console.log("CHECK", atiPageViewUrlString);
+      console.log("CHECK", ${atiPageViewUrlString});
       window.sendStaticBeacon(atiPageViewUrl);
     }
 `;

--- a/src/app/components/ATIAnalytics/canonical/sendPageViewBeaconOperaMini/index.ts
+++ b/src/app/components/ATIAnalytics/canonical/sendPageViewBeaconOperaMini/index.ts
@@ -6,6 +6,7 @@ export default (atiPageViewUrlString: string) => `
 
       var atiPageViewUrl = "${atiPageViewUrlString}";
       atiPageViewUrl += document.referrer ? "&ref=" + document.referrer : '';
+
       window.sendStaticBeacon(atiPageViewUrl);
     }
 `;

--- a/src/app/components/ATIAnalytics/canonical/sendPageViewBeaconOperaMini/index.ts
+++ b/src/app/components/ATIAnalytics/canonical/sendPageViewBeaconOperaMini/index.ts
@@ -6,7 +6,6 @@ export default (atiPageViewUrlString: string) => `
 
       var atiPageViewUrl = "${atiPageViewUrlString}";
       atiPageViewUrl += document.referrer ? "&ref=" + document.referrer : '';
-    
       window.sendStaticBeacon(atiPageViewUrl);
     }
 `;

--- a/src/app/components/ATIAnalytics/canonical/sendPageViewBeaconOperaMini/index.ts
+++ b/src/app/components/ATIAnalytics/canonical/sendPageViewBeaconOperaMini/index.ts
@@ -6,7 +6,7 @@ export default (atiPageViewUrlString: string) => `
 
       var atiPageViewUrl = "${atiPageViewUrlString}";
       atiPageViewUrl += document.referrer ? "&ref=" + document.referrer : '';
-
+    
       window.sendStaticBeacon(atiPageViewUrl);
     }
 `;

--- a/src/app/components/ATIAnalytics/canonical/sendPageViewBeaconOperaMini/index.ts
+++ b/src/app/components/ATIAnalytics/canonical/sendPageViewBeaconOperaMini/index.ts
@@ -1,13 +1,12 @@
 import isOperaProxy from '#app/lib/utilities/isOperaProxy';
 
 export default (atiPageViewUrlString: string) => `
-    console.log("CHECK IS OPERA", ${isOperaProxy.toString()}())
     if (${isOperaProxy.toString()}() && !Boolean(window.hasOperaMiniScriptRan)) {
       window.hasOperaMiniScriptRan = true;
 
       var atiPageViewUrl = "${atiPageViewUrlString}";
       atiPageViewUrl += document.referrer ? "&ref=" + document.referrer : '';
-      console.log("CHECK", ${atiPageViewUrlString});
+      console.log("CHECK PAGE VIEW EVENT", "${atiPageViewUrlString}")
       window.sendStaticBeacon(atiPageViewUrl);
     }
 `;

--- a/src/app/hooks/useHydrationDetection/index.tsx
+++ b/src/app/hooks/useHydrationDetection/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 
 /**
  * Detects whether the component has been hydrated.
@@ -6,12 +6,12 @@ import { useState, useEffect } from 'react';
  * @returns {boolean} True if the component is hydrated (client-side), false otherwise (server-side).
  */
 export default (): boolean => {
-  const [isHydrated, setIsHydrated] = useState(false);
+  //  const [isHydrated, setIsHydrated] = useState(false);
   console.log('CHECK NOT HYDRATED');
   useEffect(() => {
     // setIsHydrated(true);
     console.log('CHECK HAS HYDRATED');
   }, []);
 
-  return isHydrated;
+  return false;
 };

--- a/src/app/hooks/useHydrationDetection/index.tsx
+++ b/src/app/hooks/useHydrationDetection/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 /**
  * Detects whether the component has been hydrated.
@@ -6,12 +6,12 @@ import { useEffect } from 'react';
  * @returns {boolean} True if the component is hydrated (client-side), false otherwise (server-side).
  */
 export default (): boolean => {
-  //  const [isHydrated, setIsHydrated] = useState(false);
+  const [isHydrated, setIsHydrated] = useState(false);
   console.log('CHECK NOT HYDRATED');
   useEffect(() => {
-    // setIsHydrated(true);
+    setIsHydrated(true);
     console.log('CHECK HAS HYDRATED');
   }, []);
 
-  return false;
+  return isHydrated;
 };

--- a/src/app/hooks/useHydrationDetection/index.tsx
+++ b/src/app/hooks/useHydrationDetection/index.tsx
@@ -7,9 +7,10 @@ import { useState, useEffect } from 'react';
  */
 export default (): boolean => {
   const [isHydrated, setIsHydrated] = useState(false);
-
+  console.log('CHECK NOT HYDRATED');
   useEffect(() => {
     // setIsHydrated(true);
+    console.log('CHECK HAS HYDRATED');
   }, []);
 
   return isHydrated;

--- a/src/app/hooks/useHydrationDetection/index.tsx
+++ b/src/app/hooks/useHydrationDetection/index.tsx
@@ -9,7 +9,7 @@ export default (): boolean => {
   const [isHydrated, setIsHydrated] = useState(false);
 
   useEffect(() => {
-    setIsHydrated(true);
+    // setIsHydrated(true);
   }, []);
 
   return isHydrated;

--- a/src/app/lib/analyticsUtils/staticATITracking/clickTracking/index.ts
+++ b/src/app/lib/analyticsUtils/staticATITracking/clickTracking/index.ts
@@ -4,6 +4,7 @@ export default () => {
   const STATIC_ATI_CLICK_TRACKING = 'data-static-ati-click';
 
   document.addEventListener('click', (event: MouseEvent) => {
+    console.log('CLICK DETECTED...');
     let targetElement;
     const clickedElement = event.target as HTMLElement;
 

--- a/src/app/lib/analyticsUtils/staticATITracking/processClientDeviceAndSendStaticBeacon/index.ts
+++ b/src/app/lib/analyticsUtils/staticATITracking/processClientDeviceAndSendStaticBeacon/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore next */
 export const addProcessClientDeviceAndSendStaticBeaconToWindow = () => {
   window.processClientDeviceAndSendStaticBeacon = (atiURL, reverbURL) => {
+    console.log('SEND SCRIPT ADDED');
     const {
       screen: { width, height, colorDepth, pixelDepth },
       innerWidth,

--- a/src/app/lib/analyticsUtils/staticATITracking/sendStaticBeacon/index.ts
+++ b/src/app/lib/analyticsUtils/staticATITracking/sendStaticBeacon/index.ts
@@ -1,5 +1,7 @@
 export const addSendStaticBeaconToWindow = () => `
+    console.log("SEND STATIC SCRIPT ADDED")
     window.sendStaticBeacon = function (atiUrlString) {
+        console.log("ATTEMPTING SEND...", atiUrlString)
         var xhr = new XMLHttpRequest();
         xhr.open("GET", atiUrlString, true);
         xhr.withCredentials = true;

--- a/src/app/lib/utilities/isOperaProxy/index.js
+++ b/src/app/lib/utilities/isOperaProxy/index.js
@@ -4,5 +4,7 @@
 // The below line prevents Jest from generating code coverage for this file, due to same inlining with toString() https://github.com/istanbuljs/istanbuljs/issues/499#issuecomment-579815603, https://github.com/istanbuljs/istanbuljs/issues/499#issuecomment-613427710
 /* istanbul ignore next */
 export default function isOperaProxy() {
-  return true;
+  return (
+    Object.prototype.toString.call(window.operamini) === '[object OperaMini]'
+  );
 }

--- a/src/app/lib/utilities/isOperaProxy/index.js
+++ b/src/app/lib/utilities/isOperaProxy/index.js
@@ -4,7 +4,5 @@
 // The below line prevents Jest from generating code coverage for this file, due to same inlining with toString() https://github.com/istanbuljs/istanbuljs/issues/499#issuecomment-579815603, https://github.com/istanbuljs/istanbuljs/issues/499#issuecomment-613427710
 /* istanbul ignore next */
 export default function isOperaProxy() {
-  return (
-    Object.prototype.toString.call(window.operamini) === '[object OperaMini]'
-  );
+  return true;
 }

--- a/ws-nextjs-app/pages/_document.page.tsx
+++ b/ws-nextjs-app/pages/_document.page.tsx
@@ -36,6 +36,7 @@ import NO_JS_CLASSNAME from '#app/lib/noJs.const';
 import getPathExtension from '#app/utilities/getPathExtension';
 import ReverbTemplate from '#src/server/Document/Renderers/ReverbTemplate';
 import { PageTypes } from '#app/models/types/global';
+import ComponentTracking from '#src/server/Document/Renderers/ComponentTracking';
 import removeSensitiveHeaders from '../utilities/removeSensitiveHeaders';
 import derivePageType from '../utilities/derivePageType';
 
@@ -203,6 +204,10 @@ export default class AppDocument extends Document<DocProps> {
               {helmetMetaTags}
               {helmetLinkTags}
               {helmetScriptTags}
+              <ComponentTracking
+                trackComponentViews={false}
+                enableStaticClickTrackingOnOperaMiniOnly
+              />
               <style
                 data-emotion={ids.join(' ')}
                 dangerouslySetInnerHTML={{ __html: css }}

--- a/ws-nextjs-app/pages/_document.page.tsx
+++ b/ws-nextjs-app/pages/_document.page.tsx
@@ -203,11 +203,11 @@ export default class AppDocument extends Document<DocProps> {
               {title}
               {helmetMetaTags}
               {helmetLinkTags}
-              {helmetScriptTags}
               <ComponentTracking
                 trackComponentViews={false}
                 enableStaticClickTrackingOnOperaMiniOnly
               />
+              {helmetScriptTags}
               <style
                 data-emotion={ids.join(' ')}
                 dangerouslySetInnerHTML={{ __html: css }}


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1550

Summary
======
With these changes, we can see both view and click tracking come through:
<img width="768" height="115" alt="Screenshot 2025-10-17 at 12 19 17" src="https://github.com/user-attachments/assets/883318cc-01e4-4576-a367-1fae4efb64d2" />


Code changes
======
- _A bullet point list of key code changes that have been made._


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

