### PR TITLE
Add `nonce` to Opera Mini classname script

### DIFF
--- a/src/app/lib/utilities/addOperaMiniClassScript/index.client.test.tsx
+++ b/src/app/lib/utilities/addOperaMiniClassScript/index.client.test.tsx
@@ -45,4 +45,13 @@ describe('addOperaMiniClassScript', () => {
       expect(classListAddSpy).not.toHaveBeenCalledWith('is-opera-mini');
     });
   });
+
+  describe('when nonce is provided', () => {
+    it('should add nonce attribute to script tag', () => {
+      const nonceValue = 'test-nonce';
+      const scriptElement = addOperaMiniClassScript(nonceValue);
+
+      expect(scriptElement.props.nonce).toBe(nonceValue);
+    });
+  });
 });

--- a/src/app/lib/utilities/addOperaMiniClassScript/index.client.test.tsx
+++ b/src/app/lib/utilities/addOperaMiniClassScript/index.client.test.tsx
@@ -25,7 +25,7 @@ describe('addOperaMiniClassScript', () => {
     });
 
     it('should add is-opera-mini class to documentElement', () => {
-      eval(addOperaMiniClassScript.props.dangerouslySetInnerHTML.__html);
+      eval(addOperaMiniClassScript().props.dangerouslySetInnerHTML.__html);
 
       expect(classListAddSpy).toHaveBeenCalledWith('is-opera-mini');
     });
@@ -40,7 +40,7 @@ describe('addOperaMiniClassScript', () => {
     });
 
     it('should not add is-opera-mini class to documentElement', () => {
-      eval(addOperaMiniClassScript.props.dangerouslySetInnerHTML.__html);
+      eval(addOperaMiniClassScript().props.dangerouslySetInnerHTML.__html);
 
       expect(classListAddSpy).not.toHaveBeenCalledWith('is-opera-mini');
     });

--- a/src/app/lib/utilities/addOperaMiniClassScript/index.tsx
+++ b/src/app/lib/utilities/addOperaMiniClassScript/index.tsx
@@ -5,8 +5,8 @@ export const OPERA_MINI_CLASSNAME = 'is-opera-mini';
 
 export default (nonce?: string | null) => (
   <script
-    type="text/javascript"
     {...(nonce ? { nonce } : {})}
+    type="text/javascript"
     // eslint-disable-next-line react/no-danger
     dangerouslySetInnerHTML={{
       __html: `

--- a/src/app/lib/utilities/addOperaMiniClassScript/index.tsx
+++ b/src/app/lib/utilities/addOperaMiniClassScript/index.tsx
@@ -3,9 +3,10 @@ import isOperaProxy from '../isOperaProxy';
 
 export const OPERA_MINI_CLASSNAME = 'is-opera-mini';
 
-export default (
+export default (nonce?: string | null) => (
   <script
     type="text/javascript"
+    {...(nonce ? { nonce } : {})}
     // eslint-disable-next-line react/no-danger
     dangerouslySetInnerHTML={{
       __html: `

--- a/src/server/Document/Renderers/CanonicalRenderer.tsx
+++ b/src/server/Document/Renderers/CanonicalRenderer.tsx
@@ -115,7 +115,7 @@ export default function CanonicalRenderer({
             __html: `window.SIMORGH_ENV_VARS=${appEnvVariables}`,
           }}
         />
-        {addOperaMiniClassScript}
+        {addOperaMiniClassScript(nonce)}
         <ComponentTracking
           {...(nonce ? { nonce } : {})}
           trackComponentViews={false}

--- a/ws-nextjs-app/pages/_document.page.tsx
+++ b/ws-nextjs-app/pages/_document.page.tsx
@@ -197,7 +197,7 @@ export default class AppDocument extends Document<DocProps> {
                   __html: `document.documentElement.classList.remove("no-js");`,
                 }}
               />
-              {addOperaMiniClassScript}
+              {addOperaMiniClassScript()}
               <Script strategy="beforeInteractive">
                 {`window.SIMORGH_ENV_VARS=${JSON.stringify(clientSideEnvVariables)}`}
               </Script>


### PR DESCRIPTION
Summary
======
- Adds `nonce` to the new Opera Mini class name script if its provided

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

