### PR TITLE
Remove `background-colour` from RelatedTopics component

### DIFF
--- a/src/app/components/RelatedTopics/index.styles.ts
+++ b/src/app/components/RelatedTopics/index.styles.ts
@@ -1,10 +1,9 @@
 import { css, Theme } from '@emotion/react';
 
 const styles = {
-  wrapper: ({ spacings, palette }: Theme) =>
+  wrapper: ({ spacings }: Theme) =>
     css({
       padding: `0 0 ${spacings.QUINTUPLE}rem`,
-      backgroundColor: palette.GREY_2,
     }),
   sectionLabel: ({ mq }: Theme) =>
     css({


### PR DESCRIPTION
Related to https://bbc.atlassian.net/browse/WS-1879

Summary
======
Removes background-colour on RelatedTopics component, deferring to the background colour of the page to determine it

Fixes white background on MediaArticlePages:

Before:
<img width="805" height="287" alt="Screenshot 2025-12-16 at 09 15 06" src="https://github.com/user-attachments/assets/c6371d89-7fbb-4569-ad70-2112a5129944" />

After:
<img width="820" height="266" alt="Screenshot 2025-12-16 at 09 14 50" src="https://github.com/user-attachments/assets/91f2155a-c879-4a20-8849-e43debfbb550" />


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

