### PR TITLE
WS-1836: Add PWA promotional banner event tracking

### DIFF
--- a/src/app/components/PWAPromotionalBanner/index.test.tsx
+++ b/src/app/components/PWAPromotionalBanner/index.test.tsx
@@ -47,9 +47,9 @@ describe('PWAPromotionalBanner', () => {
   });
 
   it('should not show banner if dismissed recently', () => {
-    localStorage.setItem('pwa_promotionalBanner_dismissals', '1');
+    localStorage.setItem('pwa_promotional_banner_dismissals', '1');
     localStorage.setItem(
-      'pwa_promotionalBanner_last_dismissed',
+      'pwa_promotional_banner_last_dismissed',
       `${Date.now()}`,
     );
     act(() => {

--- a/src/app/components/PWAPromotionalBanner/index.tsx
+++ b/src/app/components/PWAPromotionalBanner/index.tsx
@@ -61,19 +61,15 @@ const PWAPromotionalBanner = () => {
     eventName: 'pwa-prompt-dismissed',
   });
 
-  const handleBannerDismiss = useCallback(
-    (event?: React.MouseEvent) => {
-      setBannerDismissed();
-      setIsVisible(false);
-      onCloseClickTrack?.(event);
-    },
-    [onCloseClickTrack],
-  );
+  const handleBannerDismiss = useCallback(() => {
+    setBannerDismissed();
+    setIsVisible(false);
+  }, []);
 
   const handleSecondaryClick = useCallback(
     (event?: React.MouseEvent) => {
       onSecondaryClickTrack?.(event);
-      handleBannerDismiss(event);
+      handleBannerDismiss();
     },
     [onSecondaryClickTrack, handleBannerDismiss],
   );
@@ -119,7 +115,10 @@ const PWAPromotionalBanner = () => {
         }}
         onSecondaryClick={handleSecondaryClick}
         isDismissible
-        onClose={handleBannerDismiss}
+        onClose={(e?: React.MouseEvent) => {
+          onCloseClickTrack?.(e);
+          handleBannerDismiss();
+        }}
         bannerLabel={promotionalBanner.bannerLabel}
       />
     </div>

--- a/src/app/components/PWAPromotionalBanner/index.tsx
+++ b/src/app/components/PWAPromotionalBanner/index.tsx
@@ -1,11 +1,13 @@
-import { useState, use } from 'react';
+import { useState, use, useCallback } from 'react';
 import usePWAInstallPrompt from '#app/hooks/usePWAInstallPrompt';
 import PromotionalBanner from '#app/components/PromotionalBanner';
-
+import useClickTracker from '#app/hooks/useClickTrackerHandler';
+import useViewTracker from '#app/hooks/useViewTracker';
+import useCustomEventTracker from '#app/hooks/useCustomEventTracker';
 import { ServiceContext } from '../../contexts/ServiceContext';
 
-const PWA_BANNER_DISMISS_KEY = 'pwa_promotionalBanner_dismissals';
-const PWA_BANNER_LAST_DISMISS_KEY = 'pwa_promotionalBanner_last_dismissed';
+const PWA_BANNER_DISMISS_KEY = 'pwa_promotional_banner_dismissals';
+const PWA_BANNER_LAST_DISMISS_KEY = 'pwa_promotional_banner_last_dismissed';
 const PWA_BANNER_MAX_DISMISSALS = 3;
 const PWA_BANNER_DISMISS_INTERVAL_MS = 10 * 24 * 60 * 60 * 1000; // 10 days
 
@@ -36,38 +38,97 @@ const PWAPromotionalBanner = () => {
   const { promotionalBanner } = use(ServiceContext);
   const [isVisible, setIsVisible] = useState(() => isBannerVisible());
 
-  const handleBannerDismiss = () => {
-    setBannerDismissed();
-    setIsVisible(false);
-  };
+  const { ref: viewRef } = useViewTracker({
+    componentName: 'pwa_promotional_banner',
+  });
+
+  const { onClick: onPrimaryClickTrack } = useClickTracker({
+    componentName: 'pwa_promotional_banner_primary',
+  });
+  const { onClick: onSecondaryClickTrack } = useClickTracker({
+    componentName: 'pwa_promotional_banner_secondary',
+  });
+  const { onClick: onCloseClickTrack } = useClickTracker({
+    componentName: 'pwa_promotional_banner_close',
+  });
+
+  const trackPwaPromptShown = useCustomEventTracker({
+    eventName: 'pwa_prompt_shown',
+  });
+  const trackPwaPromptAccepted = useCustomEventTracker({
+    eventName: 'pwa_prompt_accepted',
+  });
+  const trackPwaPromptDismissed = useCustomEventTracker({
+    eventName: 'pwa_prompt_dismissed',
+  });
+
+  const handleBannerDismiss = useCallback(
+    (event?: React.MouseEvent) => {
+      setBannerDismissed();
+      setIsVisible(false);
+      onCloseClickTrack?.(event);
+    },
+    [onCloseClickTrack],
+  );
+
+  const handleSecondaryClick = useCallback(
+    (event?: React.MouseEvent) => {
+      onSecondaryClickTrack?.(event);
+      handleBannerDismiss(event);
+    },
+    [onSecondaryClickTrack, handleBannerDismiss],
+  );
 
   const { promptInstall, isInstallable } = usePWAInstallPrompt({
-    onAccepted: handleBannerDismiss,
-    onDismissed: handleBannerDismiss,
+    onAccepted: () => {
+      handleBannerDismiss();
+      trackPwaPromptAccepted();
+    },
+    onDismissed: () => {
+      handleBannerDismiss();
+      trackPwaPromptDismissed();
+    },
     onError: () => setIsVisible(false),
   });
+
+  useState(() => {
+    if (isVisible && isInstallable && promotionalBanner) {
+      trackPwaPromptShown();
+    }
+  });
+
+  const handlePrimaryClick = useCallback(
+    (event?: React.MouseEvent) => {
+      onPrimaryClickTrack?.(event);
+      promptInstall();
+    },
+    [onPrimaryClickTrack, promptInstall],
+  );
 
   if (!isVisible || !isInstallable || !promotionalBanner) {
     return null;
   }
+
   return (
-    <PromotionalBanner
-      title={promotionalBanner.title}
-      description={promotionalBanner.description}
-      orText={promotionalBanner.orText}
-      primaryButton={{
-        text: promotionalBanner.primaryButton.text,
-        longText: promotionalBanner.primaryButton.longText,
-      }}
-      onPrimaryClick={promptInstall}
-      secondaryButton={{
-        text: promotionalBanner.secondaryButton.text,
-      }}
-      onSecondaryClick={handleBannerDismiss}
-      isDismissible
-      onClose={handleBannerDismiss}
-      bannerLabel={promotionalBanner.bannerLabel}
-    />
+    <div ref={viewRef}>
+      <PromotionalBanner
+        title={promotionalBanner.title}
+        description={promotionalBanner.description}
+        orText={promotionalBanner.orText}
+        primaryButton={{
+          text: promotionalBanner.primaryButton.text,
+          longText: promotionalBanner.primaryButton.longText,
+        }}
+        onPrimaryClick={handlePrimaryClick}
+        secondaryButton={{
+          text: promotionalBanner.secondaryButton.text,
+        }}
+        onSecondaryClick={handleSecondaryClick}
+        isDismissible
+        onClose={handleBannerDismiss}
+        bannerLabel={promotionalBanner.bannerLabel}
+      />
+    </div>
   );
 };
 export default PWAPromotionalBanner;

--- a/src/app/components/PWAPromotionalBanner/index.tsx
+++ b/src/app/components/PWAPromotionalBanner/index.tsx
@@ -1,5 +1,6 @@
 import { useState, use, useCallback } from 'react';
 import usePWAInstallPrompt from '#app/hooks/usePWAInstallPrompt';
+import usePWAInstallTracker from '#app/hooks/usePWAInstallTracker';
 import PromotionalBanner from '#app/components/PromotionalBanner';
 import useClickTracker from '#app/hooks/useClickTrackerHandler';
 import useViewTracker from '#app/hooks/useViewTracker';
@@ -35,31 +36,31 @@ const isBannerVisible = () => {
 };
 
 const PWAPromotionalBanner = () => {
+  usePWAInstallTracker();
   const { promotionalBanner } = use(ServiceContext);
   const [isVisible, setIsVisible] = useState(() => isBannerVisible());
-
-  const { ref: viewRef } = useViewTracker({
-    componentName: 'pwa_promotional_banner',
+  const viewTracker = useViewTracker({
+    componentName: 'pwa-promotional-banner',
   });
 
   const { onClick: onPrimaryClickTrack } = useClickTracker({
-    componentName: 'pwa_promotional_banner_primary',
+    componentName: 'pwa-promotional-banner-primary',
   });
   const { onClick: onSecondaryClickTrack } = useClickTracker({
-    componentName: 'pwa_promotional_banner_secondary',
+    componentName: 'pwa-promotional-banner-secondary',
   });
   const { onClick: onCloseClickTrack } = useClickTracker({
-    componentName: 'pwa_promotional_banner_close',
+    componentName: 'pwa-promotional-banner-close',
   });
 
   const trackPwaPromptShown = useCustomEventTracker({
     eventName: 'pwa_prompt_shown',
   });
   const trackPwaPromptAccepted = useCustomEventTracker({
-    eventName: 'pwa_prompt_accepted',
+    eventName: 'pwa-prompt-accepted',
   });
   const trackPwaPromptDismissed = useCustomEventTracker({
-    eventName: 'pwa_prompt_dismissed',
+    eventName: 'pwa-prompt-dismissed',
   });
 
   const handleBannerDismiss = useCallback(
@@ -89,12 +90,7 @@ const PWAPromotionalBanner = () => {
       trackPwaPromptDismissed();
     },
     onError: () => setIsVisible(false),
-  });
-
-  useState(() => {
-    if (isVisible && isInstallable && promotionalBanner) {
-      trackPwaPromptShown();
-    }
+    onPromptShown: trackPwaPromptShown,
   });
 
   const handlePrimaryClick = useCallback(
@@ -110,7 +106,7 @@ const PWAPromotionalBanner = () => {
   }
 
   return (
-    <div ref={viewRef}>
+    <div {...viewTracker}>
       <PromotionalBanner
         title={promotionalBanner.title}
         description={promotionalBanner.description}

--- a/src/app/components/PWAPromotionalBanner/index.tsx
+++ b/src/app/components/PWAPromotionalBanner/index.tsx
@@ -80,7 +80,7 @@ const PWAPromotionalBanner = () => {
 
   const { promptInstall, isInstallable } = usePWAInstallPrompt({
     onAccepted: () => {
-      handleBannerDismiss();
+      setIsVisible(false);
       trackPwaPromptAccepted();
     },
     onDismissed: () => {

--- a/src/app/components/PWAPromotionalBanner/index.tsx
+++ b/src/app/components/PWAPromotionalBanner/index.tsx
@@ -1,6 +1,5 @@
 import { useState, use, useCallback } from 'react';
 import usePWAInstallPrompt from '#app/hooks/usePWAInstallPrompt';
-import usePWAInstallTracker from '#app/hooks/usePWAInstallTracker';
 import PromotionalBanner from '#app/components/PromotionalBanner';
 import useClickTracker from '#app/hooks/useClickTrackerHandler';
 import useViewTracker from '#app/hooks/useViewTracker';
@@ -36,7 +35,6 @@ const isBannerVisible = () => {
 };
 
 const PWAPromotionalBanner = () => {
-  usePWAInstallTracker();
   const { promotionalBanner } = use(ServiceContext);
   const [isVisible, setIsVisible] = useState(() => isBannerVisible());
   const viewTracker = useViewTracker({
@@ -54,7 +52,7 @@ const PWAPromotionalBanner = () => {
   });
 
   const trackPwaPromptShown = useCustomEventTracker({
-    eventName: 'pwa_prompt_shown',
+    eventName: 'pwa-prompt-shown',
   });
   const trackPwaPromptAccepted = useCustomEventTracker({
     eventName: 'pwa-prompt-accepted',

--- a/src/app/hooks/usePWAInstallPrompt/index.ts
+++ b/src/app/hooks/usePWAInstallPrompt/index.ts
@@ -10,12 +10,14 @@ interface UsePWAInstallPromptCallbacks {
   onAccepted?: () => void;
   onDismissed?: () => void;
   onError?: (error: unknown) => void;
+  onPromptShown?: () => void;
 }
 
 const usePWAInstallPrompt = ({
   onAccepted,
   onDismissed,
   onError,
+  onPromptShown,
 }: UsePWAInstallPromptCallbacks = {}) => {
   const deferredPrompt = useRef<BeforeInstallPromptEvent | null>(null);
   const [isInstallable, setIsInstallable] = useState(false);
@@ -47,24 +49,29 @@ const usePWAInstallPrompt = ({
     };
   }, [isPWA]);
 
-  const promptInstall = () => {
+  const promptInstall = async () => {
     if (!deferredPrompt.current) return;
-    deferredPrompt.current.prompt();
-    deferredPrompt.current.userChoice
-      .then(result => {
-        if (result.outcome === 'accepted') {
-          onAccepted?.();
-        } else {
-          onDismissed?.();
-        }
-      })
-      .catch(error => {
-        onError?.(error);
-      })
-      .finally(() => {
-        deferredPrompt.current = null;
-        setIsInstallable(false);
-      });
+    try {
+      await deferredPrompt.current.prompt();
+      onPromptShown?.();
+      deferredPrompt.current.userChoice
+        .then(result => {
+          if (result.outcome === 'accepted') {
+            onAccepted?.();
+          } else {
+            onDismissed?.();
+          }
+        })
+        .catch(error => {
+          onError?.(error);
+        })
+        .finally(() => {
+          deferredPrompt.current = null;
+          setIsInstallable(false);
+        });
+    } catch (error) {
+      onError?.(error);
+    }
   };
 
   return {

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -4,6 +4,7 @@ import useOptimizelyVariation, {
   ExperimentType,
 } from '#app/hooks/useOptimizelyVariation';
 import OptimizelyPageMetrics from '#app/components/OptimizelyPageMetrics';
+import PWAPromotionalBanner from '#app/components/PWAPromotionalBanner';
 import ATIAnalytics from '../../components/ATIAnalytics';
 import {
   Curation,
@@ -84,6 +85,8 @@ const HomePage = ({ pageData }: HomePageProps) => {
 
   return (
     <>
+      {/* TODO: Used for testing - remove before merging */}
+      <PWAPromotionalBanner />
       <ChartbeatAnalytics title={title} />
       <MetadataContainer
         title={metadataTitle}

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -85,8 +85,6 @@ const HomePage = ({ pageData }: HomePageProps) => {
 
   return (
     <>
-      {/* TODO: Used for testing - remove before merging */}
-      <PWAPromotionalBanner />
       <ChartbeatAnalytics title={title} />
       <MetadataContainer
         title={metadataTitle}

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -4,7 +4,6 @@ import useOptimizelyVariation, {
   ExperimentType,
 } from '#app/hooks/useOptimizelyVariation';
 import OptimizelyPageMetrics from '#app/components/OptimizelyPageMetrics';
-import PWAPromotionalBanner from '#app/components/PWAPromotionalBanner';
 import ATIAnalytics from '../../components/ATIAnalytics';
 import {
   Curation,


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1836

Summary
======
This PR implements comprehensive analytics tracking for the PWA promotional banner.

It uses the standard tracking hooks `useClickTracker`, `useViewTracker`, `useCustomEventTracker` to send Piano Analytics events for all banner interactions and PWA installation prompt outcomes.

References:

_Promotional Banner_
<img width="997" height="173" alt="image" src="https://github.com/user-attachments/assets/3cddc1cf-6ee3-42b3-b17b-1e91fe69206a" />

_Installation Prompt_
<img width="456" height="458" alt="image" src="https://github.com/user-attachments/assets/0460e0c9-f46c-41a9-bc49-7eb97305e4e4" />

Code changes
======
Added analytics tracking:
- View event: Sent when the banner is displayed, using `useViewTracker`
- Primary button click: Tracked with `useClickTracker` and triggers the PWA install prompt.
- Secondary button click: Tracked with `useClickTracker` and dismisses the banner.
- Close button click: Tracked with `useClickTracker` and dismisses the banner.
- PWA prompt events: Custom events sent via  `useCustomEventTracker` for installation prompt shown, accepted, and dismissed.


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. Add `<PWAPromotionalBanner />` to the `HomePage` and test on http://localhost:7080/mundo ([commit](https://github.com/bbc/simorgh/blob/1a1cdf1af6afa90a11d12a8c2fb0d8d10d1f5acc/src/app/pages/HomePage/HomePage.tsx#L89))


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

