### PR TITLE
WS-1462: PWA Promotional Banner Experiment - early return

### DIFF
--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -418,13 +418,20 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
   ) : null;
 
   // EXPERIMENT: PWA Promotional Banner
-  const hasSecondaryColumnTopStories =
-    pageData?.secondaryColumn?.topStories?.length;
+  // EXPERIMENT: PWA Promotional Banner
+  const pwaPromoBannerExperimentName = 'newswb_ws_pwa_promo_prompt';
+  const pwaPromoBannerVariant = useOptimizelyVariation({
+    experimentName: pwaPromoBannerExperimentName,
+    experimentType: ExperimentType.SERVER_SIDE,
+  });
+  const shouldRenderPWAPromotionalBanner =
+    !pageData?.secondaryColumn?.topStories?.length &&
+    pwaPromoBannerVariant === 'on';
 
   return (
     <div css={styles.pageWrapper}>
       {/* EXPERIMENT: PWA Promotional Banner */}
-      {!hasSecondaryColumnTopStories ? <PWAPromotionalBanner /> : null}
+      {shouldRenderPWAPromotionalBanner && <PWAPromotionalBanner />}
       <ATIAnalytics atiData={atiData} />
       <ChartbeatAnalytics
         sectionName={pageData?.relatedContent?.section?.name}

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -76,6 +76,7 @@ const HomePage = ({ pageData }: HomePageProps) => {
     experimentName: pwaPromoBannerExperimentName,
     experimentType: ExperimentType.SERVER_SIDE,
   });
+  const shouldRenderPWAPromotionalBanner = pwaPromoBannerVariant === 'on';
 
   // if variant is set to 'homepage_time_of_day_a' or 'homepage_time_of_day_b' then reorder curations
   if (
@@ -93,7 +94,7 @@ const HomePage = ({ pageData }: HomePageProps) => {
   return (
     <>
       {/* EXPERIMENT: PWA Promotional Banner */}
-      <PWAPromotionalBanner />
+      {shouldRenderPWAPromotionalBanner && <PWAPromotionalBanner />}
       <ChartbeatAnalytics title={title} />
       <MetadataContainer
         title={metadataTitle}


### PR DESCRIPTION
Summary
======
- We noticed that the `beforeinstallprompt` event fires before the experiment variant becomes available. This may affect the native browser behavior when it suggests installing the PWA. Therefore we want to wait until experiment variant is available

<img width="3840" height="1598" alt="image" src="https://github.com/user-attachments/assets/78f01b1b-2496-4db4-9b0f-0e795f25ed21" />


Code changes
======
- Only render `PWAPromotionalBanner` (and `usePWAInstallPrompt`) when experiment is on


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

