### PR TITLE
[NO TICKET] FIX: Resolve idclient assertions in e2es

### DIFF
--- a/cypress/e2e/pages/liveRadio/index.cy.js
+++ b/cypress/e2e/pages/liveRadio/index.cy.js
@@ -2,7 +2,6 @@ import runTestsForPage from '#nextjs/cypress/support/helpers/runTestsForPage';
 import e2eTests from './tests';
 import testsForAllPages from '../testsForAllPages';
 import testsForAllCanonicalPages from '../testsForAllCanonicalPages';
-import { setUserIDCookie } from '../../specialFeatures/atiAnalytics/helpers';
 import { assertPageView } from '../../specialFeatures/atiAnalytics/assertions';
 import {
   assertRadioScheduleComponentClick,
@@ -131,6 +130,5 @@ runTestsForPage({
 runTestsForPage({
   pageType: 'liveRadio',
   testSuites: atiAnalyticsTestSuites,
-  beforeAll: [setUserIDCookie],
   testIsolation: true,
 });

--- a/cypress/e2e/pages/mostReadPage/index.cy.js
+++ b/cypress/e2e/pages/mostReadPage/index.cy.js
@@ -3,7 +3,6 @@ import testsForCanonicalOnly from './testsForCanonicalOnly';
 import crossPlatformTests from './tests';
 import testsForAllPages from '../testsForAllPages';
 import testsForAllCanonicalPages from '../testsForAllCanonicalPages';
-import { setUserIDCookie } from '../../specialFeatures/atiAnalytics/helpers';
 import { assertPageView } from '../../specialFeatures/atiAnalytics/assertions';
 import getPathWithSuffix from '../../../support/helpers/getPathWithSuffix';
 import { assertLiteSiteSummaryComponentToMainSiteClick } from '../../specialFeatures/atiAnalytics/assertions/liteSiteSummary';
@@ -136,12 +135,10 @@ runTestsForPage({
 runTestsForPage({
   pageType,
   testSuites: atiAnalyticsTestSuites,
-  beforeAll: [setUserIDCookie],
   testIsolation: true,
 });
 
 runTestsForPage({
   pageType,
   testSuites: [...atiAnalyticsAmpTestSuites, ...atiAnalyticsLiteTestSuites],
-  beforeAll: [setUserIDCookie],
 });

--- a/cypress/e2e/pages/onDemandAudio/index.cy.js
+++ b/cypress/e2e/pages/onDemandAudio/index.cy.js
@@ -2,7 +2,6 @@ import runTestsForPage from '#nextjs/cypress/support/helpers/runTestsForPage';
 import e2eTests from './tests';
 import testsForAllPages from '../testsForAllPages';
 import testsForAllCanonicalPages from '../testsForAllCanonicalPages';
-import { setUserIDCookie } from '../../specialFeatures/atiAnalytics/helpers';
 import { assertPageView } from '../../specialFeatures/atiAnalytics/assertions';
 import {
   assertPodcastLinksComponentClick,
@@ -567,12 +566,10 @@ runTestsForPage({
 runTestsForPage({
   pageType,
   testSuites: atiAnalyticsTestSuites,
-  beforeAll: [setUserIDCookie],
   testIsolation: true,
 });
 
 runTestsForPage({
   pageType,
   testSuites: atiAnalyticsLiteTestSuites,
-  beforeAll: [setUserIDCookie],
 });

--- a/cypress/e2e/pages/onDemandTV/index.cy.js
+++ b/cypress/e2e/pages/onDemandTV/index.cy.js
@@ -1,7 +1,6 @@
 import runTestsForPage from '#nextjs/cypress/support/helpers/runTestsForPage';
 import e2eTests from './tests';
 import testsForAllCanonicalPages from '../testsForAllCanonicalPages';
-import { setUserIDCookie } from '../../specialFeatures/atiAnalytics/helpers';
 import { assertPageView } from '../../specialFeatures/atiAnalytics/assertions';
 import getPathWithSuffix from '../../../support/helpers/getPathWithSuffix';
 import { assertLiteSiteSummaryComponentToMainSiteClick } from '../../specialFeatures/atiAnalytics/assertions/liteSiteSummary';
@@ -263,12 +262,10 @@ runTestsForPage({
 runTestsForPage({
   pageType,
   testSuites: atiAnalyticsTestSuites,
-  beforeAll: [setUserIDCookie],
   testIsolation: true,
 });
 
 runTestsForPage({
   pageType,
   testSuites: atiAnalyticsLiteTestSuites,
-  beforeAll: [setUserIDCookie],
 });

--- a/cypress/e2e/pages/topicPage/index.cy.js
+++ b/cypress/e2e/pages/topicPage/index.cy.js
@@ -5,7 +5,6 @@ import urlValidationTest from '../../../support/helpers/urlValidationTest';
 import testsForAllCanonicalPages from '../testsForAllCanonicalPages';
 import getPathWithSuffix from '../../../support/helpers/getPathWithSuffix';
 import { assertLiteSiteSummaryComponentToMainSiteClick } from '../../specialFeatures/atiAnalytics/assertions/liteSiteSummary';
-import { setUserIDCookie } from '../../specialFeatures/atiAnalytics/helpers';
 import { assertPageView } from '../../specialFeatures/atiAnalytics/assertions';
 import {
   assertDropdownNavigationComponentClick,
@@ -139,12 +138,10 @@ runTestsForPage({
 runTestsForPage({
   pageType: TOPIC_PAGE,
   testSuites: atiAnalyticsTestSuites,
-  beforeAll: [setUserIDCookie],
   testIsolation: true,
 });
 
 runTestsForPage({
   pageType: TOPIC_PAGE,
   testSuites: atiAnalyticsLiteTestSuites,
-  beforeAll: [setUserIDCookie],
 });

--- a/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.js
@@ -6,7 +6,6 @@ import {
 import {
   ATI_PAGE_VIEW,
   ATI_PAGE_VIEW_REVERB,
-  ATI_USER_ID_COOKIE,
   getATIParamsFromURL,
   interceptATIAnalyticsBeacons,
   getExpectedAtiDestination,
@@ -214,13 +213,6 @@ export const assertPageView = ({
         contentType,
         applicationType,
       });
-
-      if (['responsive', 'lite'].includes(applicationType)) {
-        expect(params.idclient).to.equal(
-          ATI_USER_ID_COOKIE,
-          'params.idclient (atuserid cookie value)',
-        );
-      }
 
       expect(params.p).to.equal(pageIdentifier, 'params.p (page identifier)');
       expect(parseInt(params.s2, 10)).to.equal(

--- a/cypress/e2e/specialFeatures/atiAnalytics/helpers/index.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/helpers/index.js
@@ -10,8 +10,6 @@ export const ATI_PAGE_VIEW = 'ati-page-view';
 
 export const ATI_PAGE_VIEW_REVERB = 'ati-page-view-reverb';
 
-export const ATI_USER_ID_COOKIE = 'atuserid-cookie-value';
-
 const SCROLLABLE_NAVIGATION = 'scrollable-navigation';
 const DROPDOWN_NAVIGATION = 'dropdown-navigation';
 const TOP_STORIES = 'top-stories';
@@ -119,12 +117,6 @@ export const interceptATIAnalyticsBeacons = () => {
       request.reply({ statusCode: 200 });
     },
   ).as(`${ATI_PAGE_VIEW_REVERB}`);
-};
-
-export const setUserIDCookie = () => {
-  cy.session('user-session', () => {
-    cy.setCookie('atuserid', JSON.stringify({ val: ATI_USER_ID_COOKIE }));
-  });
 };
 
 export const getExpectedAtiDestination = ({ service, applicationEnv }) => {

--- a/cypress/e2e/specialFeatures/atiAnalytics/index.cy.js
+++ b/cypress/e2e/specialFeatures/atiAnalytics/index.cy.js
@@ -15,7 +15,6 @@ import {
   assertSocialEmbedComponentView,
 } from './assertions/socialEmbed';
 
-import { setUserIDCookie } from './helpers';
 import getPathWithSuffix from '../../../support/helpers/getPathWithSuffix';
 
 const canonicalTestSuites = [];
@@ -62,5 +61,4 @@ const liteTestSuites = canonicalTestSuites.map(testSuite => {
 });
 runTestsForPage({
   testSuites: [...canonicalTestSuites, ...ampTestSuites, ...liteTestSuites],
-  beforeAll: [setUserIDCookie],
 });

--- a/ws-nextjs-app/cypress/e2e/articlePage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/articlePage/index.cy.ts
@@ -20,7 +20,6 @@ import {
   assertTopBarOJComponentClick,
   assertTopBarOJComponentView,
 } from '../specialFeatures/atiAnalytics/assertions/topBarOjs';
-import { setUserIDCookie } from '../specialFeatures/atiAnalytics/helpers';
 import {
   assertArticleLiteSiteLinkComponentClick,
   assertArticleLiteSiteLinkComponentView,
@@ -527,7 +526,6 @@ runTestsForPage({
     ...atiAnalyticsTestSuites.filter(({ service }) => service !== 'news'),
     ...atiLiteTestSuites,
   ] as unknown as TestDataType[],
-  beforeAll: [setUserIDCookie],
 });
 
 runTestsForPage({

--- a/ws-nextjs-app/cypress/e2e/homePage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/homePage/index.cy.ts
@@ -31,7 +31,6 @@ import {
   assertRadioScheduleComponentClick,
   assertRadioScheduleComponentView,
 } from '../specialFeatures/atiAnalytics/assertions/radioSchedule';
-import { setUserIDCookie } from '../specialFeatures/atiAnalytics/helpers';
 import urlValidationTest from '../../support/helpers/urlValidationTest';
 
 const tests = [urlValidationTest, canonicalTests, testsForAllCanonicalPages];
@@ -267,12 +266,10 @@ runTestsForPage({
 runTestsForPage({
   pageType: HOME_PAGE,
   testSuites: atiAnalyticsTestSuites,
-  beforeAll: [setUserIDCookie],
   testIsolation: true,
 });
 
 runTestsForPage({
   pageType: HOME_PAGE,
   testSuites: atiAnalyticsLiteTestSuites,
-  beforeAll: [setUserIDCookie],
 });

--- a/ws-nextjs-app/cypress/e2e/languagesPage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/languagesPage/index.cy.ts
@@ -1,5 +1,5 @@
-import { assertPageView } from '../../../../cypress/e2e/specialFeatures/atiAnalytics/assertions';
 import { HOME_PAGE } from '#app/routes/utils/pageTypes';
+import { assertPageView } from '../../../../cypress/e2e/specialFeatures/atiAnalytics/assertions';
 import {
   assertWSLanguagesPageURNLive,
   assertWSLanguagesPageURN,
@@ -8,7 +8,6 @@ import {
 import runTestsForPage, {
   TestDataType,
 } from '../../support/helpers/runTestsForPage';
-import { setUserIDCookie } from '../specialFeatures/atiAnalytics/helpers';
 
 const testSuites = [
   {
@@ -52,6 +51,5 @@ runTestsForPage({
 runTestsForPage({
   pageType: HOME_PAGE,
   testSuites: atiAnalyticsTestSuites,
-  beforeAll: [setUserIDCookie],
   testIsolation: true,
 });

--- a/ws-nextjs-app/cypress/e2e/livePage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/livePage/index.cy.ts
@@ -7,7 +7,6 @@ import testsThatAlwaysRunForAllPages from '../testsForAllPages';
 import runTestsForPage, {
   TestDataType,
 } from '../../support/helpers/runTestsForPage';
-import { setUserIDCookie } from '../specialFeatures/atiAnalytics/helpers';
 import {
   assertDropdownNavigationComponentClick,
   assertDropdownNavigationComponentView,
@@ -97,7 +96,6 @@ describe('Live Page Spec', () => {
   runTestsForPage({
     pageType: LIVE_PAGE,
     testSuites: atiAnalyticsTestSuites,
-    beforeAll: [setUserIDCookie],
     testIsolation: true,
   });
 });

--- a/ws-nextjs-app/cypress/e2e/mediaAssetPage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/mediaAssetPage/index.cy.ts
@@ -10,7 +10,6 @@ import ampArticleTests from './testsForAMPOnly';
 import canonicalArticleTests from './testsForCanonicalOnly';
 import liteTests from '../articlePage/testsForLiteOnly';
 import getPathWithSuffix from '../../support/helpers/getPathWithSuffix';
-import { setUserIDCookie } from '../specialFeatures/atiAnalytics/helpers';
 import {
   assertDropdownNavigationComponentClick,
   assertDropdownNavigationComponentView,
@@ -391,6 +390,5 @@ runTestsForPage({
 runTestsForPage({
   pageType: MEDIA_ASSET_PAGE,
   testSuites: atiAnalyticsTestSuites,
-  beforeAll: [setUserIDCookie],
   testIsolation: true,
 });

--- a/ws-nextjs-app/cypress/e2e/photoGalleryPage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/photoGalleryPage/index.cy.ts
@@ -7,7 +7,6 @@ import testsForAllPages from '../testsForAllPages';
 import testsForAllCanonicalPages from '../testsForAllCanonicalPages';
 import testsForAllAMPPages from '../testsForAllAMPPages';
 import liteArticleTests from '../articlePage/testsForLiteOnly';
-import { setUserIDCookie } from '../specialFeatures/atiAnalytics/helpers';
 import {
   assertDropdownNavigationComponentClick,
   assertDropdownNavigationComponentView,
@@ -189,6 +188,5 @@ runTestsForPage({
 runTestsForPage({
   pageType: PHOTO_GALLERY_PAGE,
   testSuites: atiAnalyticsTestSuites,
-  beforeAll: [setUserIDCookie],
   testIsolation: true,
 });

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.ts
@@ -6,7 +6,6 @@ import {
 import {
   ATI_PAGE_VIEW,
   ATI_PAGE_VIEW_REVERB,
-  ATI_USER_ID_COOKIE,
   getATIParamsFromURL,
   interceptATIAnalyticsBeacons,
   getExpectedAtiDestination,
@@ -214,13 +213,6 @@ export const assertPageView = ({
         contentType,
         applicationType,
       });
-
-      if (['responsive', 'lite'].includes(applicationType)) {
-        expect(params.idclient).to.equal(
-          ATI_USER_ID_COOKIE,
-          'params.idclient (atuserid cookie value)',
-        );
-      }
 
       expect(params.p).to.equal(pageIdentifier, 'params.p (page identifier)');
       expect(parseInt(params.s2, 10)).to.equal(

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/helpers/index.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/helpers/index.ts
@@ -11,7 +11,6 @@ export const ATI_PAGE_VIEW = 'ati-page-view';
 
 export const ATI_PAGE_VIEW_REVERB = 'ati-page-view-reverb';
 
-export const ATI_USER_ID_COOKIE = 'atuserid-cookie-value';
 
 const SCROLLABLE_NAVIGATION = 'scrollable-navigation';
 const DROPDOWN_NAVIGATION = 'dropdown-navigation';
@@ -123,10 +122,6 @@ export const interceptATIAnalyticsBeacons = () => {
       request.reply({ statusCode: 200 });
     },
   ).as(`${ATI_PAGE_VIEW_REVERB}`);
-};
-
-export const setUserIDCookie = () => {
-  cy.setCookie('atuserid', JSON.stringify({ val: ATI_USER_ID_COOKIE }));
 };
 
 export const getExpectedAtiDestination = ({

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/index.cy.ts
@@ -2,7 +2,6 @@
 import { PageTypes } from '#app/models/types/global';
 import { LIVE_PAGE } from '../../../../../src/app/routes/utils/pageTypes';
 import { assertPageView } from '../../../../../cypress/e2e/specialFeatures/atiAnalytics/assertions';
-import { setUserIDCookie } from '../../../../../cypress/e2e/specialFeatures/atiAnalytics/helpers';
 // TODO: Resolve error which is preventing e2e tests to run
 // import {
 //   assertRecommendationsComponentClick,
@@ -153,6 +152,6 @@ runTestsForPage({
     ...ampTestSuites,
     ...liteTestSuites,
   ] as unknown as TestDataType[],
-  beforeEachFns: [setUserIDCookie],
+  beforeEachFns: [],
   pageType: 'all' as PageTypes,
 });

--- a/ws-nextjs-app/cypress/e2e/storyPage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/storyPage/index.cy.ts
@@ -9,7 +9,6 @@ import testsForAllAMPPages from '../testsForAllAMPPages';
 import canonicalAndAmpArticleTests from './tests';
 import ampArticleTests from './testsForAMPOnly';
 import canonicalArticleTests from './testsForCanonicalOnly';
-import { setUserIDCookie } from '../specialFeatures/atiAnalytics/helpers';
 import {
   assertDropdownNavigationComponentClick,
   assertDropdownNavigationComponentView,
@@ -293,6 +292,5 @@ runTestsForPage({
 runTestsForPage({
   pageType: STORY_PAGE,
   testSuites: atiAnalyticsTestSuites,
-  beforeAll: [setUserIDCookie],
   testIsolation: true,
 });


### PR DESCRIPTION
Resolves JIRA: NO TICKET

Summary
======
Remove spurious `idclient` assertions and retains the assertion that
check for the existence of the parameter.

Code changes
======
- Remove `idclient` from `assertPageView` in Piano e2es.


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

