### PR TITLE
NOTICKET - Add `showCookieBannerBasedOnCountry` to Next.js app

### DIFF
--- a/ws-nextjs-app/pages/_app.page.tsx
+++ b/ws-nextjs-app/pages/_app.page.tsx
@@ -38,6 +38,7 @@ interface Props extends AppProps {
     pathname: string;
     service: Services;
     showAdsBasedOnLocation: boolean;
+    showCookieBannerBasedOnCountry?: boolean;
     status: number;
     timeOnServer?: number;
     toggles: Toggles;
@@ -63,6 +64,7 @@ export default function App({ Component, pageProps }: Props) {
     pathname,
     service,
     showAdsBasedOnLocation,
+    showCookieBannerBasedOnCountry = true,
     status,
     timeOnServer,
     toggles,
@@ -100,6 +102,7 @@ export default function App({ Component, pageProps }: Props) {
           variant={variant}
           timeOnServer={timeOnServer}
           showAdsBasedOnLocation={showAdsBasedOnLocation}
+          showCookieBannerBasedOnCountry={showCookieBannerBasedOnCountry}
           serverSideExperiments={serverSideExperiments}
           country={country}
           isNextJs={isNextJs}


### PR DESCRIPTION
Summary
======
- Passes down `showCookieBannerBasedOnCountry` prop from `getServerSideProps` to Next.js app contexts to ensure cookie banner only appears when appropriate

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

