### PR TITLE
WS-1608 - Pass experiment props to OJ components

### DIFF
--- a/src/app/components/MostRead/index.tsx
+++ b/src/app/components/MostRead/index.tsx
@@ -32,7 +32,6 @@ interface MostReadProps {
   mobileDivider?: boolean;
   headingBackgroundColour?: string;
   className?: string;
-  sendOptimizelyEvents?: boolean;
   eventTrackingData?: EventTrackingData;
 }
 

--- a/src/app/components/RelatedContentSection/index.tsx
+++ b/src/app/components/RelatedContentSection/index.tsx
@@ -12,6 +12,7 @@ import last from 'ramda/src/last';
 import filter from 'ramda/src/filter';
 import pipe from 'ramda/src/pipe';
 import useViewTracker from '#hooks/useViewTracker';
+import { ComponentExperimentProps } from '#app/models/types/global';
 import { ServiceContext } from '../../contexts/ServiceContext';
 import styles from './index.styles';
 import generatePromoId from '../../lib/utilities/generatePromoId';
@@ -37,9 +38,10 @@ const isHeadlineFirst = (item: object) => {
 
 type Props = {
   content: OptimoBlock[];
+  experimentProps?: ComponentExperimentProps;
 };
 
-const RelatedContentSection = ({ content }: Props) => {
+const RelatedContentSection = ({ content, experimentProps }: Props) => {
   const { translations, script, service } = use(ServiceContext);
 
   const {
@@ -50,6 +52,7 @@ const RelatedContentSection = ({ content }: Props) => {
   const eventTrackingData = {
     block: {
       componentName: 'related-content',
+      ...(experimentProps && experimentProps),
     },
   };
   const viewTracker = useViewTracker(eventTrackingData.block);

--- a/src/app/components/RelatedContentSection/index.tsx
+++ b/src/app/components/RelatedContentSection/index.tsx
@@ -11,7 +11,6 @@ import identity from 'ramda/src/identity';
 import last from 'ramda/src/last';
 import filter from 'ramda/src/filter';
 import pipe from 'ramda/src/pipe';
-import { OptimizelyContext } from '@optimizely/react-sdk';
 import useViewTracker from '#hooks/useViewTracker';
 import { ServiceContext } from '../../contexts/ServiceContext';
 import styles from './index.styles';
@@ -38,12 +37,10 @@ const isHeadlineFirst = (item: object) => {
 
 type Props = {
   content: OptimoBlock[];
-  sendOptimizelyEvents?: boolean;
 };
 
-const RelatedContentSection = ({ content, sendOptimizelyEvents }: Props) => {
+const RelatedContentSection = ({ content }: Props) => {
   const { translations, script, service } = use(ServiceContext);
-  const { optimizely } = use(OptimizelyContext);
 
   const {
     palette: { GREY_2 },
@@ -53,9 +50,6 @@ const RelatedContentSection = ({ content, sendOptimizelyEvents }: Props) => {
   const eventTrackingData = {
     block: {
       componentName: 'related-content',
-      ...(sendOptimizelyEvents && {
-        optimizely,
-      }),
     },
   };
   const viewTracker = useViewTracker(eventTrackingData.block);

--- a/src/app/legacy/containers/CpsFeaturesAnalysis/index.jsx
+++ b/src/app/legacy/containers/CpsFeaturesAnalysis/index.jsx
@@ -14,7 +14,6 @@ import {
   GEL_SPACING_DBL,
   GEL_SPACING_TRPL,
 } from '#psammead/gel-foundations/src/spacings';
-import { OptimizelyContext } from '@optimizely/react-sdk';
 import { ServiceContext } from '../../../contexts/ServiceContext';
 import CpsOnwardJourney from '../CpsOnwardJourney';
 import FrostedGlassPromo from '../../../components/FrostedGlassPromo/lazy';
@@ -61,21 +60,12 @@ const StoryPromoLiFeatures = styled(StoryPromoLi)`
   }
 `;
 
-const PromoListComponent = ({
-  promoItems,
-  dir = 'ltr',
-  sendOptimizelyEvents,
-}) => {
+const PromoListComponent = ({ promoItems, dir = 'ltr' }) => {
   const { serviceDatetimeLocale } = use(ServiceContext);
-  const { optimizely } = use(OptimizelyContext);
 
   const eventTrackingDataWithOptimizely = {
     block: {
       ...eventTrackingData.block,
-      ...(sendOptimizelyEvents && {
-        optimizely,
-        optimizelyMetricNameOverride: 'features',
-      }),
     },
   };
 
@@ -107,17 +97,12 @@ const PromoListComponent = ({
   );
 };
 
-const PromoComponent = ({ promo, dir = 'ltr', sendOptimizelyEvents }) => {
-  const { optimizely } = use(OptimizelyContext);
+const PromoComponent = ({ promo, dir = 'ltr' }) => {
   const { serviceDatetimeLocale } = use(ServiceContext);
 
   const eventTrackingDataWithOptimizely = {
     block: {
       ...eventTrackingData.block,
-      ...(sendOptimizelyEvents && {
-        optimizely,
-        optimizelyMetricNameOverride: 'features',
-      }),
     },
   };
 
@@ -141,7 +126,6 @@ const FeaturesAnalysis = ({
   content,
   parentColumns,
   sectionLabelBackground,
-  sendOptimizelyEvents,
 }) => {
   const { translations } = use(ServiceContext);
 
@@ -161,7 +145,6 @@ const FeaturesAnalysis = ({
       promoListComponent={PromoListComponent}
       columnType="secondary"
       sectionLabelBackground={sectionLabelBackground}
-      sendOptimizelyEvents={sendOptimizelyEvents}
     />
   );
 };

--- a/src/app/legacy/containers/CpsFeaturesAnalysis/index.jsx
+++ b/src/app/legacy/containers/CpsFeaturesAnalysis/index.jsx
@@ -60,12 +60,13 @@ const StoryPromoLiFeatures = styled(StoryPromoLi)`
   }
 `;
 
-const PromoListComponent = ({ promoItems, dir = 'ltr' }) => {
+const PromoListComponent = ({ promoItems, dir = 'ltr', experimentProps }) => {
   const { serviceDatetimeLocale } = use(ServiceContext);
 
   const eventTrackingDataWithOptimizely = {
     block: {
       ...eventTrackingData.block,
+      ...(experimentProps && experimentProps),
     },
   };
 
@@ -97,12 +98,13 @@ const PromoListComponent = ({ promoItems, dir = 'ltr' }) => {
   );
 };
 
-const PromoComponent = ({ promo, dir = 'ltr' }) => {
+const PromoComponent = ({ promo, dir = 'ltr', experimentProps }) => {
   const { serviceDatetimeLocale } = use(ServiceContext);
 
   const eventTrackingDataWithOptimizely = {
     block: {
       ...eventTrackingData.block,
+      ...(experimentProps && experimentProps),
     },
   };
 
@@ -126,6 +128,7 @@ const FeaturesAnalysis = ({
   content,
   parentColumns,
   sectionLabelBackground,
+  experimentProps = {},
 }) => {
   const { translations } = use(ServiceContext);
 
@@ -145,6 +148,7 @@ const FeaturesAnalysis = ({
       promoListComponent={PromoListComponent}
       columnType="secondary"
       sectionLabelBackground={sectionLabelBackground}
+      experimentProps={experimentProps}
     />
   );
 };

--- a/src/app/legacy/containers/CpsOnwardJourney/index.jsx
+++ b/src/app/legacy/containers/CpsOnwardJourney/index.jsx
@@ -128,7 +128,6 @@ const CpsOnwardJourney = ({
   columnType,
   skipLink = null,
   eventTrackingData = null,
-  sendOptimizelyEvents = false,
 }) => {
   const { script, service, dir } = use(ServiceContext);
 
@@ -171,7 +170,6 @@ const CpsOnwardJourney = ({
               promo={singleContent}
               dir={dir}
               eventTrackingData={eventTrackingData}
-              sendOptimizelyEvents={sendOptimizelyEvents}
             />
           </SingleContentWrapper>
         ) : (
@@ -180,7 +178,6 @@ const CpsOnwardJourney = ({
             dir={dir}
             isMediaContent={isMediaContent}
             eventTrackingData={eventTrackingData}
-            sendOptimizelyEvents={sendOptimizelyEvents}
           />
         )}
       </OptionallyRenderedSkipWrapper>

--- a/src/app/legacy/containers/CpsOnwardJourney/index.jsx
+++ b/src/app/legacy/containers/CpsOnwardJourney/index.jsx
@@ -128,6 +128,7 @@ const CpsOnwardJourney = ({
   columnType,
   skipLink = null,
   eventTrackingData = null,
+  experimentProps = null,
 }) => {
   const { script, service, dir } = use(ServiceContext);
 
@@ -170,6 +171,7 @@ const CpsOnwardJourney = ({
               promo={singleContent}
               dir={dir}
               eventTrackingData={eventTrackingData}
+              experimentProps={experimentProps}
             />
           </SingleContentWrapper>
         ) : (
@@ -178,6 +180,7 @@ const CpsOnwardJourney = ({
             dir={dir}
             isMediaContent={isMediaContent}
             eventTrackingData={eventTrackingData}
+            experimentProps={experimentProps}
           />
         )}
       </OptionallyRenderedSkipWrapper>

--- a/src/app/models/types/global.ts
+++ b/src/app/models/types/global.ts
@@ -24,6 +24,12 @@ export type Toggles =
   | Record<string, ToggleDefinition>
   | { _environment: string };
 
+export type ComponentExperimentProps = {
+  sendOptimizelyEvents?: boolean;
+  experimentName?: string;
+  experimentVariant?: string;
+};
+
 export type ServerSideExperiment = {
   experimentName: string;
   variation: string;

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -453,15 +453,11 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
               tagBackgroundColour={WHITE}
             />
           )}
-          <RelatedContentSection
-            content={blocks}
-            sendOptimizelyEvents={false}
-          />
+          <RelatedContentSection content={blocks} />
         </div>
         {!isApp && !isPGL && (
           <SecondaryColumn
             pageData={pageData}
-            sendOptimizelyEvents={false}
             experimentVariant={timeOfDayExperimentVariant}
             timeOfDayExperimentName={timeOfDayExperimentName}
           />
@@ -475,7 +471,6 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
           size="default"
           headingBackgroundColour={GREY_2}
           mobileDivider={showTopics}
-          sendOptimizelyEvents={false}
         />
       )}
     </div>

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -233,13 +233,10 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
 
   // EXPERIMENT: Time of Day Experiment
   const timeOfDayExperimentName = 'newswb_ws_tod_article';
-  let timeOfDayExperimentVariant = useOptimizelyVariation({
+  const timeOfDayExperimentVariant = useOptimizelyVariation({
     experimentName: timeOfDayExperimentName,
     experimentType: ExperimentType.CLIENT_SIDE,
   });
-
-  // TEMPORARY OVERRIDE FOR DEV/TESTING PURPOSES - REMOVE LATER
-  timeOfDayExperimentVariant = 'morning';
 
   const allowAdvertising = pageData?.metadata?.allowAdvertising ?? false;
   const adcampaign = pageData?.metadata?.adCampaignKeyword;

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -218,13 +218,11 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
   } = useTheme();
 
   // Continue Reading Button Experiment
-  const experimentName = 'newswb_ws_read_more_b';
-  const experimentVariant = useOptimizelyVariation({
-    experimentName,
+  const readMoreExperimentName = 'newswb_ws_read_more_b';
+  const readMoreExperimentVariant = useOptimizelyVariation({
+    experimentName: readMoreExperimentName,
     experimentType: ExperimentType.CLIENT_SIDE,
   });
-  const isInServerSideExperiment =
-    experimentVariant && experimentVariant !== 'off';
 
   // EXPERIMENT: Article Read Time
   const readTimeExperimentName = 'newswb_ws_article_read_time';
@@ -292,10 +290,22 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
   const atiData = {
     ...atiAnalytics,
     ...(isCPS && { pageTitle: `${atiAnalytics.pageTitle} - ${brandName}` }),
-    ...(isInServerSideExperiment && {
-      experimentName,
-      experimentVariant,
-    }),
+    // Better way to handle this?
+    ...(readMoreExperimentVariant &&
+      readMoreExperimentVariant !== 'off' && {
+        experimentName: readMoreExperimentName,
+        experimentVariant: readMoreExperimentVariant,
+      }),
+    ...(readTimeExperimentVariant &&
+      readTimeExperimentVariant !== 'off' && {
+        experimentName: readTimeExperimentName,
+        experimentVariant: readTimeExperimentVariant,
+      }),
+    ...(timeOfDayExperimentVariant &&
+      timeOfDayExperimentVariant !== 'off' && {
+        experimentName: timeOfDayExperimentName,
+        experimentVariant: timeOfDayExperimentVariant,
+      }),
   };
 
   // EXPERIMENT: Article Read Time
@@ -365,8 +375,8 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
     !isAmp &&
       !isLite &&
       !isApp &&
-      experimentVariant &&
-      ['read-more-b'].includes(experimentVariant),
+      readMoreExperimentVariant &&
+      ['read-more-b'].includes(readMoreExperimentVariant),
   );
 
   return (
@@ -453,11 +463,22 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
               tagBackgroundColour={WHITE}
             />
           )}
-          <RelatedContentSection content={blocks} />
+          <RelatedContentSection
+            content={blocks}
+            // EXPERIMENT: Time of Day Experiment
+            {...(timeOfDayExperimentVariant && {
+              experimentProps: {
+                sendOptimizelyEvents: true,
+                experimentName: timeOfDayExperimentName,
+                experimentVariant: timeOfDayExperimentVariant,
+              },
+            })}
+          />
         </div>
         {!isApp && !isPGL && (
           <SecondaryColumn
             pageData={pageData}
+            // EXPERIMENT: Time of Day Experiment
             experimentVariant={timeOfDayExperimentVariant}
             timeOfDayExperimentName={timeOfDayExperimentName}
           />
@@ -471,6 +492,15 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
           size="default"
           headingBackgroundColour={GREY_2}
           mobileDivider={showTopics}
+          // EXPERIMENT: Time of Day Experiment
+          eventTrackingData={{
+            componentName: 'most-read',
+            ...(timeOfDayExperimentVariant && {
+              sendOptimizelyEvents: true,
+              experimentName: timeOfDayExperimentName,
+              experimentVariant: timeOfDayExperimentVariant,
+            }),
+          }}
         />
       )}
     </div>

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.tsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.tsx
@@ -6,29 +6,18 @@ import useViewTracker from '#hooks/useViewTracker';
 import SectionLabel from '#psammead/psammead-section-label/src';
 import PromoItem from '#components/OptimoPromos/PromoItem/index.styles';
 import PromoList from '#components/OptimoPromos/PromoList';
-import { OptimizelyContext } from '@optimizely/react-sdk';
 import { ServiceContext } from '../../../../contexts/ServiceContext';
 import styles from './index.styles';
 import TopStoriesItem from './TopStoriesItem';
 import generatePromoId from '../../../../lib/utilities/generatePromoId';
 import { TopStoryItem } from './types';
 
-const TopStoriesSection = ({
-  content = [],
-  sendOptimizelyEvents,
-}: {
-  content: TopStoryItem[];
-  sendOptimizelyEvents?: boolean;
-}) => {
+const TopStoriesSection = ({ content = [] }: { content: TopStoryItem[] }) => {
   const { translations, script, service } = use(ServiceContext);
-  const { optimizely } = use(OptimizelyContext);
 
   const eventTrackingData = {
     block: {
       componentName: 'top-stories',
-      ...(sendOptimizelyEvents && {
-        optimizely,
-      }),
     },
   };
   const eventTrackingDataSend = eventTrackingData?.block;

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.tsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.tsx
@@ -6,18 +6,26 @@ import useViewTracker from '#hooks/useViewTracker';
 import SectionLabel from '#psammead/psammead-section-label/src';
 import PromoItem from '#components/OptimoPromos/PromoItem/index.styles';
 import PromoList from '#components/OptimoPromos/PromoList';
+import { ComponentExperimentProps } from '#app/models/types/global';
 import { ServiceContext } from '../../../../contexts/ServiceContext';
 import styles from './index.styles';
 import TopStoriesItem from './TopStoriesItem';
 import generatePromoId from '../../../../lib/utilities/generatePromoId';
 import { TopStoryItem } from './types';
 
-const TopStoriesSection = ({ content = [] }: { content: TopStoryItem[] }) => {
+const TopStoriesSection = ({
+  content = [],
+  experimentProps,
+}: {
+  content: TopStoryItem[];
+  experimentProps?: ComponentExperimentProps;
+}) => {
   const { translations, script, service } = use(ServiceContext);
 
   const eventTrackingData = {
     block: {
       componentName: 'top-stories',
+      ...(experimentProps && experimentProps),
     },
   };
   const eventTrackingDataSend = eventTrackingData?.block;

--- a/src/app/pages/ArticlePage/SecondaryColumn.tsx
+++ b/src/app/pages/ArticlePage/SecondaryColumn.tsx
@@ -25,8 +25,8 @@ const SecondaryColumn = ({
   timeOfDayExperimentName,
 }: {
   pageData: Article;
-  experimentVariant: string | null;
-  timeOfDayExperimentName?: string | null;
+  experimentVariant?: string;
+  timeOfDayExperimentName?: string;
 }) => {
   const topStoriesContent = pageData?.secondaryColumn?.topStories;
   const featuresContent = pageData?.secondaryColumn?.features;
@@ -93,7 +93,16 @@ const SecondaryColumn = ({
           data-testid="top-stories"
           data-experiment-position="secondaryColumn"
         >
-          <TopStoriesSection content={topStoriesContent} />
+          <TopStoriesSection
+            content={topStoriesContent}
+            {...(experimentVariant && {
+              experimentProps: {
+                sendOptimizelyEvents: true,
+                experimentName: timeOfDayExperimentName,
+                experimentVariant,
+              },
+            })}
+          />
         </div>
       )}
       {featuresContent && (
@@ -102,6 +111,13 @@ const SecondaryColumn = ({
             content={featuresContent}
             parentColumns={{}}
             sectionLabelBackground={GREY_2}
+            {...(experimentVariant && {
+              experimentProps: {
+                sendOptimizelyEvents: true,
+                experimentName: timeOfDayExperimentName,
+                experimentVariant,
+              },
+            })}
           />
         </div>
       )}

--- a/src/app/pages/ArticlePage/SecondaryColumn.tsx
+++ b/src/app/pages/ArticlePage/SecondaryColumn.tsx
@@ -25,7 +25,7 @@ const SecondaryColumn = ({
   timeOfDayExperimentName,
 }: {
   pageData: Article;
-  experimentVariant?: string;
+  experimentVariant?: string | null;
   timeOfDayExperimentName?: string;
 }) => {
   const topStoriesContent = pageData?.secondaryColumn?.topStories;
@@ -45,7 +45,10 @@ const SecondaryColumn = ({
   )
     return null;
   const showAdaptiveSection =
-    experimentVariant === 'morning' || experimentVariant === 'evening';
+    // Morning
+    experimentVariant === 'article_time_of_day_a' ||
+    // Evening
+    experimentVariant === 'article_time_of_day_b';
 
   // ideally we would want to be agnostic about the type of Curation we want to render here and have the decision made in the BFF
   // however, we cannot do this with the billboard curation as we would need to fetch the whole topic it is in, which is the whole home page,

--- a/src/app/pages/ArticlePage/SecondaryColumn.tsx
+++ b/src/app/pages/ArticlePage/SecondaryColumn.tsx
@@ -21,12 +21,10 @@ const adaptiveCurationsSectionStyles = ({ spacings, mq }: Theme) => ({
 
 const SecondaryColumn = ({
   pageData,
-  sendOptimizelyEvents,
   experimentVariant,
   timeOfDayExperimentName,
 }: {
   pageData: Article;
-  sendOptimizelyEvents: boolean;
   experimentVariant: string | null;
   timeOfDayExperimentName?: string | null;
 }) => {
@@ -95,17 +93,13 @@ const SecondaryColumn = ({
           data-testid="top-stories"
           data-experiment-position="secondaryColumn"
         >
-          <TopStoriesSection
-            content={topStoriesContent}
-            sendOptimizelyEvents={sendOptimizelyEvents}
-          />
+          <TopStoriesSection content={topStoriesContent} />
         </div>
       )}
       {featuresContent && (
         <div css={styles.featuresSection} data-testid="features">
           <FeaturesAnalysis
             content={featuresContent}
-            sendOptimizelyEvents={sendOptimizelyEvents}
             parentColumns={{}}
             sectionLabelBackground={GREY_2}
           />

--- a/src/app/pages/ArticlePage/index.test.tsx
+++ b/src/app/pages/ArticlePage/index.test.tsx
@@ -982,9 +982,11 @@ describe('Article Page', () => {
   });
 
   describe('Adaptive curations in secondary column', () => {
-    it("should render adaptive curations when variant is 'variant_a'", async () => {
+    it("should render adaptive curations when variant is 'article_time_of_day_a'", async () => {
       // negative tests possible when override removed
-      (useOptimizelyVariation as jest.Mock).mockReturnValue('variant_a');
+      (useOptimizelyVariation as jest.Mock).mockReturnValue(
+        'article_time_of_day_a',
+      );
       const dummyBillboardCurationData = {
         summaries: [
           {


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1608

Summary
======
Pass experiment props used for Optimizely/ATI tracking down to Article onward journey components - Related Content, Most Read, Top Stories and Features+Analysis

Code changes
======
- Passes `experimentProps` object containing the experiment name and variation to OJ components
- Removes `sendOptimizelyEvents` boolean and `OptimizelyContext` imports as these are no longer needed and handled within the `eventTrackingData` object and view/click hooks
- Amends variation names to those set in Optimizely


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

