### PR TITLE
WS-222: Fix flaxy atuserid/idclient e2e tests

### DIFF
--- a/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
@@ -93,10 +93,13 @@ const assertLocationSpecificPianoDestinationExists = ({ service }) => {
   });
 };
 
-const assertReverbViewabilityComponentEventParamsExist = ({ params }) => {
-  // if (['responsive', 'lite'].includes(applicationType)) {
-  //   expect(params).to.have.property('idclient');
-  // }
+const assertReverbViewabilityComponentEventParamsExist = ({
+  params,
+  applicationType,
+}) => {
+  if (['responsive', 'lite'].includes(applicationType)) {
+    expect(params).to.have.property('idclient');
+  }
 
   expect(params).to.have.property('s'); // destination
   expect(params).to.have.property('events'); // event details

--- a/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
@@ -94,6 +94,10 @@ const assertLocationSpecificPianoDestinationExists = ({ service }) => {
 };
 
 const assertReverbViewabilityComponentEventParamsExist = ({ params }) => {
+  // if (['responsive', 'lite'].includes(applicationType)) {
+  //   expect(params).to.have.property('idclient');
+  // }
+
   expect(params).to.have.property('s'); // destination
   expect(params).to.have.property('events'); // event details
   expect(params).to.have.property('context');
@@ -250,14 +254,6 @@ const assertViewabilityModelViewEvent = ({
 
   assertReverbViewabilityComponentEventParamsExist({ params });
 
-  // TODO: Commenting out temporarily until old ATI code is removed - https://bbc.atlassian.net/browse/WS-222
-  // if (['responsive', 'lite'].includes(applicationType)) {
-  //   expect(params.idclient).to.equal(
-  //     ATI_USER_ID_COOKIE,
-  //     'params.idclient (atuserid cookie value)',
-  //   );
-  // }
-
   expect(params.events).to.satisfy(
     payload =>
       validateViewabilityEventDetails({ payload, actionType: VIEW_EVENT }),
@@ -302,14 +298,6 @@ const assertViewabilityModelClickEvent = ({
   assertReverbViewabilityComponentEventParamsExist({
     params,
   });
-
-  // TODO: Commenting out temporarily until old ATI code is removed - https://bbc.atlassian.net/browse/WS-222
-  // if (['responsive', 'lite'].includes(applicationType)) {
-  //   expect(params.idclient).to.equal(
-  //     ATI_USER_ID_COOKIE,
-  //     'params.idclient (atuserid cookie value)',
-  //   );
-  // }
 
   expect(params.events).to.satisfy(
     payload =>

--- a/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
@@ -250,12 +250,12 @@ export const assertPageView = ({
 const assertViewabilityModelViewEvent = ({
   pageIdentifier,
   params,
-  // applicationType,
+  applicationType,
   siteId,
 }) => {
   const eventContext = JSON.parse(params.context);
 
-  assertReverbViewabilityComponentEventParamsExist({ params });
+  assertReverbViewabilityComponentEventParamsExist({ params, applicationType });
 
   expect(params.events).to.satisfy(
     payload =>
@@ -271,6 +271,7 @@ export const assertATIComponentViewEvent = ({
   component,
   pageIdentifier,
   contentType,
+  applicationType,
   siteId,
 }) => {
   const requestAlias = `@${component}-viewability-view`;
@@ -285,6 +286,7 @@ export const assertATIComponentViewEvent = ({
         pageIdentifier,
         contentType,
         params,
+        applicationType,
         siteId,
       });
     });
@@ -293,13 +295,14 @@ export const assertATIComponentViewEvent = ({
 const assertViewabilityModelClickEvent = ({
   pageIdentifier,
   params,
-  // applicationType,
+  applicationType,
   siteId,
 }) => {
   const eventContext = JSON.parse(params.context);
 
   assertReverbViewabilityComponentEventParamsExist({
     params,
+    applicationType,
   });
 
   expect(params.events).to.satisfy(
@@ -319,6 +322,7 @@ export const assertATIComponentClickEvent = ({
   component,
   contentType,
   pageIdentifier,
+  applicationType,
   siteId,
 }) => {
   const requestAlias = `@${component}-viewability-click`;
@@ -332,6 +336,7 @@ export const assertATIComponentClickEvent = ({
         contentType,
         pageIdentifier,
         params,
+        applicationType,
         siteId,
       });
     });

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/billboard.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/billboard.ts
@@ -5,7 +5,6 @@ const { BILLBOARD } = COMPONENTS;
 
 export const assertBillboardComponentView = ({
   pageIdentifier,
-  contentType,
   path,
   applicationType,
   siteId,
@@ -21,7 +20,6 @@ export const assertBillboardComponentView = ({
     assertATIComponentViewEvent({
       component: BILLBOARD,
       pageIdentifier,
-      contentType,
       applicationType,
       siteId,
     });
@@ -30,7 +28,6 @@ export const assertBillboardComponentView = ({
 
 export const assertBillboardComponentClick = ({
   pageIdentifier,
-  contentType,
   path,
   applicationType,
   siteId,
@@ -49,7 +46,6 @@ export const assertBillboardComponentClick = ({
     assertATIComponentClickEvent({
       component: BILLBOARD,
       pageIdentifier,
-      contentType,
       applicationType,
       siteId,
     });

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/continueReadingButton.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/continueReadingButton.ts
@@ -32,6 +32,7 @@ export const assertContinueReadingButtonComponentView = ({
         component: CONTINUE_READING_BUTTON,
         pageIdentifier,
         contentType,
+        applicationType,
         siteId,
       });
     },
@@ -64,6 +65,7 @@ export const assertContinueReadingButtonComponentClick = ({
         component: CONTINUE_READING_BUTTON,
         pageIdentifier,
         contentType,
+        applicationType,
         siteId,
       });
     },

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.ts
@@ -250,12 +250,12 @@ export const assertPageView = ({
 const assertViewabilityModelViewEvent = ({
   pageIdentifier,
   params,
-  // applicationType,
+  applicationType,
   siteId,
 }) => {
   const eventContext = JSON.parse(params.context);
 
-  assertReverbViewabilityComponentEventParamsExist({ params });
+  assertReverbViewabilityComponentEventParamsExist({ params, applicationType });
 
   expect(params.events).to.satisfy(
     payload =>
@@ -270,6 +270,7 @@ const assertViewabilityModelViewEvent = ({
 export const assertATIComponentViewEvent = ({
   component,
   pageIdentifier,
+  applicationType,
   siteId,
 }) => {
   const requestAlias = `@${component}-viewability-view`;
@@ -282,6 +283,7 @@ export const assertATIComponentViewEvent = ({
       assertViewabilityModelViewEvent({
         pageIdentifier,
         params,
+        applicationType,
         siteId,
       });
     });
@@ -290,13 +292,14 @@ export const assertATIComponentViewEvent = ({
 const assertViewabilityModelClickEvent = ({
   pageIdentifier,
   params,
-  // applicationType,
+  applicationType,
   siteId,
 }) => {
   const eventContext = JSON.parse(params.context);
 
   assertReverbViewabilityComponentEventParamsExist({
     params,
+    applicationType,
   });
 
   expect(params.events).to.satisfy(
@@ -315,6 +318,7 @@ const assertViewabilityModelClickEvent = ({
 export const assertATIComponentClickEvent = ({
   component,
   pageIdentifier,
+  applicationType,
   siteId,
 }) => {
   const requestAlias = `@${component}-viewability-click`;
@@ -326,6 +330,7 @@ export const assertATIComponentClickEvent = ({
       assertViewabilityModelClickEvent({
         pageIdentifier,
         params,
+        applicationType,
         siteId,
       });
     });

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.ts
@@ -93,7 +93,14 @@ const assertLocationSpecificPianoDestinationExists = ({ service }) => {
   });
 };
 
-const assertReverbViewabilityComponentEventParamsExist = ({ params }) => {
+const assertReverbViewabilityComponentEventParamsExist = ({
+  params,
+  applicationType,
+}) => {
+  if (['responsive', 'lite'].includes(applicationType)) {
+    expect(params).to.have.property('idclient');
+  }
+
   expect(params).to.have.property('s'); // destination
   expect(params).to.have.property('events'); // event details
   expect(params).to.have.property('context');
@@ -250,14 +257,6 @@ const assertViewabilityModelViewEvent = ({
 
   assertReverbViewabilityComponentEventParamsExist({ params });
 
-  // TODO: Commenting out temporarily until old ATI code is removed - https://bbc.atlassian.net/browse/WS-222
-  // if (['responsive', 'lite'].includes(applicationType)) {
-  //   expect(params.idclient).to.equal(
-  //     ATI_USER_ID_COOKIE,
-  //     'params.idclient (atuserid cookie value)',
-  //   );
-  // }
-
   expect(params.events).to.satisfy(
     payload =>
       validateViewabilityEventDetails({ payload, actionType: VIEW_EVENT }),
@@ -299,14 +298,6 @@ const assertViewabilityModelClickEvent = ({
   assertReverbViewabilityComponentEventParamsExist({
     params,
   });
-
-  // TODO: Commenting out temporarily until old ATI code is removed - https://bbc.atlassian.net/browse/WS-222
-  // if (['responsive', 'lite'].includes(applicationType)) {
-  //   expect(params.idclient).to.equal(
-  //     ATI_USER_ID_COOKIE,
-  //     'params.idclient (atuserid cookie value)',
-  //   );
-  // }
 
   expect(params.events).to.satisfy(
     payload =>

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.ts
@@ -6,7 +6,7 @@ import {
 import {
   ATI_PAGE_VIEW,
   ATI_PAGE_VIEW_REVERB,
-  // ATI_USER_ID_COOKIE,
+  ATI_USER_ID_COOKIE,
   getATIParamsFromURL,
   interceptATIAnalyticsBeacons,
   getExpectedAtiDestination,
@@ -14,7 +14,7 @@ import {
 import environment from '../../../../support/helpers/getAppEnv';
 
 const usesReverbViewabilityModel = applicationType =>
-  applicationType !== 'lite';
+  !['lite', 'amp'].includes(applicationType);
 
 const getAppName = service => {
   if (service === 'ws') {
@@ -183,7 +183,6 @@ const validateViewabilityEventDetails = ({ payload, actionType }) => {
 };
 
 export const assertPageView = ({
-  useReverb,
   pageIdentifier,
   applicationType,
   contentType,
@@ -196,10 +195,9 @@ export const assertPageView = ({
     cy.visit(path, { retryOnStatusCodeFailure: true });
 
     const useViewabilty = usesReverbViewabilityModel(applicationType);
-    const atiPageViewAlias =
-      useReverb && useViewabilty && applicationType !== 'amp'
-        ? ATI_PAGE_VIEW_REVERB
-        : ATI_PAGE_VIEW;
+    const atiPageViewAlias = useViewabilty
+      ? ATI_PAGE_VIEW_REVERB
+      : ATI_PAGE_VIEW;
 
     cy.wait(`@${atiPageViewAlias}`).then(({ request }) => {
       const params = getATIParamsFromURL(request.url);
@@ -210,13 +208,12 @@ export const assertPageView = ({
         applicationType,
       });
 
-      // TODO: Commenting out temporarily until old ATI code is removed - https://bbc.atlassian.net/browse/WS-222
-      // if (['responsive', 'lite'].includes(applicationType)) {
-      //   expect(params.idclient).to.equal(
-      //     ATI_USER_ID_COOKIE,
-      //     'params.idclient (atuserid cookie value)',
-      //   );
-      // }
+      if (['responsive', 'lite'].includes(applicationType)) {
+        expect(params.idclient).to.equal(
+          ATI_USER_ID_COOKIE,
+          'params.idclient (atuserid cookie value)',
+        );
+      }
 
       expect(params.p).to.equal(pageIdentifier, 'params.p (page identifier)');
       expect(parseInt(params.s2, 10)).to.equal(

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/topBarOjs.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/topBarOjs.ts
@@ -12,6 +12,7 @@ export const assertTopBarOJComponentView = ({
   pageIdentifier,
   contentType,
   path,
+  applicationType,
   siteId,
 }: AtiAssertionFnProps) => {
   it('should send a view event for the Top Bar OJ component', () => {
@@ -27,6 +28,7 @@ export const assertTopBarOJComponentView = ({
       component: TOP_BAR_OJ,
       pageIdentifier,
       contentType,
+      applicationType,
       siteId,
     });
   });
@@ -36,6 +38,7 @@ export const assertTopBarOJComponentClick = ({
   pageIdentifier,
   contentType,
   path,
+  applicationType,
   siteId,
 }: AtiAssertionFnProps) => {
   it('should send a click event for the Top Bar OJ component', () => {
@@ -53,6 +56,7 @@ export const assertTopBarOJComponentClick = ({
       component: TOP_BAR_OJ,
       pageIdentifier,
       contentType,
+      applicationType,
       siteId,
     });
   });


### PR DESCRIPTION
Resolves JIRA: WS-222

Summary
======
Resolve inconsistent test assertions outcomes resulting from flaky
`cy.setCookie('atuserid', 'value')` behaviour for non-interactive cypress. 

Code changes
======
- Remove `ATI_USER_ID_COOKIE` equality assertion for click/view events.
- Assert that the `idclient` parameter is present in click/view requests.
- Pass `applicationType` in click/view event assertions where absent.


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

