### PR TITLE
Personalisation - Bookmark Curations (Portrait Video Carousel) [10% Time Project DNM]

### DIFF
--- a/src/app/components/Curation/BookmarkButton.tsx
+++ b/src/app/components/Curation/BookmarkButton.tsx
@@ -1,14 +1,14 @@
 import { css, Theme, useTheme } from '@emotion/react';
-import { Pin, PinFilled } from '../icons';
+import { Bookmark, BookmarkFilled } from '../icons';
 
-type PinButtonProps = {
+interface BookmarkButtonProps {
   label: string;
-  isPinned?: boolean;
+  isBookmarked?: boolean;
   onClick?: () => void;
   className?: string;
-};
+}
 
-const pinButtonStyles = ({ palette, spacings }: Theme) =>
+const bookmarkButtonStyles = ({ palette, spacings }: Theme) =>
   css({
     display: 'inline-flex',
     alignItems: 'center',
@@ -24,37 +24,37 @@ const pinButtonStyles = ({ palette, spacings }: Theme) =>
     ':hover, :focus-visible': {
       color: palette.POSTBOX,
     },
-    '.pin-icon': {
+    '.bookmark-icon': {
       width: `${spacings.TRIPLE}rem`,
       height: `${spacings.TRIPLE}rem`,
     },
   });
 
-const PinButton = ({
+const BookmarkButton = ({
   label,
-  isPinned = false,
+  isBookmarked = false,
   onClick,
   className,
-}: PinButtonProps) => {
+}: BookmarkButtonProps) => {
   const theme = useTheme();
 
   return (
     <button
       type="button"
       aria-label={label}
-      aria-pressed={isPinned}
+      aria-pressed={isBookmarked}
       onClick={onClick}
-      css={pinButtonStyles(theme)}
+      css={bookmarkButtonStyles(theme)}
       className={className}
       title={label}
     >
-      {isPinned ? (
-        <PinFilled className="pin-icon" />
+      {isBookmarked ? (
+        <BookmarkFilled className="bookmark-icon" />
       ) : (
-        <Pin className="pin-icon" />
+        <Bookmark className="bookmark-icon" />
       )}
     </button>
   );
 };
 
-export default PinButton;
+export default BookmarkButton;

--- a/src/app/components/Curation/PinButton.tsx
+++ b/src/app/components/Curation/PinButton.tsx
@@ -1,5 +1,5 @@
 import { css, Theme, useTheme } from '@emotion/react';
-import { Pin } from '../icons';
+import { Pin, PinFilled } from '../icons';
 
 type PinButtonProps = {
   label: string;
@@ -51,7 +51,11 @@ const PinButton = ({
       className={className}
       title={label}
     >
-      <Pin className="pin-icon" />
+      {isPinned ? (
+        <PinFilled className="pin-icon" />
+      ) : (
+        <Pin className="pin-icon" />
+      )}
     </button>
   );
 };

--- a/src/app/components/Curation/PinButton.tsx
+++ b/src/app/components/Curation/PinButton.tsx
@@ -14,22 +14,19 @@ const pinButtonStyles = ({ palette, spacings }: Theme) =>
     alignItems: 'center',
     justifyContent: 'center',
     background: 'transparent',
-    border: `1px solid ${palette.GREY_6}`,
-    borderRadius: `${spacings.FULL}rem`,
-    padding: `${spacings.HALF}rem`,
-    color: palette.GREY_8,
+    border: 'none',
+    padding: 0,
+    color: palette.GREY_10,
     cursor: 'pointer',
     lineHeight: 0,
     transition:
       'color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease',
     ':hover, :focus-visible': {
       color: palette.POSTBOX,
-      borderColor: palette.POSTBOX,
-      backgroundColor: palette.GHOST,
     },
     '.pin-icon': {
-      width: `${spacings.FULL + spacings.HALF}rem`,
-      height: `${spacings.FULL + spacings.HALF}rem`,
+      width: `${spacings.TRIPLE}rem`,
+      height: `${spacings.TRIPLE}rem`,
     },
   });
 

--- a/src/app/components/Curation/PinButton.tsx
+++ b/src/app/components/Curation/PinButton.tsx
@@ -1,0 +1,59 @@
+import { css, Theme, useTheme } from '@emotion/react';
+import { Pin } from '../icons';
+
+type PinButtonProps = {
+  label: string;
+  isPinned?: boolean;
+  onClick?: () => void;
+  className?: string;
+};
+
+const pinButtonStyles = ({ palette, spacings }: Theme) =>
+  css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'transparent',
+    border: `1px solid ${palette.GREY_6}`,
+    borderRadius: `${spacings.FULL}rem`,
+    padding: `${spacings.HALF}rem`,
+    color: palette.GREY_8,
+    cursor: 'pointer',
+    lineHeight: 0,
+    transition:
+      'color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease',
+    ':hover, :focus-visible': {
+      color: palette.POSTBOX,
+      borderColor: palette.POSTBOX,
+      backgroundColor: palette.GHOST,
+    },
+    '.pin-icon': {
+      width: `${spacings.FULL + spacings.HALF}rem`,
+      height: `${spacings.FULL + spacings.HALF}rem`,
+    },
+  });
+
+const PinButton = ({
+  label,
+  isPinned = false,
+  onClick,
+  className,
+}: PinButtonProps) => {
+  const theme = useTheme();
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={isPinned}
+      onClick={onClick}
+      css={pinButtonStyles(theme)}
+      className={className}
+      title={label}
+    >
+      <Pin className="pin-icon" />
+    </button>
+  );
+};
+
+export default PinButton;

--- a/src/app/components/Curation/index.tsx
+++ b/src/app/components/Curation/index.tsx
@@ -22,6 +22,7 @@ import UsefulLinks from '../UsefulLinks';
 import SocialLinks from '../SocialLinks';
 import styles from './index.styles';
 import MediaLoader from '../MediaLoader';
+import PinButton from './PinButton';
 
 const {
   SIMPLE_CURATION_GRID,
@@ -40,6 +41,12 @@ const {
 
 const { NONE } = VISUAL_STYLE;
 const { NORMAL } = VISUAL_PROMINENCE;
+
+type CurationProps = Curation & {
+  pinnable?: boolean;
+  onPinCuration?: (curationId?: string) => void;
+  isPinned?: boolean;
+};
 
 const getGridComponent = (componentName: string | null) => {
   switch (componentName) {
@@ -70,7 +77,10 @@ export default ({
   timeOfDayExperimentName,
   timeOfDayVariant,
   mediaCollection,
-}: Curation) => {
+  pinnable = false,
+  onPinCuration,
+  isPinned = false,
+}: CurationProps) => {
   const componentName = getComponentName({
     visualStyle,
     visualProminence,
@@ -172,12 +182,26 @@ export default ({
       return embed ? <Embed oembed={embed} /> : null;
     case PORTRAIT_VIDEO_CAROUSEL:
       if (portraitVideo?.blocks && portraitVideo?.blocks?.length > 0) {
+        const showPinButton =
+          pinnable && typeof onPinCuration === 'function' && !!curationId;
+        const pinLabelBase =
+          title?.trim() || curationSubheading || 'curation';
+
         return (
           <PortraitVideoCarousel
             title={title}
             blocks={portraitVideo.blocks}
             eventTrackingData={eventTrackingData}
             timeOfDayVariant={timeOfDayVariant ?? undefined}
+            pinButton={
+              showPinButton ? (
+                <PinButton
+                  label={`${isPinned ? 'Unpin' : 'Pin'} ${pinLabelBase}`}
+                  isPinned={isPinned}
+                  onClick={() => onPinCuration?.(curationId)}
+                />
+              ) : undefined
+            }
           />
         );
       }

--- a/src/app/components/Curation/index.tsx
+++ b/src/app/components/Curation/index.tsx
@@ -22,7 +22,7 @@ import UsefulLinks from '../UsefulLinks';
 import SocialLinks from '../SocialLinks';
 import styles from './index.styles';
 import MediaLoader from '../MediaLoader';
-import PinButton from './PinButton';
+import BookmarkButton from './BookmarkButton';
 
 const {
   SIMPLE_CURATION_GRID,
@@ -42,11 +42,11 @@ const {
 const { NONE } = VISUAL_STYLE;
 const { NORMAL } = VISUAL_PROMINENCE;
 
-type CurationProps = Curation & {
-  pinnable?: boolean;
-  onPinCuration?: (curationId?: string) => void;
-  isPinned?: boolean;
-};
+interface CurationProps extends Curation {
+  bookmarkable?: boolean;
+  onBookmarkCuration?: (curationId?: string) => void;
+  isBookmarked?: boolean;
+}
 
 const getGridComponent = (componentName: string | null) => {
   switch (componentName) {
@@ -77,9 +77,9 @@ export default ({
   timeOfDayExperimentName,
   timeOfDayVariant,
   mediaCollection,
-  pinnable = false,
-  onPinCuration,
-  isPinned = false,
+  bookmarkable = false,
+  onBookmarkCuration,
+  isBookmarked = false,
 }: CurationProps) => {
   const componentName = getComponentName({
     visualStyle,
@@ -182,9 +182,11 @@ export default ({
       return embed ? <Embed oembed={embed} /> : null;
     case PORTRAIT_VIDEO_CAROUSEL:
       if (portraitVideo?.blocks && portraitVideo?.blocks?.length > 0) {
-        const showPinButton =
-          pinnable && typeof onPinCuration === 'function' && !!curationId;
-        const pinLabelBase =
+        const showBookmarkButton =
+          bookmarkable &&
+          typeof onBookmarkCuration === 'function' &&
+          !!curationId;
+        const bookmarkLabelBase =
           title?.trim() || curationSubheading || 'curation';
 
         return (
@@ -193,12 +195,12 @@ export default ({
             blocks={portraitVideo.blocks}
             eventTrackingData={eventTrackingData}
             timeOfDayVariant={timeOfDayVariant ?? undefined}
-            pinButton={
-              showPinButton ? (
-                <PinButton
-                  label={`${isPinned ? 'Unpin' : 'Pin'} ${pinLabelBase}`}
-                  isPinned={isPinned}
-                  onClick={() => onPinCuration?.(curationId)}
+            bookmarkButton={
+              showBookmarkButton ? (
+                <BookmarkButton
+                  label={`${isBookmarked ? 'Remove bookmark' : 'Bookmark'} ${bookmarkLabelBase}`}
+                  isBookmarked={isBookmarked}
+                  onClick={() => onBookmarkCuration?.(curationId)}
                 />
               ) : undefined
             }

--- a/src/app/components/PortraitVideoCarousel/index.styles.ts
+++ b/src/app/components/PortraitVideoCarousel/index.styles.ts
@@ -17,6 +17,14 @@ const styles = {
         display: 'none',
       },
     }),
+  headingRow: ({ spacings }: Theme) =>
+    css({
+      display: 'flex',
+      alignItems: 'flex-start',
+      justifyContent: 'space-between',
+      gap: `${spacings.FULL}rem`,
+      marginBottom: `${spacings.FULL}rem`,
+    }),
   heading: ({ palette, mq, spacings }: Theme) =>
     css({
       display: 'inline-block',

--- a/src/app/components/PortraitVideoCarousel/index.styles.ts
+++ b/src/app/components/PortraitVideoCarousel/index.styles.ts
@@ -25,7 +25,7 @@ const styles = {
       gap: `${spacings.FULL}rem`,
       marginBottom: `${spacings.FULL}rem`,
     }),
-  heading: ({ palette, mq, spacings }: Theme) =>
+  heading: ({ palette }: Theme) =>
     css({
       display: 'inline-block',
       color: palette.GREY_10,

--- a/src/app/components/PortraitVideoCarousel/index.styles.ts
+++ b/src/app/components/PortraitVideoCarousel/index.styles.ts
@@ -20,7 +20,7 @@ const styles = {
   headingRow: ({ spacings }: Theme) =>
     css({
       display: 'flex',
-      alignItems: 'flex-start',
+      alignItems: 'center',
       justifyContent: 'space-between',
       gap: `${spacings.FULL}rem`,
       marginBottom: `${spacings.FULL}rem`,
@@ -29,10 +29,7 @@ const styles = {
     css({
       display: 'inline-block',
       color: palette.GREY_10,
-      margin: `0`,
-      [mq.GROUP_3_MIN_WIDTH]: {
-        margin: `${spacings.DOUBLE}rem 0 0 0`,
-      },
+      margin: 0,
     }),
   carouselContainer: () =>
     css({

--- a/src/app/components/PortraitVideoCarousel/index.tsx
+++ b/src/app/components/PortraitVideoCarousel/index.tsx
@@ -1,4 +1,4 @@
-import { use, useRef, useState } from 'react';
+import { ReactNode, use, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { RequestContext } from '#app/contexts/RequestContext';
 import useViewTracker from '#app/hooks/useViewTracker';
@@ -17,6 +17,7 @@ type PortraitVideoCarouselProps = {
   blocks: PortraitClipMediaBlock[];
   eventTrackingData: EventTrackingData;
   timeOfDayVariant?: string;
+  pinButton?: ReactNode;
 };
 
 const PortraitVideoCarousel = ({
@@ -24,6 +25,7 @@ const PortraitVideoCarousel = ({
   blocks,
   eventTrackingData,
   timeOfDayVariant,
+  pinButton,
 }: PortraitVideoCarouselProps) => {
   const scrollRef = useRef<HTMLUListElement>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -67,14 +69,17 @@ const PortraitVideoCarousel = ({
         css={styles.section}
         {...viewTracker}
       >
-        <Heading
-          level={2}
-          size="doublePica"
-          fontVariant="sansBold"
-          css={styles.heading}
-        >
-          {title}
-        </Heading>
+        <div css={styles.headingRow}>
+          <Heading
+            level={2}
+            size="doublePica"
+            fontVariant="sansBold"
+            css={styles.heading}
+          >
+            {title}
+          </Heading>
+          {pinButton}
+        </div>
         <noscript>
           <PortraitVideoNoJs />
         </noscript>

--- a/src/app/components/PortraitVideoCarousel/index.tsx
+++ b/src/app/components/PortraitVideoCarousel/index.tsx
@@ -12,20 +12,20 @@ import Heading from '../Heading';
 import PortraitVideoNoJs from './PortraitVideoNoJs';
 import { PortraitClipMediaBlock } from '../MediaLoader/types';
 
-type PortraitVideoCarouselProps = {
+interface PortraitVideoCarouselProps {
   title: string;
   blocks: PortraitClipMediaBlock[];
   eventTrackingData: EventTrackingData;
   timeOfDayVariant?: string;
-  pinButton?: ReactNode;
-};
+  bookmarkButton?: ReactNode;
+}
 
 const PortraitVideoCarousel = ({
   title,
   blocks,
   eventTrackingData,
   timeOfDayVariant,
-  pinButton,
+  bookmarkButton,
 }: PortraitVideoCarouselProps) => {
   const scrollRef = useRef<HTMLUListElement>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -78,7 +78,7 @@ const PortraitVideoCarousel = ({
           >
             {title}
           </Heading>
-          {pinButton}
+          {bookmarkButton}
         </div>
         <noscript>
           <PortraitVideoNoJs />

--- a/src/app/components/icons/index.tsx
+++ b/src/app/components/icons/index.tsx
@@ -43,11 +43,11 @@ export enum ChevronOrientation {
   FORWARD = 'forward',
 }
 
-type ChevronProps = {
+interface ChevronProps {
   className?: string;
   dir: Direction;
   orientation: ChevronOrientation;
-};
+}
 
 export const Chevron = ({ className, dir, orientation }: ChevronProps) => {
   let normalisedDirection = ChevronOrientation.FORWARD;
@@ -205,7 +205,7 @@ export const Play = ({ className }: { className?: string }) => (
   </svg>
 );
 
-export const Pin = ({ className }: { className?: string }) => (
+export const Bookmark = ({ className }: { className?: string }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 32 32"
@@ -220,7 +220,7 @@ export const Pin = ({ className }: { className?: string }) => (
   </svg>
 );
 
-export const PinFilled = ({ className }: { className?: string }) => (
+export const BookmarkFilled = ({ className }: { className?: string }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 32 32"

--- a/src/app/components/icons/index.tsx
+++ b/src/app/components/icons/index.tsx
@@ -208,7 +208,7 @@ export const Play = ({ className }: { className?: string }) => (
 export const Pin = ({ className }: { className?: string }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 -960 960 960"
+    viewBox="0 0 32 32"
     width="12"
     height="12"
     fill="currentColor"
@@ -216,7 +216,22 @@ export const Pin = ({ className }: { className?: string }) => (
     focusable="false"
     className={className}
   >
-    <path d="m636-458.67 84 78V-314H513.33v240.67L480-40l-33.33-33.33V-314H240v-66.67l80-78v-314.66h-46.67V-840h409.34v66.67H636v314.66Zm-304 78h292l-54.67-52v-340.66H386.67v340.66l-54.67 52Zm146 0Z" />
+    <path d="M24 4v22.6l-8-4.5-8 4.5V4h16m2-2H6v28l10-5.6L26 30V2h0z" />
+  </svg>
+);
+
+export const PinFilled = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 32 32"
+    width="12"
+    height="12"
+    fill="currentColor"
+    aria-hidden="true"
+    focusable="false"
+    className={className}
+  >
+    <polygon points="6,2 6,30 15.4,24.7 16,24.4 16.6,24.7 26,30 26,2 " />
   </svg>
 );
 

--- a/src/app/components/icons/index.tsx
+++ b/src/app/components/icons/index.tsx
@@ -205,6 +205,21 @@ export const Play = ({ className }: { className?: string }) => (
   </svg>
 );
 
+export const Pin = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 -960 960 960"
+    width="12"
+    height="12"
+    fill="currentColor"
+    aria-hidden="true"
+    focusable="false"
+    className={className}
+  >
+    <path d="m636-458.67 84 78V-314H513.33v240.67L480-40l-33.33-33.33V-314H240v-66.67l80-78v-314.66h-46.67V-840h409.34v66.67H636v314.66Zm-304 78h292l-54.67-52v-340.66H386.67v340.66l-54.67 52Zm146 0Z" />
+  </svg>
+);
+
 export const TriangleDown = ({ className }: { className?: string }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, use, useState } from 'react';
+import { Fragment, use, useEffect, useState } from 'react';
 import VisuallyHiddenText from '#app/components/VisuallyHiddenText';
 import useOptimizelyVariation, {
   ExperimentType,
@@ -42,6 +42,40 @@ export interface HomePageProps {
 const isBillboard = (curation?: Curation) =>
   curation?.visualStyle === 'BANNER' &&
   curation?.visualProminence === 'MAXIMUM';
+
+const getPinnedStorageKey = (service?: string) =>
+  service ? `homepagePinnedCuration:${service}` : null;
+
+const readPinnedCurationId = ({
+  service,
+  curations,
+  isPinningEnabled,
+}: {
+  service: string;
+  curations: Curation[];
+  isPinningEnabled: boolean;
+}) => {
+  if (!isPinningEnabled || typeof window === 'undefined') {
+    return null;
+  }
+
+  const storageKey = getPinnedStorageKey(service);
+  if (!storageKey) return null;
+
+  const storedId = window.localStorage.getItem(storageKey);
+  if (
+    storedId &&
+    curations.some(({ curationId }) => curationId === storedId)
+  ) {
+    return storedId;
+  }
+
+  if (storedId) {
+    window.localStorage.removeItem(storageKey);
+  }
+
+  return null;
+};
 
 const applyPinnedCurationOrder = ({
   curations,
@@ -127,11 +161,45 @@ const HomePage = ({ pageData }: HomePageProps) => {
   const isPinningEnabled =
     service === 'portuguese' || service === 'arabic';
 
+  useEffect(() => {
+    const initialPinnedId = readPinnedCurationId({
+      service,
+      curations,
+      isPinningEnabled,
+    });
+    if (initialPinnedId) {
+      setPinnedCurationId(initialPinnedId);
+    }
+  }, [service, curations, isPinningEnabled]);
+
+  useEffect(() => {
+    if (!isPinningEnabled || !pinnedCurationId) return;
+    const exists = curations.some(
+      ({ curationId }) => curationId === pinnedCurationId,
+    );
+    if (!exists) {
+      setPinnedCurationId(null);
+      const storageKey = getPinnedStorageKey(service);
+      if (storageKey && typeof window !== 'undefined') {
+        window.localStorage.removeItem(storageKey);
+      }
+    }
+  }, [curations, isPinningEnabled, pinnedCurationId, service]);
+
   const handlePinCuration = (curationId?: string) => {
     if (!isPinningEnabled || !curationId) return;
-    setPinnedCurationId(previous =>
-      previous === curationId ? null : curationId,
-    );
+    setPinnedCurationId(previous => {
+      const nextPinnedId = previous === curationId ? null : curationId;
+      const storageKey = getPinnedStorageKey(service);
+      if (storageKey && typeof window !== 'undefined') {
+        if (nextPinnedId) {
+          window.localStorage.setItem(storageKey, nextPinnedId);
+        } else {
+          window.localStorage.removeItem(storageKey);
+        }
+      }
+      return nextPinnedId;
+    });
   };
 
   const curationsForRender = applyPinnedCurationOrder({

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, use } from 'react';
+import { Fragment, use, useState } from 'react';
 import VisuallyHiddenText from '#app/components/VisuallyHiddenText';
 import useOptimizelyVariation, {
   ExperimentType,
@@ -39,6 +39,48 @@ export interface HomePageProps {
   };
 }
 
+const isBillboard = (curation?: Curation) =>
+  curation?.visualStyle === 'BANNER' &&
+  curation?.visualProminence === 'MAXIMUM';
+
+const applyPinnedCurationOrder = ({
+  curations,
+  pinnedCurationId,
+  isPinningEnabled,
+}: {
+  curations: Curation[];
+  pinnedCurationId?: string | null;
+  isPinningEnabled: boolean;
+}): Curation[] => {
+  if (!isPinningEnabled || !pinnedCurationId) {
+    return curations;
+  }
+
+  const pinnedIndex = curations.findIndex(
+    ({ curationId }) => curationId === pinnedCurationId,
+  );
+
+  if (pinnedIndex === -1) {
+    return curations;
+  }
+
+  const hasBillboardAtTop = isBillboard(curations[0]);
+  const targetIndex = hasBillboardAtTop ? 1 : 0;
+
+  if (pinnedIndex === targetIndex) {
+    return curations;
+  }
+
+  const reorderedCurations = [...curations];
+  const [pinnedCuration] = reorderedCurations.splice(pinnedIndex, 1);
+  reorderedCurations.splice(targetIndex, 0, pinnedCuration);
+
+  return reorderedCurations.map((curation, position) => ({
+    ...curation,
+    position,
+  }));
+};
+
 const HomePage = ({ pageData }: HomePageProps) => {
   const {
     translations,
@@ -57,7 +99,9 @@ const HomePage = ({ pageData }: HomePageProps) => {
     seoDescription,
     metadata: { atiAnalytics },
   } = pageData;
-  let { curations } = pageData;
+  let { curations = [] } = pageData;
+
+  const [pinnedCurationId, setPinnedCurationId] = useState<string | null>(null);
 
   const metadataTitle = seoTitle || homePageTitle;
   const metadataDescription = seoDescription || description;
@@ -80,7 +124,23 @@ const HomePage = ({ pageData }: HomePageProps) => {
     });
   }
 
-  const itemList = getItemList({ curations, name: brandName });
+  const isPinningEnabled =
+    service === 'portuguese' || service === 'arabic';
+
+  const handlePinCuration = (curationId?: string) => {
+    if (!isPinningEnabled || !curationId) return;
+    setPinnedCurationId(previous =>
+      previous === curationId ? null : curationId,
+    );
+  };
+
+  const curationsForRender = applyPinnedCurationOrder({
+    curations,
+    pinnedCurationId,
+    isPinningEnabled,
+  });
+
+  const itemList = getItemList({ curations: curationsForRender, name: brandName });
 
   return (
     <>
@@ -109,7 +169,7 @@ const HomePage = ({ pageData }: HomePageProps) => {
         </VisuallyHiddenText>
         <div css={styles.inner}>
           <div css={styles.margins}>
-            {curations.map(
+            {curationsForRender.map(
               (
                 {
                   visualProminence,
@@ -125,13 +185,13 @@ const HomePage = ({ pageData }: HomePageProps) => {
               ) => {
                 const nthCurationByStyleAndProminence =
                   getNthCurationByStyleAndProminence({
-                    curations,
+                    curations: curationsForRender,
                     position,
                     visualStyle,
                     visualProminence,
                   });
                 const indexOfFirstNonBanner =
-                  getIndexOfFirstNonBanner(curations);
+                  getIndexOfFirstNonBanner(curationsForRender);
                 return (
                   <Fragment key={`${curationId}-${position}`}>
                     <HomeCuration
@@ -142,13 +202,16 @@ const HomePage = ({ pageData }: HomePageProps) => {
                       topStoriesTitle={topStoriesTitle}
                       position={position}
                       link={link}
-                      curationLength={curations?.length}
+                      curationLength={curationsForRender?.length}
                       nthCurationByStyleAndProminence={
                         nthCurationByStyleAndProminence
                       }
                       renderVisuallyHiddenH2Title={position === 0}
                       curationId={curationId}
                       timeOfDayVariant={timeOfDayVariant}
+                      pinnable={isPinningEnabled}
+                      isPinned={pinnedCurationId === curationId}
+                      onPinCuration={handlePinCuration}
                       {...curationProps}
                     />
                     {index === indexOfFirstNonBanner && <MPU />}

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -43,23 +43,23 @@ const isBillboard = (curation?: Curation) =>
   curation?.visualStyle === 'BANNER' &&
   curation?.visualProminence === 'MAXIMUM';
 
-const getPinnedStorageKey = (service?: string) =>
-  service ? `homepagePinnedCuration:${service}` : null;
+const getBookmarkedStorageKey = (service?: string) =>
+  service ? `homepageBookmarkedCuration:${service}` : null;
 
-const readPinnedCurationId = ({
+const readBookmarkedCurationId = ({
   service,
   curations,
-  isPinningEnabled,
+  isBookmarkingEnabled,
 }: {
   service: string;
   curations: Curation[];
-  isPinningEnabled: boolean;
+  isBookmarkingEnabled: boolean;
 }) => {
-  if (!isPinningEnabled || typeof window === 'undefined') {
+  if (!isBookmarkingEnabled || typeof window === 'undefined') {
     return null;
   }
 
-  const storageKey = getPinnedStorageKey(service);
+  const storageKey = getBookmarkedStorageKey(service);
   if (!storageKey) return null;
 
   const storedId = window.localStorage.getItem(storageKey);
@@ -77,37 +77,37 @@ const readPinnedCurationId = ({
   return null;
 };
 
-const applyPinnedCurationOrder = ({
+const applyBookmarkedCurationOrder = ({
   curations,
-  pinnedCurationId,
-  isPinningEnabled,
+  bookmarkedCurationId,
+  isBookmarkingEnabled,
 }: {
   curations: Curation[];
-  pinnedCurationId?: string | null;
-  isPinningEnabled: boolean;
+  bookmarkedCurationId?: string | null;
+  isBookmarkingEnabled: boolean;
 }): Curation[] => {
-  if (!isPinningEnabled || !pinnedCurationId) {
+  if (!isBookmarkingEnabled || !bookmarkedCurationId) {
     return curations;
   }
 
-  const pinnedIndex = curations.findIndex(
-    ({ curationId }) => curationId === pinnedCurationId,
+  const bookmarkedIndex = curations.findIndex(
+    ({ curationId }) => curationId === bookmarkedCurationId,
   );
 
-  if (pinnedIndex === -1) {
+  if (bookmarkedIndex === -1) {
     return curations;
   }
 
   const hasBillboardAtTop = isBillboard(curations[0]);
   const targetIndex = hasBillboardAtTop ? 1 : 0;
 
-  if (pinnedIndex === targetIndex) {
+  if (bookmarkedIndex === targetIndex) {
     return curations;
   }
 
   const reorderedCurations = [...curations];
-  const [pinnedCuration] = reorderedCurations.splice(pinnedIndex, 1);
-  reorderedCurations.splice(targetIndex, 0, pinnedCuration);
+  const [bookmarkedCuration] = reorderedCurations.splice(bookmarkedIndex, 1);
+  reorderedCurations.splice(targetIndex, 0, bookmarkedCuration);
 
   return reorderedCurations.map((curation, position) => ({
     ...curation,
@@ -135,7 +135,7 @@ const HomePage = ({ pageData }: HomePageProps) => {
   } = pageData;
   let { curations = [] } = pageData;
 
-  const [pinnedCurationId, setPinnedCurationId] = useState<string | null>(null);
+  const [bookmarkedCurationId, setBookmarkedCurationId] = useState<string | null>(null);
 
   const metadataTitle = seoTitle || homePageTitle;
   const metadataDescription = seoDescription || description;
@@ -158,54 +158,54 @@ const HomePage = ({ pageData }: HomePageProps) => {
     });
   }
 
-  const isPinningEnabled =
+  const isBookmarkingEnabled =
     service === 'portuguese' || service === 'arabic';
 
   useEffect(() => {
-    const initialPinnedId = readPinnedCurationId({
+    const initialBookmarkedId = readBookmarkedCurationId({
       service,
       curations,
-      isPinningEnabled,
+      isBookmarkingEnabled,
     });
-    if (initialPinnedId) {
-      setPinnedCurationId(initialPinnedId);
+    if (initialBookmarkedId) {
+      setBookmarkedCurationId(initialBookmarkedId);
     }
-  }, [service, curations, isPinningEnabled]);
+  }, [service, curations, isBookmarkingEnabled]);
 
   useEffect(() => {
-    if (!isPinningEnabled || !pinnedCurationId) return;
+    if (!isBookmarkingEnabled || !bookmarkedCurationId) return;
     const exists = curations.some(
-      ({ curationId }) => curationId === pinnedCurationId,
+      ({ curationId }) => curationId === bookmarkedCurationId,
     );
     if (!exists) {
-      setPinnedCurationId(null);
-      const storageKey = getPinnedStorageKey(service);
+      setBookmarkedCurationId(null);
+      const storageKey = getBookmarkedStorageKey(service);
       if (storageKey && typeof window !== 'undefined') {
         window.localStorage.removeItem(storageKey);
       }
     }
-  }, [curations, isPinningEnabled, pinnedCurationId, service]);
+  }, [curations, isBookmarkingEnabled, bookmarkedCurationId, service]);
 
-  const handlePinCuration = (curationId?: string) => {
-    if (!isPinningEnabled || !curationId) return;
-    setPinnedCurationId(previous => {
-      const nextPinnedId = previous === curationId ? null : curationId;
-      const storageKey = getPinnedStorageKey(service);
+  const handleBookmarkCuration = (curationId?: string) => {
+    if (!isBookmarkingEnabled || !curationId) return;
+    setBookmarkedCurationId(previous => {
+      const nextBookmarkedId = previous === curationId ? null : curationId;
+      const storageKey = getBookmarkedStorageKey(service);
       if (storageKey && typeof window !== 'undefined') {
-        if (nextPinnedId) {
-          window.localStorage.setItem(storageKey, nextPinnedId);
+        if (nextBookmarkedId) {
+          window.localStorage.setItem(storageKey, nextBookmarkedId);
         } else {
           window.localStorage.removeItem(storageKey);
         }
       }
-      return nextPinnedId;
+      return nextBookmarkedId;
     });
   };
 
-  const curationsForRender = applyPinnedCurationOrder({
+  const curationsForRender = applyBookmarkedCurationOrder({
     curations,
-    pinnedCurationId,
-    isPinningEnabled,
+    bookmarkedCurationId,
+    isBookmarkingEnabled,
   });
 
   const itemList = getItemList({ curations: curationsForRender, name: brandName });
@@ -277,9 +277,9 @@ const HomePage = ({ pageData }: HomePageProps) => {
                       renderVisuallyHiddenH2Title={position === 0}
                       curationId={curationId}
                       timeOfDayVariant={timeOfDayVariant}
-                      pinnable={isPinningEnabled}
-                      isPinned={pinnedCurationId === curationId}
-                      onPinCuration={handlePinCuration}
+                      bookmarkable={isBookmarkingEnabled}
+                      isBookmarked={bookmarkedCurationId === curationId}
+                      onBookmarkCuration={handleBookmarkCuration}
                       {...curationProps}
                     />
                     {index === indexOfFirstNonBanner && <MPU />}


### PR DESCRIPTION
10% time project idea

Summary
======

- Adds a bookmark feature to the Portrait Video Carousel to assist in personalisation for the user
- Uses `localStorage` to persist the state of the bookmark so that the users preference remains upon subsequent returns

Code changes
======
- See files changed

https://github.com/user-attachments/assets/403f181f-c209-4d4c-997f-2e9027e2822e





Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

