### PR TITLE
WS-1805 - Use `country` string in Optimizely attribute

### DIFF
--- a/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.client.test.tsx
+++ b/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.client.test.tsx
@@ -9,10 +9,7 @@ import { ServiceContext } from '#contexts/ServiceContext';
 import { RequestContext, RequestContextProps } from '#contexts/RequestContext';
 import { ServiceConfig } from '#app/models/types/serviceConfig';
 import latin from '../../../../components/ThemeProvider/fontScripts/latin';
-import withOptimizelyProvider, {
-  REFERRER_CATEGORIES,
-  COUNTRY_CODES_TO_EXPERIMENT,
-} from '.';
+import withOptimizelyProvider, { REFERRER_CATEGORIES } from '.';
 
 const props = {
   bbcOrigin: 'https://www.bbc.com',
@@ -259,35 +256,23 @@ describe('withOptimizelyProvider HOC', () => {
     });
   });
 
-  describe('countryKnown attribute', () => {
-    it.each(COUNTRY_CODES_TO_EXPERIMENT)(
-      'should set countryKnown to true when the country code is %s',
-      countryCode => {
-        render(<TestComponent country={countryCode} />);
-
-        expect(
-          (optimizelyProviderSpy.mock.calls[0]?.[0]?.user as UserInfo)
-            ?.attributes?.countryKnown,
-        ).toBe(true);
-      },
-    );
-
-    it('should set countryKnown to false when the country code is not in defined list', () => {
-      render(<TestComponent country="fakecode" />);
+  describe('country attribute', () => {
+    it('should set country to the value provided by RequestContext', () => {
+      render(<TestComponent country="gb" />);
 
       expect(
         (optimizelyProviderSpy.mock.calls[0]?.[0]?.user as UserInfo)?.attributes
-          ?.countryKnown,
-      ).toBe(false);
+          ?.country,
+      ).toBe('GB');
     });
 
-    it('should set countryKnown to false when the country code is unknown', () => {
+    it('should set country to null when RequestContext does not provide a country', () => {
       render(<TestComponent />);
 
       expect(
         (optimizelyProviderSpy.mock.calls[0]?.[0]?.user as UserInfo)?.attributes
-          ?.countryKnown,
-      ).toBe(false);
+          ?.country,
+      ).toBeNull();
     });
   });
 });

--- a/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.client.test.tsx
+++ b/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.client.test.tsx
@@ -263,7 +263,7 @@ describe('withOptimizelyProvider HOC', () => {
       expect(
         (optimizelyProviderSpy.mock.calls[0]?.[0]?.user as UserInfo)?.attributes
           ?.country,
-      ).toBe('GB');
+      ).toBe('gb');
     });
 
     it('should set country to null when RequestContext does not provide a country', () => {

--- a/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.tsx
+++ b/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.tsx
@@ -78,24 +78,6 @@ const getReferrer = () => {
   return null;
 };
 
-export const COUNTRY_CODES_TO_EXPERIMENT = [
-  'es',
-  'mx',
-  'ar',
-  'co',
-  'us',
-  'cl',
-  've',
-  'uy',
-  'do',
-];
-
-const isCountryKnown = (country?: string | null) => {
-  if (!country) return false;
-
-  return COUNTRY_CODES_TO_EXPERIMENT.includes(country.toLowerCase());
-};
-
 const optimizely = createInstance({
   sdkKey: getEnvConfig().SIMORGH_OPTIMIZELY_SDK_KEY,
   eventBatchSize: 10,
@@ -120,7 +102,7 @@ const withOptimizelyProvider = <T,>(Component: ComponentType<T>) => {
             service,
             mobile: isMobile(),
             referrer: getReferrer(),
-            countryKnown: isCountryKnown(country),
+            country: country ?? null,
           },
         }}
       >


### PR DESCRIPTION
Arised from https://bbc.atlassian.net/browse/WS-1805

Summary
======
Passes the `country` string, if provided, to Optimizely instead of determining a boolean ourselves. This allows us to use Optimizely to create an audience for `countryKnown` and gives us flexibility in the reporting to segment on country code

Code changes
======
- Passes up `country` value to Optimizely user attributes
- Alters test to check country code from RequestContext


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

