### PR TITLE
Add temporary catch-all exception for `av-embeds`

### DIFF
--- a/ws-nextjs-app/pages/[service]/[[...]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/[[...]].page.tsx
@@ -41,6 +41,9 @@ const getPageType = ({
   resolvedUrl: string;
   reqHeaders: IncomingHttpHeaders;
 }) => {
+  // TODO: Exception for av-embeds that should be removed once final av-embeds route has page-type header
+  if (resolvedUrl?.includes('av-embeds')) return AV_EMBEDS;
+
   const pageTypeHeader = reqHeaders['page-type']?.toString() as PageTypes;
 
   const { SIMORGH_APP_ENV } = getEnvConfig();


### PR DESCRIPTION
Summary
======
Fixes issue introduced in https://github.com/bbc/simorgh/pull/13530 whereby we need to reintroduce the `resolvedUrl.includes('av-embeds')` check as I missed a route in the upstream route handling system to add the `page-type` header to one of the av-embeds routes

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

