### PR TITLE
Ws 1756 useful link dark UI 2

### DIFF
--- a/src/app/components/UsefulLinks/index.styles.tsx
+++ b/src/app/components/UsefulLinks/index.styles.tsx
@@ -41,12 +41,9 @@ const styles = {
       paddingTop: `${pixelsToRem(12)}rem`,
       paddingBottom: `${pixelsToRem(12)}rem`,
       width: '100%',
-
       '&:visited': {
         color: isDarkUi ? palette.GREY_4 : palette.GREY_6,
-        textDecoration: 'underline',
       },
-
       '&:hover, &:focus': {
         textDecoration: 'underline',
         textDecorationThickness: `${pixelsToRem(3)}rem`,

--- a/src/app/components/UsefulLinks/index.styles.tsx
+++ b/src/app/components/UsefulLinks/index.styles.tsx
@@ -35,17 +35,21 @@ const styles = {
   link: ({ palette, fontVariants, fontSizes, isDarkUi }: Theme) =>
     css({
       color: isDarkUi ? palette.GREY_2 : palette.GREY_10,
-      textDecoration: 'none',
+      textDecoration: 'underline',
       ...fontSizes.pica,
       ...fontVariants.sansBold,
       paddingTop: `${pixelsToRem(12)}rem`,
       paddingBottom: `${pixelsToRem(12)}rem`,
       width: '100%',
+
       '&:visited': {
         color: isDarkUi ? palette.GREY_4 : palette.GREY_6,
+        textDecoration: 'underline',
       },
+
       '&:hover, &:focus': {
         textDecoration: 'underline',
+        textDecorationThickness: `${pixelsToRem(3)}rem`,
       },
     }),
 };

--- a/src/app/components/UsefulLinks/metadata.json
+++ b/src/app/components/UsefulLinks/metadata.json
@@ -20,7 +20,7 @@
     }
   },
   "swarm": {
-    "done": false,
+    "done": true,
     "reference": {
       "url": "https://paper.dropbox.com/doc/A11Y-Swarm-Useful-links-component--CzBuyGEHnZidyflOaDzbDNy4Ag-XVbiG0FkskWFdapCOCpI3",
       "label": "Accessibility Swarm Notes"

--- a/src/app/components/UsefulLinks/metadata.json
+++ b/src/app/components/UsefulLinks/metadata.json
@@ -22,7 +22,7 @@
   "swarm": {
     "done": false,
     "reference": {
-      "url": "https://paper.dropbox.com/doc/A11Y-Swarm-Useful-links-component--CmaWk9LP4gvTnfHz7Cjf4Nq2Ag-XVbiG0FkskWFdapCOCpI3",
+      "url": "https://paper.dropbox.com/doc/A11Y-Swarm-Useful-links-component--CzBuyGEHnZidyflOaDzbDNy4Ag-XVbiG0FkskWFdapCOCpI3",
       "label": "Accessibility Swarm Notes"
     }
   }


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1912

Summary
======
Adding underline for Useful links by default and a bit thicker underline for hover and focus: 
<img width="567" height="155" alt="Screenshot 2025-12-11 at 10 16 33" src="https://github.com/user-attachments/assets/0478d099-987d-45c2-9ce0-0357407abd4f" />
