### PR TITLE
Fix service parsing in `_app`

### DIFF
--- a/ws-nextjs-app/pages/_app.page.tsx
+++ b/ws-nextjs-app/pages/_app.page.tsx
@@ -19,6 +19,7 @@ import extractHeaders from '#src/server/utilities/extractHeaders';
 import { getServerExperiments } from '#src/server/utilities/experimentHeader';
 import getToggles from '#app/lib/utilities/getToggles/withCache';
 import getPathExtension from '#app/utilities/getPathExtension';
+import parseRoute from '#app/routes/utils/parseRoute';
 import addCspHeader from '#nextjs/utilities/addCspHeader';
 import derivePageType from '#nextjs/utilities/derivePageType';
 import addServiceChainHeader from '#nextjs/utilities/addServiceChainHeader';
@@ -65,10 +66,8 @@ export default class CustomApp extends App<Props> {
 
     const { isApp, isAmp, isLite } = getPathExtension(asPath);
 
-    const routeSegments = asPath?.split('/')?.filter(Boolean);
-
-    const [service] = (routeSegments || []) as [Services];
-
+    const { service } = parseRoute(asPath) as { service: Services };
+    console.log({ service });
     const toggles = await getToggles(service);
 
     const pageType =

--- a/ws-nextjs-app/pages/_app.page.tsx
+++ b/ws-nextjs-app/pages/_app.page.tsx
@@ -67,7 +67,7 @@ export default class CustomApp extends App<Props> {
     const { isApp, isAmp, isLite } = getPathExtension(asPath);
 
     const { service } = parseRoute(asPath) as { service: Services };
-    console.log({ service });
+
     const toggles = await getToggles(service);
 
     const pageType =


### PR DESCRIPTION
Summary
======
- Resolves issue with parsing the service from the path in `_app`
- This was highlighted with the release of Homepages on Next.js, as the likes of `/kyrgyz.lite` resulted in a service of `kyrgyz.lite` instead of just `kyrgyz`


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

