### PR TITLE
Suppress hydration warning on the radio schedule heading

### DIFF
--- a/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
+++ b/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
@@ -142,6 +142,7 @@ const ScheduleItemHeader = ({
       <TitleWrapper
         service={service}
         script={script}
+        suppressHydrationWarning
         {...programStateConfig[state]}
       >
         {episodeTitle}


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Suppress hydration warning (cause unknown) on the radio schedule title wrapper 🤷‍♀️ 
This unblocks the CD pipeline

Code changes
======
Add `suppressHydrationWarning` as recommended in the docs https://nextjs.org/docs/messages/react-hydration-error#solution-3-using-suppresshydrationwarning