### PR TITLE
Update Korean navigation add Latest videos label to Japanese

### DIFF
--- a/src/app/lib/config/services/japanese.ts
+++ b/src/app/lib/config/services/japanese.ts
@@ -253,6 +253,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'トップ記事',
       featuresAnalysisTitle: '読み物・解説',
+      latestMediaTitle: '最新動画',
     },
     mostRead: {
       header: '注目の記事',

--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -333,6 +333,26 @@ export const service: DefaultServiceConfig = {
         url: '/korean',
       },
       {
+        title: '국내',
+        url: '/korean/topics/cxnyk3v82rgt',
+      },
+      {
+        title: '북한',
+        url: '/korean/topics/cg726kygwz9t',
+      },
+      {
+        title: '세계',
+        url: '/korean/topics/ce71k82r6gzt',
+      },
+      {
+        title: '건강·과학',
+        url: '/korean/topics/cly27z42zk7t',
+      },
+      {
+        title: '문화',
+        url: '/korean/topics/c8y946p5qknt',
+      },
+      {
         title: '비디오',
         url: '/korean/topics/cnwng7v0e54t',
       },
@@ -343,10 +363,6 @@ export const service: DefaultServiceConfig = {
       {
         title: '다운로드',
         url: '/korean/downloads',
-      },
-      {
-        title: 'TOP 뉴스',
-        url: '/korean/popular/read',
       },
     ],
     timezone: 'Asia/Seoul',

--- a/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
@@ -126,29 +126,57 @@ exports[`Canonical Korean Live Radio Page Header Navigation link should match te
 
 exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 2`] = `
 {
+  "text": "국내",
+  "url": "/korean/topics/cxnyk3v82rgt",
+}
+`;
+
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 3`] = `
+{
+  "text": "북한",
+  "url": "/korean/topics/cg726kygwz9t",
+}
+`;
+
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 4`] = `
+{
+  "text": "세계",
+  "url": "/korean/topics/ce71k82r6gzt",
+}
+`;
+
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 5`] = `
+{
+  "text": "건강·과학",
+  "url": "/korean/topics/cly27z42zk7t",
+}
+`;
+
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 6`] = `
+{
+  "text": "문화",
+  "url": "/korean/topics/c8y946p5qknt",
+}
+`;
+
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 7`] = `
+{
   "text": "비디오",
   "url": "/korean/topics/cnwng7v0e54t",
 }
 `;
 
-exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 3`] = `
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 8`] = `
 {
   "text": "라디오",
   "url": "/korean/bbc_korean_radio/programmes/w13xttll",
 }
 `;
 
-exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 9`] = `
 {
   "text": "다운로드",
   "url": "/korean/downloads",
-}
-`;
-
-exports[`Canonical Korean Live Radio Page Header Navigation link should match text and url 5`] = `
-{
-  "text": "TOP 뉴스",
-  "url": "/korean/popular/read",
 }
 `;
 


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Updated Korean navigation to add Domestic, North Korea, World, Science and Health and Culture items and remove Most popular
- Added Japanese translation of Latest videos which was defaulting to English

Code changes
======

- Edited Navigation section of src/app/lib/config/services/korean.ts 
- Added latestMediaTitle string to src/app/lib/config/services/japanese.ts
- Updated snapshots 



Testing
======
1. Open Korean front page, The links in the nav should have the following links
  뉴스 | 국내 | 북한 | 세계 | 건강•과학 | 문화 | 비디오 | 라디오 | 다운로드 (News | Domestic | North Korea | World | Health & Science | Culture | Video | Radio | Downloads)

2. Open a Japanese sfv the title of lates video component on the secondary column should be 最新動画



Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

