### PR TITLE
Pass `seo` fields from Home/Topic pages down in `pageData`

### DIFF
--- a/src/app/routes/homePage/getInitialData/index.ts
+++ b/src/app/routes/homePage/getInitialData/index.ts
@@ -24,16 +24,25 @@ export default async ({
     });
 
     const {
-      data: { title, description, curations, metadata },
+      data: {
+        title,
+        seoTitle,
+        description,
+        seoDescription,
+        curations,
+        metadata,
+      },
     } = json;
 
     return {
       status,
       pageData: {
         title,
+        seoTitle,
         metadata: { ...metadata, type: pageType },
         curations,
         description,
+        seoDescription,
       },
     };
   } catch (error: unknown) {

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -39,7 +39,9 @@ export default async ({ service, path: pathname, variant, page, getAgent }) => {
       status,
       pageData: {
         title: data.title,
+        seoTitle: data.seoTitle,
         description: data.description,
+        seoDescription: data.seoDescription,
         imageData,
         curations: data.curations,
         activePage: data.activePage || 1,

--- a/src/integration/pages/homePage/arabic/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/arabic/__snapshots__/canonical.test.js.snap
@@ -274,7 +274,7 @@ exports[`Canonical Home Page SEO Linked data should match text 1`] = `
   "@graph": [
     {
       "@type": "CollectionPage",
-      "headline": "الرئيسية",
+      "headline": "BBC News عربي",
       "image": {
         "@type": "ImageObject",
         "height": 576,
@@ -289,7 +289,7 @@ exports[`Canonical Home Page SEO Linked data should match text 1`] = `
       "mainEntityOfPage": {
         "@id": "http://localhost:7080/arabic",
         "@type": "WebPage",
-        "name": "الرئيسية",
+        "name": "BBC News عربي",
       },
       "publisher": {
         "@type": "NewsMediaOrganization",
@@ -352,7 +352,7 @@ exports[`Canonical Home Page SEO Linked data should match text 1`] = `
 }
 `;
 
-exports[`Canonical Home Page SEO OG description 1`] = `"بي بي سي العربية هي شبكة لنقل الأخبار والمعلومات ومقاطع الفيديو إلى العالم عبر عدة وسائط، تشمل الإنترنت ومواقع التواصل الاجتماعي والراديو والتلفزيون والهواتف المحمولة."`;
+exports[`Canonical Home Page SEO OG description 1`] = `"BBC News عربي: الأخبار والمعلومات باللغة العربية."`;
 
 exports[`Canonical Home Page SEO OG image 1`] = `"https://news.files.bbci.co.uk/ws/img/logos/og/arabic.png"`;
 
@@ -362,13 +362,13 @@ exports[`Canonical Home Page SEO OG locale 1`] = `"ar"`;
 
 exports[`Canonical Home Page SEO OG site name 1`] = `"BBC News عربي"`;
 
-exports[`Canonical Home Page SEO OG title 1`] = `"الرئيسية - BBC News عربي"`;
+exports[`Canonical Home Page SEO OG title 1`] = `"BBC News عربي - BBC News عربي"`;
 
 exports[`Canonical Home Page SEO OG type 1`] = `"website"`;
 
 exports[`Canonical Home Page SEO OG url 1`] = `"http://localhost:7080/arabic"`;
 
-exports[`Canonical Home Page SEO Page title 1`] = `"الرئيسية - BBC News عربي"`;
+exports[`Canonical Home Page SEO Page title 1`] = `"BBC News عربي - BBC News عربي"`;
 
 exports[`Canonical Home Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
@@ -376,7 +376,7 @@ exports[`Canonical Home Page SEO Twitter card 1`] = `"summary_large_image"`;
 
 exports[`Canonical Home Page SEO Twitter creator 1`] = `"@BBCArabic"`;
 
-exports[`Canonical Home Page SEO Twitter description 1`] = `"بي بي سي العربية هي شبكة لنقل الأخبار والمعلومات ومقاطع الفيديو إلى العالم عبر عدة وسائط، تشمل الإنترنت ومواقع التواصل الاجتماعي والراديو والتلفزيون والهواتف المحمولة."`;
+exports[`Canonical Home Page SEO Twitter description 1`] = `"BBC News عربي: الأخبار والمعلومات باللغة العربية."`;
 
 exports[`Canonical Home Page SEO Twitter image alt 1`] = `"BBC News عربي"`;
 
@@ -384,7 +384,7 @@ exports[`Canonical Home Page SEO Twitter image src 1`] = `"https://news.files.bb
 
 exports[`Canonical Home Page SEO Twitter site 1`] = `"@BBCArabic"`;
 
-exports[`Canonical Home Page SEO Twitter title 1`] = `"الرئيسية - BBC News عربي"`;
+exports[`Canonical Home Page SEO Twitter title 1`] = `"BBC News عربي - BBC News عربي"`;
 
 exports[`Canonical Home Page Timestamp should match text and date 1`] = `
 {

--- a/src/integration/pages/homePage/hindi/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/hindi/__snapshots__/canonical.test.js.snap
@@ -345,7 +345,7 @@ exports[`Canonical Home Page SEO Linked data should match text 1`] = `
   "@graph": [
     {
       "@type": "CollectionPage",
-      "headline": "ब्रेकिंग न्यूज़ समाचार, ताजा खबर | News, latest news, breaking news",
+      "headline": "BBC News हिंदी",
       "image": {
         "@type": "ImageObject",
         "height": 576,
@@ -360,7 +360,7 @@ exports[`Canonical Home Page SEO Linked data should match text 1`] = `
       "mainEntityOfPage": {
         "@id": "http://localhost:7080/hindi",
         "@type": "WebPage",
-        "name": "ब्रेकिंग न्यूज़ समाचार, ताजा खबर | News, latest news, breaking news",
+        "name": "BBC News हिंदी",
       },
       "publisher": {
         "@type": "NewsMediaOrganization",
@@ -787,13 +787,13 @@ exports[`Canonical Home Page SEO OG locale 1`] = `"hi-IN"`;
 
 exports[`Canonical Home Page SEO OG site name 1`] = `"BBC News हिंदी"`;
 
-exports[`Canonical Home Page SEO OG title 1`] = `"ब्रेकिंग न्यूज़ समाचार, ताजा खबर | News, latest news, breaking news - BBC News हिंदी"`;
+exports[`Canonical Home Page SEO OG title 1`] = `"BBC News हिंदी - BBC News हिंदी"`;
 
 exports[`Canonical Home Page SEO OG type 1`] = `"website"`;
 
 exports[`Canonical Home Page SEO OG url 1`] = `"http://localhost:7080/hindi"`;
 
-exports[`Canonical Home Page SEO Page title 1`] = `"ब्रेकिंग न्यूज़ समाचार, ताजा खबर | News, latest news, breaking news - BBC News हिंदी"`;
+exports[`Canonical Home Page SEO Page title 1`] = `"BBC News हिंदी - BBC News हिंदी"`;
 
 exports[`Canonical Home Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
@@ -809,7 +809,7 @@ exports[`Canonical Home Page SEO Twitter image src 1`] = `"https://news.files.bb
 
 exports[`Canonical Home Page SEO Twitter site 1`] = `"@bbchindi"`;
 
-exports[`Canonical Home Page SEO Twitter title 1`] = `"ब्रेकिंग न्यूज़ समाचार, ताजा खबर | News, latest news, breaking news - BBC News हिंदी"`;
+exports[`Canonical Home Page SEO Twitter title 1`] = `"BBC News हिंदी - BBC News हिंदी"`;
 
 exports[`Canonical Home Page Timestamp should match text and date 1`] = `
 {

--- a/src/integration/pages/homePage/kyrgyz/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/homePage/kyrgyz/__snapshots__/canonical.test.js.snap
@@ -259,7 +259,7 @@ exports[`Canonical Home Page SEO Linked data should match text 1`] = `
   "@graph": [
     {
       "@type": "CollectionPage",
-      "headline": "Кабарлар, акыркы мүнөттөгү кабарлар, талдоо, видео",
+      "headline": "BBC News Kyrgyz",
       "image": {
         "@type": "ImageObject",
         "height": 576,
@@ -274,7 +274,7 @@ exports[`Canonical Home Page SEO Linked data should match text 1`] = `
       "mainEntityOfPage": {
         "@id": "http://localhost:7080/kyrgyz",
         "@type": "WebPage",
-        "name": "Кабарлар, акыркы мүнөттөгү кабарлар, талдоо, видео",
+        "name": "BBC News Kyrgyz",
       },
       "publisher": {
         "@type": "NewsMediaOrganization",
@@ -716,13 +716,13 @@ exports[`Canonical Home Page SEO OG locale 1`] = `"ky-KG"`;
 
 exports[`Canonical Home Page SEO OG site name 1`] = `"BBC News Кыргыз Кызматы"`;
 
-exports[`Canonical Home Page SEO OG title 1`] = `"Кабарлар, акыркы мүнөттөгү кабарлар, талдоо, видео - BBC News Кыргыз Кызматы"`;
+exports[`Canonical Home Page SEO OG title 1`] = `"BBC News Kyrgyz - BBC News Кыргыз Кызматы"`;
 
 exports[`Canonical Home Page SEO OG type 1`] = `"website"`;
 
 exports[`Canonical Home Page SEO OG url 1`] = `"http://localhost:7080/kyrgyz"`;
 
-exports[`Canonical Home Page SEO Page title 1`] = `"Кабарлар, акыркы мүнөттөгү кабарлар, талдоо, видео - BBC News Кыргыз Кызматы"`;
+exports[`Canonical Home Page SEO Page title 1`] = `"BBC News Kyrgyz - BBC News Кыргыз Кызматы"`;
 
 exports[`Canonical Home Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
@@ -741,7 +741,7 @@ exports[`Canonical Home Page SEO Twitter image src 1`] = `"https://news.files.bb
 
 exports[`Canonical Home Page SEO Twitter site 1`] = `"@bbckyrgyz"`;
 
-exports[`Canonical Home Page SEO Twitter title 1`] = `"Кабарлар, акыркы мүнөттөгү кабарлар, талдоо, видео - BBC News Кыргыз Кызматы"`;
+exports[`Canonical Home Page SEO Twitter title 1`] = `"BBC News Kyrgyz - BBC News Кыргыз Кызматы"`;
 
 exports[`Canonical Home Page Timestamp should match text and date 1`] = `
 {


### PR DESCRIPTION
Arised from JIRA: https://bbc.atlassian.net/browse/WS-1568

Summary
======
- Passes down `seoTitle` and `seoDescription` fields from the Home/Topic page `getInitialData` functions


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

