### PR TITLE
WS-1583 - Move continue reading button `beforeEach` handler to global `beforeEach`

### DIFF
--- a/ws-nextjs-app/cypress/e2e/articlePage/helpers.ts
+++ b/ws-nextjs-app/cypress/e2e/articlePage/helpers.ts
@@ -56,21 +56,3 @@ export const getVideoEmbedUrl = (
 
   return isAmp ? `${embedUrl}/amp` : embedUrl;
 };
-
-export const handleContinueReadingButton = () => {
-  const CONTINUE_READING_BUTTON_ID = '#continue-reading-button';
-
-  cy.get('body').then($body => {
-    if ($body.find(CONTINUE_READING_BUTTON_ID).length > 0) {
-      cy.get(CONTINUE_READING_BUTTON_ID).then($button => {
-        const buttonDisplay = window
-          .getComputedStyle($button[0])
-          .getPropertyValue('display');
-
-        if (buttonDisplay !== 'none') {
-          cy.get(CONTINUE_READING_BUTTON_ID).click();
-        }
-      });
-    }
-  });
-};

--- a/ws-nextjs-app/cypress/e2e/articlePage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/articlePage/index.cy.ts
@@ -8,7 +8,6 @@ import canonicalAndAmpArticleTests from './tests';
 import ampArticleTests from './testsForAMPOnly';
 import canonicalArticleTests from './testsForCanonicalOnly';
 import liteArticleTests from './testsForLiteOnly';
-import { handleContinueReadingButton } from './helpers';
 
 const canonicalTests = [
   testsForAllPages,
@@ -268,7 +267,7 @@ const liteTestSuites = canonicalTestSuites
 
 runTestsForPage({
   pageType: ARTICLE_PAGE,
-  beforeEachFns: [handleContinueReadingButton],
+  beforeEachFns: [],
   testSuites: [...canonicalTestSuites, ...ampTestSuites, ...liteTestSuites],
   deleteServiceWorker: true,
 });

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/index.cy.ts
@@ -61,7 +61,6 @@ import {
   assertDropdownNavigationComponentView,
 } from './assertions/navigation';
 import getPathWithSuffix from '../../../support/helpers/getPathWithSuffix';
-import { handleContinueReadingButton } from '../../articlePage/helpers';
 
 const canonicalTestSuites = [
   {
@@ -358,6 +357,6 @@ runTestsForPage({
     ...ampTestSuites,
     ...liteTestSuites,
   ] as unknown as TestDataType[],
-  beforeEachFns: [setUserIDCookie, handleContinueReadingButton],
+  beforeEachFns: [setUserIDCookie],
   pageType: 'all' as PageTypes,
 });

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/index.cy.ts
@@ -61,6 +61,7 @@ import {
   assertDropdownNavigationComponentView,
 } from './assertions/navigation';
 import getPathWithSuffix from '../../../support/helpers/getPathWithSuffix';
+import { handleContinueReadingButton } from '../../articlePage/helpers';
 
 const canonicalTestSuites = [
   {
@@ -357,6 +358,6 @@ runTestsForPage({
     ...ampTestSuites,
     ...liteTestSuites,
   ] as unknown as TestDataType[],
-  beforeEachFns: [setUserIDCookie],
+  beforeEachFns: [setUserIDCookie, handleContinueReadingButton],
   pageType: 'all' as PageTypes,
 });

--- a/ws-nextjs-app/cypress/support/helpers/handleContinueReadingButton.ts
+++ b/ws-nextjs-app/cypress/support/helpers/handleContinueReadingButton.ts
@@ -1,0 +1,17 @@
+export default () => {
+  const CONTINUE_READING_BUTTON_ID = '#continue-reading-button';
+
+  cy.get('body').then($body => {
+    if ($body.find(CONTINUE_READING_BUTTON_ID).length > 0) {
+      cy.get(CONTINUE_READING_BUTTON_ID).then($button => {
+        const buttonDisplay = window
+          .getComputedStyle($button[0])
+          .getPropertyValue('display');
+
+        if (buttonDisplay !== 'none') {
+          cy.get(CONTINUE_READING_BUTTON_ID).click();
+        }
+      });
+    }
+  });
+};

--- a/ws-nextjs-app/cypress/support/helpers/runTestsForPage.ts
+++ b/ws-nextjs-app/cypress/support/helpers/runTestsForPage.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-relative-packages */
 import { PageTypes } from '#app/models/types/global';
+import handleContinueReadingButton from './handleContinueReadingButton';
 import { ServiceParametersType } from '../../types';
 import getOptimizelyKey from '../../../../cypress/support/helpers/getOptimizelyKey';
 
@@ -90,6 +91,9 @@ export default ({
           });
 
           beforeEach(() => {
+            // This is a special case to reveal the article before any other test runs
+            handleContinueReadingButton();
+
             beforeEachFns.forEach(runBeforeEach => runBeforeEach());
 
             cy.intercept(


### PR DESCRIPTION
Part of JIRA: https://bbc.atlassian.net/browse/WS-1583

Summary
======
- Moves the `handleContinueReadingButton` function inside the global `beforeEach` so that it is applied to all test suites so that we don't need to worry about adding it to individual suites in the future

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

