### PR TITLE
Update `urlValidationTest` to include `programmes/` routes

### DIFF
--- a/cypress/support/helpers/urlValidationTest.js
+++ b/cypress/support/helpers/urlValidationTest.js
@@ -6,7 +6,7 @@ export default () => {
     cy.get('main a[href^="https://www.bbc.com"]').each($tag => {
       const servicesPattern = SERVICES.join('|');
       const validHrefRegex = new RegExp(
-        `^https://www\\.bbc\\.com/(?:${servicesPattern}|programmes/p[0-9a-zA-Z]{7})(?:/.*)?$`,
+        `^https://www\\.bbc\\.com/(?:${servicesPattern}|programmes/[a-z0-9]{8,15})(?:/.*)?$`,
       );
       const href = $tag.attr('href');
       expect(href).to.exist;

--- a/cypress/support/helpers/urlValidationTest.js
+++ b/cypress/support/helpers/urlValidationTest.js
@@ -3,24 +3,16 @@ import SERVICES from '#app/lib/config/services';
 
 export default () => {
   it('all BBC links should contain a World Service', () => {
-    const allowedUrls = [
-      'programmes/p0703hz7', // present on https://www.bbc.com/persian/topics/cw9qgeqd1zqt & redirects to https://www.bbc.com/persian/podcasts/p0703hz7
-    ];
-
     cy.get('main a[href^="https://www.bbc.com"]').each($tag => {
       const servicesPattern = SERVICES.join('|');
-      const servicesRegex = new RegExp(
-        `^https://www\\.bbc\\.com/(?:${servicesPattern})(?:/.*)?$`,
+      const validHrefRegex = new RegExp(
+        `^https://www\\.bbc\\.com/(?:${servicesPattern}|programmes/p[0-9a-zA-Z]{7})(?:/.*)?$`,
       );
       const href = $tag.attr('href');
       expect(href).to.exist;
       expect(href).to.not.be.empty;
 
-      const isAllowed = allowedUrls.some(url => href.includes(url));
-
-      if (!isAllowed) {
-        expect(href).to.match(servicesRegex);
-      }
+      expect(href).to.match(validHrefRegex);
     });
   });
 };


### PR DESCRIPTION
Summary
======
- Updates the urlValidationTest e2e function to check for `programmes/pXXXXXXX` hrefs, rather than relying on hardcoded values as this isn't the most flexible over time.

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

