### PR TITLE
NO-TICKET: Reinstate page type for Live TV page

### DIFF
--- a/data/dari/watch/bbc_afghan_tv/live.json
+++ b/data/dari/watch/bbc_afghan_tv/live.json
@@ -55,6 +55,297 @@
         "intent": "MEDIA_PLAYER"
       },
       {
+        "curationId": "urn:bbc:tipo:list:65faa8a9-78d7-46ea-a159-9bc06c6146f5",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "visualProminence": "NORMAL",
+        "title": "Curation with a mix of PIDs and Optimo articles with portrait video embeds",
+        "visualStyle": "INSITU",
+        "portraitVideo": {
+          "blocks": [
+            {
+              "type": "portraitClipMedia",
+              "model": {
+                "type": "video",
+                "images": [
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx8s.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx8s.jpg",
+                    "altText": "Pelo menos 53 presos escaparam da prisão de Katacane, na Indonésia"
+                  },
+                  {
+                    "source": "https://ichef.bbci.co.uk/ace/standard/1024/cpsdevpb/42c1/test/7900c530-0e0e-11f0-a9e9-f552fbd9336f.jpg",
+                    "urlTemplate": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/42c1/test/7900c530-0e0e-11f0-a9e9-f552fbd9336f.jpg",
+                    "altText": "test"
+                  }
+                ],
+                "video": {
+                  "id": "urn:bbc:optimo:asset:cdrqd0m5nlmo",
+                  "title": "Optimo article with portrait video embed (1)",
+                  "holdingImageURL": "https://ichef.bbci.co.uk/ace/standard/512/cpsdevpb/42c1/test/7900c530-0e0e-11f0-a9e9-f552fbd9336f.jpg",
+                  "version": {
+                    "id": "p01wjx6g",
+                    "duration": "PT13S",
+                    "kind": "programme",
+                    "guidance": null,
+                    "territories": ["uk", "nonuk"]
+                  },
+                  "isEmbeddingAllowed": false
+                }
+              }
+            },
+            {
+              "type": "portraitClipMedia",
+              "model": {
+                "type": "video",
+                "images": [
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx5j.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx5j.jpg",
+                    "altText": "A Nova Rota da Seda, ou Cinturão e Rota, é considerada a maior estratégia"
+                  },
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx5j.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx5j.jpg",
+                    "altText": "A Nova Rota da Seda, ou Cinturão e Rota, é considerada a maior estratégia"
+                  }
+                ],
+                "video": {
+                  "id": "urn:bbc:pips:pid:p01wjx4r",
+                  "title": "China: o que é a Nova Rota da Seda, crucial na estratégia geopolítica de Pequim (9x16)",
+                  "holdingImageURL": "https://ichef.test.bbci.co.uk/images/ic/512xn/p01wjx5j.jpg",
+                  "version": {
+                    "id": "p01wjx4t",
+                    "duration": "PT1M10S",
+                    "kind": "programme",
+                    "guidance": null,
+                    "territories": ["nonuk", "uk"]
+                  },
+                  "isEmbeddingAllowed": true
+                }
+              }
+            },
+            {
+              "type": "portraitClipMedia",
+              "model": {
+                "type": "video",
+                "images": [
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx3n.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx3n.jpg",
+                    "altText": "O indiano Lalit Patidar, de 18 anos, foi reconhecido pelo Guinness World Records"
+                  },
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx3n.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx3n.jpg",
+                    "altText": "O indiano Lalit Patidar, de 18 anos, foi reconhecido pelo Guinness World Records"
+                  }
+                ],
+                "video": {
+                  "id": "urn:bbc:pips:pid:p01wjx29",
+                  "title": "O indiano reconhecido como 'pessoa mais peluda do mundo' (9x16)",
+                  "holdingImageURL": "https://ichef.test.bbci.co.uk/images/ic/512xn/p01wjx3n.jpg",
+                  "version": {
+                    "id": "p01wjx2c",
+                    "duration": "PT30S",
+                    "kind": "programme",
+                    "guidance": null,
+                    "territories": ["nonuk", "uk"]
+                  },
+                  "isEmbeddingAllowed": true
+                }
+              }
+            },
+            {
+              "type": "portraitClipMedia",
+              "model": {
+                "type": "video",
+                "images": [
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx3l.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx3l.jpg",
+                    "altText": "Após 37 dias de internação, o papa Francisco recebeu alta do hospital"
+                  },
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx3l.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx3l.jpg",
+                    "altText": "Após 37 dias de internação, o papa Francisco recebeu alta do hospital"
+                  }
+                ],
+                "video": {
+                  "id": "urn:bbc:pips:pid:p01wjx35",
+                  "title": "Papa Francisco reencontra fiéis ao deixar hospital em Roma (9x16)",
+                  "holdingImageURL": "https://ichef.test.bbci.co.uk/images/ic/512xn/p01wjx3l.jpg",
+                  "version": {
+                    "id": "p01wjx37",
+                    "duration": "PT13S",
+                    "kind": "programme",
+                    "guidance": null,
+                    "territories": ["nonuk", "uk"]
+                  },
+                  "isEmbeddingAllowed": true
+                }
+              }
+            },
+            {
+              "type": "portraitClipMedia",
+              "model": {
+                "type": "video",
+                "images": [
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx8v.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx8v.jpg",
+                    "altText": "A Europa está em uma espécie de \"corrida armamentista\" diante da crise da aliança"
+                  },
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx8v.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx8v.jpg",
+                    "altText": "A Europa está em uma espécie de \"corrida armamentista\" diante da crise da aliança"
+                  }
+                ],
+                "video": {
+                  "id": "urn:bbc:pips:pid:p01wjx5y",
+                  "title": "Europa se armando para guerra? Continente eleva gastos militares de olho em EUA e Rússia (9x16)",
+                  "holdingImageURL": "https://ichef.test.bbci.co.uk/images/ic/512xn/p01wjx8v.jpg",
+                  "version": {
+                    "id": "p01wjx60",
+                    "duration": "PT30S",
+                    "kind": "programme",
+                    "guidance": null,
+                    "territories": ["nonuk", "uk"]
+                  },
+                  "isEmbeddingAllowed": true
+                }
+              }
+            },
+            {
+              "type": "portraitClipMedia",
+              "model": {
+                "type": "video",
+                "images": [
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx7z.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx7z.jpg",
+                    "altText": "Hoje nove países possuem armas nucleares"
+                  },
+                  {
+                    "source": "https://ichef.bbci.co.uk/ace/standard/1024/cpsdevpb/3106/test/8568bc10-0e0e-11f0-a9e9-f552fbd9336f.jpg",
+                    "urlTemplate": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/3106/test/8568bc10-0e0e-11f0-a9e9-f552fbd9336f.jpg",
+                    "altText": "Test"
+                  }
+                ],
+                "video": {
+                  "id": "urn:bbc:optimo:asset:cgp62emnrk5o",
+                  "title": "Article with portrait video embed (2)",
+                  "holdingImageURL": "https://ichef.bbci.co.uk/ace/standard/512/cpsdevpb/3106/test/8568bc10-0e0e-11f0-a9e9-f552fbd9336f.jpg",
+                  "version": {
+                    "id": "p01wjx71",
+                    "duration": "PT20S",
+                    "kind": "programme",
+                    "guidance": null,
+                    "territories": ["uk", "nonuk"]
+                  },
+                  "isEmbeddingAllowed": false
+                }
+              }
+            },
+            {
+              "type": "portraitClipMedia",
+              "model": {
+                "type": "video",
+                "images": [
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx8g.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx8g.jpg",
+                    "altText": "A sensação de não saber por onde começar, a falta de uma rotina"
+                  },
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx8g.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx8g.jpg",
+                    "altText": "A sensação de não saber por onde começar, a falta de uma rotina"
+                  }
+                ],
+                "video": {
+                  "id": "urn:bbc:pips:pid:p01wjx7v",
+                  "title": "4 erros de quem estuda para concursos públicos (9x16)",
+                  "holdingImageURL": "https://ichef.test.bbci.co.uk/images/ic/512xn/p01wjx8g.jpg",
+                  "version": {
+                    "id": "p01wjx7x",
+                    "duration": "PT1M10S",
+                    "kind": "programme",
+                    "guidance": null,
+                    "territories": ["nonuk", "uk"]
+                  },
+                  "isEmbeddingAllowed": true
+                }
+              }
+            },
+            {
+              "type": "portraitClipMedia",
+              "model": {
+                "type": "video",
+                "images": [
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx51.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx51.jpg",
+                    "altText": "text"
+                  },
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx51.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx51.jpg",
+                    "altText": "text"
+                  }
+                ],
+                "video": {
+                  "id": "urn:bbc:pips:pid:p01wjx3q",
+                  "title": "O estudante que pode ser um dos maiores estupradores do Reino Unido (9x16)",
+                  "holdingImageURL": "https://ichef.test.bbci.co.uk/images/ic/512xn/p01wjx51.jpg",
+                  "version": {
+                    "id": "p01wjx3s",
+                    "duration": "PT20S",
+                    "kind": "programme",
+                    "guidance": null,
+                    "territories": ["nonuk", "uk"]
+                  },
+                  "isEmbeddingAllowed": true
+                }
+              }
+            },
+            {
+              "type": "portraitClipMedia",
+              "model": {
+                "type": "video",
+                "images": [
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx48.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx48.jpg",
+                    "altText": "De tempos em tempos, algum mecanismo do corpo humano é 'redescoberto' pela internet"
+                  },
+                  {
+                    "source": "https://ichef.test.bbci.co.uk/images/ic/1024xn/p01wjx48.jpg",
+                    "urlTemplate": "https://ichef.test.bbci.co.uk/images/ic/{width}xn/p01wjx48.jpg",
+                    "altText": "De tempos em tempos, algum mecanismo do corpo humano é 'redescoberto' pela internet"
+                  }
+                ],
+                "video": {
+                  "id": "urn:bbc:pips:pid:p01wjx3g",
+                  "title": "A onda de evitar picos de glicose para emagrecer — e por que ela faz sentido (9x16)",
+                  "holdingImageURL": "https://ichef.test.bbci.co.uk/images/ic/512xn/p01wjx48.jpg",
+                  "version": {
+                    "id": "p01wjx3j",
+                    "duration": "PT13S",
+                    "kind": "programme",
+                    "guidance": null,
+                    "territories": ["nonuk", "uk"]
+                  },
+                  "isEmbeddingAllowed": true
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
         "radioSchedule": [
           {
             "id": "p0lv337m",
@@ -95,7 +386,7 @@
         ],
         "curationId": "urn:bbc:programmes:available-episodes:bbc_dari_radio",
         "curationType": "available-episodes",
-        "position": 1,
+        "position": 2,
         "title": "Afghan TV Schedule",
         "visualProminence": "NORMAL",
         "visualStyle": "NONE"

--- a/ws-nextjs-app/pages/[service]/watch/[id]/LiveTvPageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/watch/[id]/LiveTvPageLayout.tsx
@@ -15,11 +15,13 @@ import styles from './styles';
 
 export default function LiveTvLayout({ pageData }: LiveTVPageProps) {
   const { lang } = use(ServiceContext);
-  if (!pageData) {
+
+  if (!pageData.title) {
     // @ts-expect-error liveTvFixture used for development purposes only
     // eslint-disable-next-line no-param-reassign
     pageData = liveTvFixture;
   }
+
   const { curations, description, title } = pageData;
 
   return (

--- a/ws-nextjs-app/pages/[service]/watch/[id]/live.page.tsx
+++ b/ws-nextjs-app/pages/[service]/watch/[id]/live.page.tsx
@@ -19,6 +19,10 @@ export const getServerSideProps: GetServerSideProps = async context => {
     timeOnServer: Date.now(),
     pageType: LIVE_TV_PAGE as PageTypes,
     service,
+    metadata: {
+      type: LIVE_TV_PAGE,
+      atiAnalytics: {},
+    },
     pathname: context?.resolvedUrl,
   };
   return {

--- a/ws-nextjs-app/pages/[service]/watch/[id]/live.page.tsx
+++ b/ws-nextjs-app/pages/[service]/watch/[id]/live.page.tsx
@@ -16,12 +16,13 @@ export const getServerSideProps: GetServerSideProps = async context => {
     isAmp: false,
     isNextJs: true,
     status: 200,
-    timeOnServer: Date.now(),
     pageType: LIVE_TV_PAGE as PageTypes,
     service,
-    metadata: {
-      type: LIVE_TV_PAGE,
-      atiAnalytics: {},
+    pageData: {
+      metadata: {
+        type: LIVE_TV_PAGE,
+        atiAnalytics: {},
+      },
     },
     pathname: context?.resolvedUrl,
   };


### PR DESCRIPTION
Resolves JIRA: N/A - issue arisen from failing test in slack alerts channel

Summary
======
Reinstates a previously removed pageData prop and metadata value for `LIVE_TV_PAGE` which then resulted in a failing test on the test environment. Also includes an update to local fixture data to add a Portrait Video Carousel onto a Live TV Page.

Code changes
======
- Reinstates `pageData` and `metadata` to baseprops for a Live TV page and sets the type to `LIVE_TV_PAGE`.
- Adds a portrait video carousel curation to dari Live TV fixture data.


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

