### PR TITLE
Disable STY e2e to fix pipeline

### DIFF
--- a/ws-nextjs-app/cypress/e2e/storyPage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/storyPage/index.cy.ts
@@ -47,12 +47,13 @@ const canonicalSmokeTestSuites = [
     runforEnv: ['live'],
     tests: canonicalTests,
   },
-  {
-    path: '/mundo/23263889',
-    service: 'mundo',
-    runforEnv: ['test', 'local'],
-    tests: canonicalTests,
-  },
+  // TODO: Re-enable once the external media/analytics issue is resolved
+  // {
+  //   path: '/mundo/23263889',
+  //   service: 'mundo',
+  //   runforEnv: ['local', 'test'],
+  //   tests: canonicalTests,
+  // },
   {
     path: '/mundo/noticias-internacional-51266689',
     service: 'mundo',


### PR DESCRIPTION
Summary
======
Disables the `/mundo/23263889` e2e to fix PR and pipeline checks


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

