### PR TITLE
WS-1592: PWA Promotional banner close label

### DIFF
--- a/src/app/components/PWAPromotionalBanner/index.tsx
+++ b/src/app/components/PWAPromotionalBanner/index.tsx
@@ -155,6 +155,7 @@ const PWAPromotionalBanner = () => {
           handleBannerDismiss();
         }}
         bannerLabel={promotionalBanner.bannerLabel}
+        closeLabel={promotionalBanner.closeLabel}
       />
     </div>
   );


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1592

Summary
======
- Add missing close label to the PWA Promotional banner that is used by screen readers

<img width="1330" height="927" alt="Screenshot 2025-12-11 at 09 26 11" src="https://github.com/user-attachments/assets/42e39e55-e6dd-437d-9208-302de4f4cf0b" />

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

