### PR TITLE
WS-1649: Update persian nav to point to Persian Afghanistan topic page

### DIFF
--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -477,7 +477,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'افغانستان',
-        url: '/persian/afghanistan',
+        url: '/persian/topics/cvjp23v3083t',
       },
       {
         title: 'جهان',

--- a/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
@@ -125,7 +125,7 @@ exports[`AMP Articles Header Navigation link should match text and url 6`] = `
 exports[`AMP Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
-  "url": "/persian/afghanistan",
+  "url": "/persian/topics/cvjp23v3083t",
 }
 `;
 

--- a/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
@@ -168,7 +168,7 @@ exports[`Canonical Articles Header Navigation link should match text and url 6`]
 exports[`Canonical Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
-  "url": "/persian/afghanistan",
+  "url": "/persian/topics/cvjp23v3083t",
 }
 `;
 

--- a/src/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.js.snap
@@ -125,7 +125,7 @@ exports[`AMP Articles Header Navigation link should match text and url 6`] = `
 exports[`AMP Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
-  "url": "/persian/afghanistan",
+  "url": "/persian/topics/cvjp23v3083t",
 }
 `;
 

--- a/src/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.js.snap
@@ -165,7 +165,7 @@ exports[`Canonical Articles Header Navigation link should match text and url 6`]
 exports[`Canonical Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
-  "url": "/persian/afghanistan",
+  "url": "/persian/topics/cvjp23v3083t",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
@@ -216,7 +216,7 @@ exports[`AMP Media Asset Page Header Navigation link should match text and url 6
 exports[`AMP Media Asset Page Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
-  "url": "/persian/afghanistan",
+  "url": "/persian/topics/cvjp23v3083t",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
@@ -168,7 +168,7 @@ exports[`Canonical Media Asset Page Header Navigation link should match text and
 exports[`Canonical Media Asset Page Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
-  "url": "/persian/afghanistan",
+  "url": "/persian/topics/cvjp23v3083t",
 }
 `;
 

--- a/ws-nextjs-app/integration/pages/articles/persian/__snapshots__/amp.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/persian/__snapshots__/amp.test.ts.snap
@@ -125,7 +125,7 @@ exports[`AMP Articles Header Navigation link should match text and url 6`] = `
 exports[`AMP Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
-  "url": "/persian/afghanistan",
+  "url": "/persian/topics/cvjp23v3083t",
 }
 `;
 

--- a/ws-nextjs-app/integration/pages/articles/persian/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/persian/__snapshots__/canonical.test.ts.snap
@@ -168,7 +168,7 @@ exports[`Canonical Articles Header Navigation link should match text and url 6`]
 exports[`Canonical Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
-  "url": "/persian/afghanistan",
+  "url": "/persian/topics/cvjp23v3083t",
 }
 `;
 

--- a/ws-nextjs-app/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.ts.snap
@@ -125,7 +125,7 @@ exports[`AMP Articles Header Navigation link should match text and url 6`] = `
 exports[`AMP Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
-  "url": "/persian/afghanistan",
+  "url": "/persian/topics/cvjp23v3083t",
 }
 `;
 

--- a/ws-nextjs-app/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.ts.snap
@@ -165,7 +165,7 @@ exports[`Canonical Articles Header Navigation link should match text and url 6`]
 exports[`Canonical Articles Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
-  "url": "/persian/afghanistan",
+  "url": "/persian/topics/cvjp23v3083t",
 }
 `;
 

--- a/ws-nextjs-app/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.ts.snap
@@ -216,7 +216,7 @@ exports[`AMP Media Asset Page Header Navigation link should match text and url 6
 exports[`AMP Media Asset Page Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
-  "url": "/persian/afghanistan",
+  "url": "/persian/topics/cvjp23v3083t",
 }
 `;
 

--- a/ws-nextjs-app/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.ts.snap
@@ -168,7 +168,7 @@ exports[`Canonical Media Asset Page Header Navigation link should match text and
 exports[`Canonical Media Asset Page Header Navigation link should match text and url 7`] = `
 {
   "text": "افغانستان",
-  "url": "/persian/afghanistan",
+  "url": "/persian/topics/cvjp23v3083t",
 }
 `;
 


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1649

Summary
======
Update persian navigation to point to https://www.bbc.com/persian/topics/cvjp23v3083t instead of https://www.bbc.com/persian/afghanistan

Code changes
======
- Update persian service config 
- Update integration snapshots