### PR TITLE
WS-1756-useful-link-dark-ui

### DIFF
--- a/src/app/components/UsefulLinks/index.styles.tsx
+++ b/src/app/components/UsefulLinks/index.styles.tsx
@@ -32,9 +32,9 @@ const styles = {
       alignItems: 'center',
       gap: `${spacings.FULL}rem`,
     }),
-  link: ({ palette, fontVariants, fontSizes }: Theme) =>
+  link: ({ palette, fontVariants, fontSizes, isDarkUi }: Theme) =>
     css({
-      color: palette.GREY_10,
+      color: isDarkUi ? palette.GREY_2 : palette.GREY_10,
       textDecoration: 'none',
       ...fontSizes.pica,
       ...fontVariants.sansBold,
@@ -42,7 +42,7 @@ const styles = {
       paddingBottom: `${pixelsToRem(12)}rem`,
       width: '100%',
       '&:visited': {
-        color: palette.GREY_6,
+        color: isDarkUi ? palette.GREY_4 : palette.GREY_6,
       },
       '&:hover, &:focus': {
         textDecoration: 'underline',


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1756

Summary
======
Updated useful links for dark UI: 
* The main colour - Grey 2. 
* Visited state colour - Grey 4.

<img width="653" height="161" alt="Screenshot 2025-12-10 at 08 38 38" src="https://github.com/user-attachments/assets/e357207c-13c1-4084-a849-740955d1dfe7" />
