### PR TITLE
NOTICKET - Disable `FlourishResponsiveHeight` Chromatic snapshot

### DIFF
--- a/src/app/components/Embeds/FlourishEmbed/index.stories.tsx
+++ b/src/app/components/Embeds/FlourishEmbed/index.stories.tsx
@@ -9,16 +9,15 @@ import FlourishEmbed from '.';
 export default {
   title: 'Components/Embeds/Flourish Embed',
   component: FlourishEmbed,
-  parameters: {
-    chromatic: {
-      diffThreshold: 0.5,
-    },
-  },
 };
 
 export const FlourishResponsiveHeight = () => (
   <FlourishEmbed {...AsianGamesFootballProps} />
 );
+
+FlourishResponsiveHeight.parameters = {
+  chromatic: { disable: true },
+};
 
 export const FlourishStory = () => <FlourishEmbed {...FlourishStoryFixture} />;
 

--- a/src/app/components/Embeds/FlourishEmbed/index.stories.tsx
+++ b/src/app/components/Embeds/FlourishEmbed/index.stories.tsx
@@ -9,6 +9,11 @@ import FlourishEmbed from '.';
 export default {
   title: 'Components/Embeds/Flourish Embed',
   component: FlourishEmbed,
+  parameters: {
+    chromatic: {
+      diffThreshold: 0.2,
+    },
+  },
 };
 
 export const FlourishResponsiveHeight = () => (

--- a/src/app/components/Embeds/FlourishEmbed/index.stories.tsx
+++ b/src/app/components/Embeds/FlourishEmbed/index.stories.tsx
@@ -11,7 +11,7 @@ export default {
   component: FlourishEmbed,
   parameters: {
     chromatic: {
-      diffThreshold: 0.2,
+      diffThreshold: 0.5,
     },
   },
 };


### PR DESCRIPTION
Summary
======
- Disables the Chromatic snapshot for `FlourishResponsiveHeight`, as the data it uses hits a geonames API that can take a very long time to respond, resulting in inconsistent Chromatic snapshots


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

