### PR TITLE
WS-1583 - Add continue reading e2e handler to individual ATI tests

### DIFF
--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/podcastPromo.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/podcastPromo.ts
@@ -5,6 +5,7 @@ import {
   assertATIComponentViewEvent,
 } from '../../../../../../cypress/e2e/specialFeatures/atiAnalytics/assertions';
 import { AtiAssertionFnProps } from './type';
+import handleContinueReadingButton from '../../../../support/helpers/handleContinueReadingButton';
 
 const { PODCAST_PROMO } = COMPONENTS;
 
@@ -19,6 +20,8 @@ export const assertPodcastPromoComponentView = ({
   it('should send a view event for the Podcast Promo component', () => {
     interceptATIAnalyticsBeacons();
     cy.visit(path);
+
+    handleContinueReadingButton();
 
     // This duplicate line of code has been added intentionally to get cypress to scroll to the bottom.
     cy.get('[data-e2e="podcast-promo"]').scrollIntoView({
@@ -50,6 +53,8 @@ export const assertPodcastPromoComponentClick = ({
   it('should send a click event for the Podcast Promo component', () => {
     interceptATIAnalyticsBeacons();
     cy.visit(path);
+
+    handleContinueReadingButton();
 
     cy.get('[data-e2e="podcast-promo"]').scrollIntoView({
       duration: 1000,

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/recommendations.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/recommendations.ts
@@ -5,6 +5,7 @@ import {
   assertATIComponentViewEvent,
 } from '../../../../../../cypress/e2e/specialFeatures/atiAnalytics/assertions';
 import { AtiAssertionFnProps } from './type';
+import handleContinueReadingButton from '../../../../support/helpers/handleContinueReadingButton';
 
 const { RECOMMENDATIONS } = COMPONENTS;
 
@@ -19,6 +20,8 @@ export const assertRecommendationsComponentView = ({
   it('should send a view event for the Recommendations component', () => {
     interceptATIAnalyticsBeacons();
     cy.visit(path);
+
+    handleContinueReadingButton();
 
     // This duplicate line of code has been added intentionally to get cypress to scroll to the bottom.
     cy.get('[data-e2e="recommendations-heading"]').scrollIntoView({
@@ -50,6 +53,8 @@ export const assertRecommendationsComponentClick = ({
   it('should send a click event for the Recommendations component', () => {
     interceptATIAnalyticsBeacons();
     cy.visit(path);
+
+    handleContinueReadingButton();
 
     cy.get('[data-e2e="recommendations-heading"]').scrollIntoView({
       duration: 1000,

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/relatedTopics.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/relatedTopics.ts
@@ -5,6 +5,7 @@ import {
   assertATIComponentViewEvent,
 } from '../../../../../../cypress/e2e/specialFeatures/atiAnalytics/assertions';
 import { AtiAssertionFnProps } from './type';
+import handleContinueReadingButton from '../../../../support/helpers/handleContinueReadingButton';
 
 const { RELATED_TOPICS } = COMPONENTS;
 
@@ -19,6 +20,8 @@ export const assertRelatedTopicsComponentView = ({
   it('should send a view event for the Related Topics component', () => {
     interceptATIAnalyticsBeacons();
     cy.visit(path);
+
+    handleContinueReadingButton();
 
     // This duplicate line of code has been added intentionally to get cypress to scroll to the bottom.
     cy.get('[data-testid="related-topics"]').scrollIntoView({
@@ -50,6 +53,8 @@ export const assertRelatedTopicsComponentClick = ({
   it('should send a click event for the Related Topics component', () => {
     interceptATIAnalyticsBeacons();
     cy.visit(path);
+
+    handleContinueReadingButton();
 
     cy.get('[data-testid="related-topics"]').scrollIntoView({
       duration: 1000,

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/scrollablePromo.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/scrollablePromo.ts
@@ -5,6 +5,7 @@ import {
   assertATIComponentViewEvent,
 } from '../../../../../../cypress/e2e/specialFeatures/atiAnalytics/assertions';
 import { AtiAssertionFnProps } from './type';
+import handleContinueReadingButton from '../../../../support/helpers/handleContinueReadingButton';
 
 const { SCROLLABLE_PROMO } = COMPONENTS;
 
@@ -19,6 +20,8 @@ export const assertScrollablePromoComponentView = ({
   it('should send a view event for the Scrollable Promo component', () => {
     interceptATIAnalyticsBeacons();
     cy.visit(path);
+
+    handleContinueReadingButton();
 
     // This duplicate line of code has been added intentionally to get cypress to scroll to the bottom.
     cy.get('[data-e2e="scrollable-promos"]').first().scrollIntoView({
@@ -50,6 +53,8 @@ export const assertScrollablePromoComponentClick = ({
   it('should send a click event for the Scrollable Promo component', () => {
     interceptATIAnalyticsBeacons();
     cy.visit(path);
+
+    handleContinueReadingButton();
 
     cy.get('[data-e2e="scrollable-promos"]').first().scrollIntoView({
       duration: 1000,

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/socialEmbed.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/socialEmbed.ts
@@ -5,6 +5,7 @@ import {
   assertATIComponentViewEvent,
 } from '../../../../../../cypress/e2e/specialFeatures/atiAnalytics/assertions';
 import { AtiAssertionFnProps } from './type';
+import handleContinueReadingButton from '../../../../support/helpers/handleContinueReadingButton';
 
 const { SOCIAL_EMBED } = COMPONENTS;
 
@@ -19,6 +20,8 @@ export const assertSocialEmbedComponentView = ({
   it('should send a view event for the Social Embed component', () => {
     interceptATIAnalyticsBeacons();
     cy.visit(path);
+
+    handleContinueReadingButton();
 
     // This duplicate line of code has been added intentionally to get cypress to scroll to the bottom.
     cy.get('[data-testid="consentBanner"]').first().scrollIntoView({
@@ -50,6 +53,8 @@ export const assertSocialEmbedComponentClick = ({
   it('should send a click event for the Social Embed component', () => {
     interceptATIAnalyticsBeacons();
     cy.visit(path);
+
+    handleContinueReadingButton();
 
     cy.get('[data-testid="consentBanner"]').first().scrollIntoView({
       duration: 1000,


### PR DESCRIPTION
Part of JIRA: https://bbc.atlassian.net/browse/WS-1583

Summary
======
- Adds `handleContinueReadingButton` function to individual ATI tests since we trigger `cy.visit(path)` within those tests, causing the continue reading button to reappear and require clicking again


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

