### PR TITLE
WS-1583 - Modify `cy.visit` command to handle continue reading button

### DIFF
--- a/ws-nextjs-app/cypress/support/commands.ts
+++ b/ws-nextjs-app/cypress/support/commands.ts
@@ -5,6 +5,7 @@ import defaultToggles from '#app/lib/config/toggles';
 import testResponseCodeAndRetry from './helpers/testResponseCodeAndRetry';
 import getAppEnv from './helpers/getAppEnv';
 import envConfig, { EnvironmentConfigType } from './config/envs';
+import handleContinueReadingButton from './helpers/handleContinueReadingButton';
 
 interface TestResponseCodeAndRetry {
   url: string;
@@ -131,3 +132,10 @@ Cypress.Commands.add('testResponseCodeAndRetry', testResponseCodeAndRetry);
 Cypress.Commands.add('getToggles', getToggles);
 Cypress.Commands.add('hasNoscriptImgAtiUrl', hasNoscriptImgAtiUrl);
 Cypress.Commands.add('testResponseCodeAndType', testResponseCodeAndType);
+
+Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+  return originalFn(url, options).then(() => {
+    // Handle Continue Reading button if it appears when cy.visit() is called
+    handleContinueReadingButton();
+  });
+});


### PR DESCRIPTION
Part of JIRA: https://bbc.atlassian.net/browse/WS-1583

Summary
======
- Modifies the `cy.visit` command to cater for the continue reading button, as calling `cy.visit` will cause the page to render/refresh and make the button reappear


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

