### PR TITLE
NOTICKET - Add `chromeWebSecurity: false` to Next.js Cypress config

### DIFF
--- a/ws-nextjs-app/cypress.config.ts
+++ b/ws-nextjs-app/cypress.config.ts
@@ -2,7 +2,7 @@
 import { defineConfig } from 'cypress';
 import fs from 'fs';
 import path from 'path';
-import MomentTimezoneInclude from '../src/app/legacy/psammead/moment-timezone-include/src'
+import MomentTimezoneInclude from '../src/app/legacy/psammead/moment-timezone-include/src';
 import webpackPreprocessor from '@cypress/webpack-preprocessor';
 import { DefinePlugin } from 'webpack';
 import dotenv from 'dotenv';
@@ -26,7 +26,7 @@ export default defineConfig({
         path: `./envConfig/${config.env.APP_ENV}.env`,
       });
 
-      const appConfig = parsed as Record<string, string>
+      const appConfig = parsed as Record<string, string>;
       const envVars = Object.keys(appConfig).reduce((vars, key) => {
         vars[key] = JSON.stringify(appConfig[key]);
         return vars;
@@ -89,7 +89,7 @@ export default defineConfig({
       };
 
       on('file:preprocessor', webpackPreprocessor(options));
-      
+
       // Add options for the cypress terminal report (cy.logs) here
       const logPrinterOptions = {
         defaultTrimLength: 2000,
@@ -147,4 +147,5 @@ export default defineConfig({
   requestTimeout: 60000,
   video: false,
   screenshotOnRunFailure: false,
+  chromeWebSecurity: false,
 });


### PR DESCRIPTION
Summary
======
Mirrors Express Cypress config for the `chromeWebSecurity` property in an attempt to resolve cross-origin Cypress issues


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

