### PR TITLE
NOTICKET - Ensure `isAmp` flag is passed in Article data fetch

### DIFF
--- a/ws-nextjs-app/pages/[service]/articles/handleArticleRoute.ts
+++ b/ws-nextjs-app/pages/[service]/articles/handleArticleRoute.ts
@@ -56,6 +56,7 @@ export default async (context: GetServerSidePropsContext) => {
     rendererEnv,
     resolvedUrl: resolvedUrlWithoutQuery,
     pageType: ARTICLE_PAGE,
+    isAmp,
   });
 
   const { pageData, status } = data;

--- a/ws-nextjs-app/utilities/pageRequests/getPageData.ts
+++ b/ws-nextjs-app/utilities/pageRequests/getPageData.ts
@@ -18,6 +18,7 @@ type Props = {
   rendererEnv?: string;
   resolvedUrl: string;
   pageType: PageTypes;
+  isAmp?: boolean;
 };
 
 const getPageData = async ({
@@ -28,6 +29,7 @@ const getPageData = async ({
   rendererEnv,
   resolvedUrl,
   pageType,
+  isAmp,
 }: Props) => {
   const path = `${id}${rendererEnv ? `?renderer_env=${rendererEnv}` : ''}`;
   const url = new URL(path, 'https://www.bbc.com');
@@ -46,6 +48,7 @@ const getPageData = async ({
       variant,
       page,
       getAgent,
+      isAmp,
     }));
   } catch (error: unknown) {
     ({ message, status } = error as FetchError);


### PR DESCRIPTION
Summary
======
Passes down `isAmp` flag to `getPageData` so that it can be used in BFF fetch

- Should allow AMP embed to be rendered in http://localhost:7081/portuguese/articles/crp8rpklrvvo.amp?renderer_env=test


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

