### PR TITLE
NOTICKET: Correct High Impact promo fallback attribution

### DIFF
--- a/src/app/components/Curation/HighImpactPromo/index.tsx
+++ b/src/app/components/Curation/HighImpactPromo/index.tsx
@@ -6,6 +6,7 @@ import Promo from '#components/Promo';
 import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import { RequestContext } from '#app/contexts/RequestContext';
 import { ServiceContext } from '#app/contexts/ServiceContext';
+import { getBrandPath } from '#app/legacy/containers/Brand';
 import styles from './index.styles';
 
 type Attribution = {
@@ -29,7 +30,8 @@ const HighImpactPromo = ({
   const { isAmp } = use(RequestContext);
   const { dir, service, brandName } = use(ServiceContext) || {};
 
-  const attributionLink = attribution?.link || (service ? `/${service}` : null);
+  const attributionLink =
+    attribution?.link || (service ? getBrandPath(service) : null);
   const attributionText = attribution?.text || brandName;
   const hasAttribution = attributionLink && attributionText;
 


### PR DESCRIPTION
Resolves JIRA: 

Summary
======
- The current logic renders http://test.bbc.com/ws instead of http://test.bbc.com/ws/languages when an external link is used for a High Impact promo. This is a temporary solution, as the attribution logic [is expected to change](https://bbc.atlassian.net/browse/WS-1613) in the near future.

Code changes
======
- _A bullet point list of key code changes that have been made._


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

