### PR TITLE
NOTICKET - Fix script switch linking with query params

### DIFF
--- a/src/app/components/Header/ScriptLink/index.test.tsx
+++ b/src/app/components/Header/ScriptLink/index.test.tsx
@@ -68,6 +68,21 @@ describe(`Script Link`, () => {
     });
   });
 
+  it('should set the correct alternate variant when URL has query parameters', () => {
+    const { container } = render(<ScriptLink />, {
+      toggles: enabledToggleState,
+      service: 'serbian',
+      variant: 'lat',
+      pathname: '/serbian/articles/c805k05kr73o/lat?foo=bar&baz=qux',
+    });
+
+    const scriptLink = container.querySelector(`a[data-variant]`);
+
+    expect(scriptLink?.getAttribute('href')).toBe(
+      '/serbian/articles/c805k05kr73o/cyr',
+    );
+  });
+
   it('should not render when scriptLink toggle is off', () => {
     const disabledToggleState = {
       scriptLink: {

--- a/src/app/components/Header/ScriptLink/index.tsx
+++ b/src/app/components/Header/ScriptLink/index.tsx
@@ -17,7 +17,8 @@ const ScriptLink = () => {
 
   const pathPartsWithoutExtension = pathname
     .replace(/\.[^/.]+$/, '') // remove any extensions, we don't want to link to AMP pages directly
-    .split('/');
+    .split('?')?.[0] // remove any query parameters
+    .split('/'); // split path into parts
 
   const currentVariantIndex = pathPartsWithoutExtension.indexOf(
     currentVariant as string,


### PR DESCRIPTION
Summary
======
After moving Topic pages to Next.js, I noticed that if there is a `page` query parameter in the URL, the script switch button doesn't link the user to the alternative variant, instead it just keeps the link the same as the current URL.

This fixes that by removing query parameters from the URL before setting the alternative URL for the variant.

This maintains existing behaviour on Live, where users are directed back to the first page if they are on a page further down if they use the script switch button.

Code changes
======
- Updates `ScriptLink` to remove query params from the path used to calculate the alternative variant URL


Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
1. Visit http://localhost:7081/serbian/topics/c1gd303q6y6t/lat?page=2
2. Hover over the script switch button and confirm the URL is http://localhost:7081/serbian/topics/c1gd303q6y6t/cyr


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

