### PR TITLE
NOTICKET - Temporarily comment out `atuserId` e2es

### DIFF
--- a/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
@@ -6,7 +6,7 @@ import {
 import {
   ATI_PAGE_VIEW,
   ATI_PAGE_VIEW_REVERB,
-  ATI_USER_ID_COOKIE,
+  // ATI_USER_ID_COOKIE,
   getATIParamsFromURL,
   interceptATIAnalyticsBeacons,
   getExpectedAtiDestination,
@@ -210,12 +210,13 @@ export const assertPageView = ({
         applicationType,
       });
 
-      if (['responsive', 'lite'].includes(applicationType)) {
-        expect(params.idclient).to.equal(
-          ATI_USER_ID_COOKIE,
-          'params.idclient (atuserid cookie value)',
-        );
-      }
+      // TODO: Commenting out temporarily until old ATI code is removed
+      // if (['responsive', 'lite'].includes(applicationType)) {
+      //   expect(params.idclient).to.equal(
+      //     ATI_USER_ID_COOKIE,
+      //     'params.idclient (atuserid cookie value)',
+      //   );
+      // }
 
       expect(params.p).to.equal(pageIdentifier, 'params.p (page identifier)');
       expect(parseInt(params.s2, 10)).to.equal(
@@ -245,19 +246,21 @@ export const assertPageView = ({
 const assertViewabilityModelViewEvent = ({
   pageIdentifier,
   params,
-  applicationType,
+  // applicationType,
   siteId,
 }) => {
   const eventContext = JSON.parse(params.context);
 
   assertReverbViewabilityComponentEventParamsExist({ params });
 
-  if (['responsive', 'lite'].includes(applicationType)) {
-    expect(params.idclient).to.equal(
-      ATI_USER_ID_COOKIE,
-      'params.idclient (atuserid cookie value)',
-    );
-  }
+  // TODO: Commenting out temporarily until old ATI code is removed
+
+  // if (['responsive', 'lite'].includes(applicationType)) {
+  //   expect(params.idclient).to.equal(
+  //     ATI_USER_ID_COOKIE,
+  //     'params.idclient (atuserid cookie value)',
+  //   );
+  // }
 
   expect(params.events).to.satisfy(
     payload =>
@@ -295,7 +298,7 @@ export const assertATIComponentViewEvent = ({
 const assertViewabilityModelClickEvent = ({
   pageIdentifier,
   params,
-  applicationType,
+  // applicationType,
   siteId,
 }) => {
   const eventContext = JSON.parse(params.context);
@@ -304,12 +307,13 @@ const assertViewabilityModelClickEvent = ({
     params,
   });
 
-  if (['responsive', 'lite'].includes(applicationType)) {
-    expect(params.idclient).to.equal(
-      ATI_USER_ID_COOKIE,
-      'params.idclient (atuserid cookie value)',
-    );
-  }
+  // TODO: Commenting out temporarily until old ATI code is removed
+  // if (['responsive', 'lite'].includes(applicationType)) {
+  //   expect(params.idclient).to.equal(
+  //     ATI_USER_ID_COOKIE,
+  //     'params.idclient (atuserid cookie value)',
+  //   );
+  // }
 
   expect(params.events).to.satisfy(
     payload =>

--- a/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
@@ -210,7 +210,7 @@ export const assertPageView = ({
         applicationType,
       });
 
-      // TODO: Commenting out temporarily until old ATI code is removed
+      // TODO: Commenting out temporarily until old ATI code is removed - https://bbc.atlassian.net/browse/WS-222
       // if (['responsive', 'lite'].includes(applicationType)) {
       //   expect(params.idclient).to.equal(
       //     ATI_USER_ID_COOKIE,
@@ -253,8 +253,7 @@ const assertViewabilityModelViewEvent = ({
 
   assertReverbViewabilityComponentEventParamsExist({ params });
 
-  // TODO: Commenting out temporarily until old ATI code is removed
-
+  // TODO: Commenting out temporarily until old ATI code is removed - https://bbc.atlassian.net/browse/WS-222
   // if (['responsive', 'lite'].includes(applicationType)) {
   //   expect(params.idclient).to.equal(
   //     ATI_USER_ID_COOKIE,
@@ -307,7 +306,7 @@ const assertViewabilityModelClickEvent = ({
     params,
   });
 
-  // TODO: Commenting out temporarily until old ATI code is removed
+  // TODO: Commenting out temporarily until old ATI code is removed - https://bbc.atlassian.net/browse/WS-222
   // if (['responsive', 'lite'].includes(applicationType)) {
   //   expect(params.idclient).to.equal(
   //     ATI_USER_ID_COOKIE,


### PR DESCRIPTION
Summary
======
- Temporarily comments out `atuserid` e2e assertions until the work into removing old ATI logic is removed. This old logic is potentially the culprit of setting the `atuserid` cookie inadvertently and will be removed in https://bbc.atlassian.net/browse/WS-222


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

