### PR TITLE
WS-143 Fix Bug Promo Media Icon not showing in hierarchical curation for large breakpoints

### DIFF
--- a/src/app/components/Curation/HierarchicalGrid/index.stories.tsx
+++ b/src/app/components/Curation/HierarchicalGrid/index.stories.tsx
@@ -27,7 +27,7 @@ const Component = ({
 
 export default {
   title: 'Components/Curation/Grid - Hierarchical',
-  Component,
+ component: Component,
   args: {
     promoCount: 12,
     promosToRender: 'default',
@@ -50,9 +50,11 @@ export default {
   },
 };
 
-export const WithMedia = {
-  render: () => <Component promoCount={12} promosToRender="withMedia" />,
-  tags: ['!dev'],
-};
+export const Example = (args) => <Component {...args} />;
 
-export const Example = Component;
+export const WithMedia = {
+  args: {
+    promoCount: 12,
+    promosToRender: 'withMedia',
+  },
+};

--- a/src/app/components/Curation/HierarchicalGrid/index.styles.tsx
+++ b/src/app/components/Curation/HierarchicalGrid/index.styles.tsx
@@ -79,7 +79,7 @@ const styles = {
     css({
       display: 'none',
       padding: 0,
-      paddingInlineEnd: `${spacings.FULL}rem`,
+      paddingInlineEnd: `${spacings.HALF}rem`,
       verticalAlign: 'text-top',
     }),
 };

--- a/src/app/components/Curation/HierarchicalGrid/index.styles.tsx
+++ b/src/app/components/Curation/HierarchicalGrid/index.styles.tsx
@@ -80,6 +80,7 @@ const styles = {
       display: 'none',
       padding: 0,
       paddingInlineEnd: `${spacings.HALF}rem`,
+      marginInlineStart: `-${spacings.HALF}rem`,
       verticalAlign: 'text-top',
     }),
 };

--- a/src/app/components/Curation/HierarchicalGrid/index.styles.tsx
+++ b/src/app/components/Curation/HierarchicalGrid/index.styles.tsx
@@ -75,6 +75,13 @@ const styles = {
         },
       }),
     }),
+  inlineIcon: ({ spacings }: Theme) =>
+    css({
+      display: 'none',
+      padding: 0,
+      paddingInlineEnd: `${spacings.FULL}rem`,
+      verticalAlign: 'text-top',
+    }),
 };
 
 const DesktopBigPromo = css({
@@ -127,6 +134,9 @@ const CompactPromo = css({
   },
   '.promo-paragraph': {
     display: 'none',
+  },
+  '.inline-icon': {
+    display: 'inline',
   },
   '::before': {
     top: 0,

--- a/src/app/components/Curation/HierarchicalGrid/index.tsx
+++ b/src/app/components/Curation/HierarchicalGrid/index.tsx
@@ -140,6 +140,11 @@ const HiearchicalGrid = ({
                         <VisuallyHiddenText data-testid="visually-hidden-text">
                           {typeTranslated}
                         </VisuallyHiddenText>
+                        <Promo.MediaIcon
+                          className="inline-icon"
+                          type={promo.type}
+                          css={styles.inlineIcon}
+                        />
                         {promo.title}
                         {showDuration && (
                           <VisuallyHiddenText>


### PR DESCRIPTION
Resolves JIRA: [WS-143](https://bbc.atlassian.net/browse/WS-143)

Summary
======

Fixes issue where the media icon was not displaying for compact promos to align with [designs](https://www.figma.com/design/doY7xZ14jG6ieIssJ4BgAy/Live-promo---handoff?node-id=1611-3651&t=wBCyyQNqtjN0rJLP-0).

Code changes
======
- Render Media Icon inline in the promo title only for compact promos

Testing
======

Check [Hierarchical Curation Promo withMedia storybook](https://ws-143-promomediaiconnotshowing--5d28eb3fe163f6002046d6fa.chromatic.com/?path=/story/components-curation-grid-hierarchical--with-media) against the [designs](https://www.figma.com/design/doY7xZ14jG6ieIssJ4BgAy/Live-promo---handoff?node-id=1611-3651&t=wBCyyQNqtjN0rJLP-0).


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

