### PR TITLE
Revert "WS-NA: Skips test to try debug blocked pipeline"

### DIFF
--- a/ws-nextjs-app/cypress/e2e/storyPage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/storyPage/index.cy.ts
@@ -50,7 +50,7 @@ const canonicalSmokeTestSuites = [
   {
     path: '/mundo/23263889',
     service: 'mundo',
-    runforEnv: ['local'],
+    runforEnv: ['test', 'local'],
     tests: canonicalTests,
   },
   {


### PR DESCRIPTION
Reverts bbc/simorgh#13416 (merged to unblock the pipeline)

Interested to see if the suppression applied to gnl-ngas repo will fix our issue.

I can see we reference something that could be their bootstrap script [here](https://github.com/bbc/simorgh/blob/latest/src/app/components/Ad/Canonical/index.tsx#L18-L26), so maybe it will?

Otherwise this revert will block the pipeline - and we may want to suppress the error ourselves.