### PR TITLE
WS-NA-10-time: Adds live pulse to nav [copilot]

### DIFF
--- a/src/app/legacy/containers/Navigation/index.jsx
+++ b/src/app/legacy/containers/Navigation/index.jsx
@@ -7,6 +7,7 @@ import {
 import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import useViewTracker from '#app/hooks/useViewTracker';
 import { RequestContext } from '#contexts/RequestContext';
+import isLiveTVNavItem from '#lib/utilities/navigation/isLiveTVNavItem';
 import LanguageNavigation from './LanguageNavigation/lazy';
 import { ServiceContext } from '../../../contexts/ServiceContext';
 import Canonical from './index.canonical';
@@ -23,12 +24,18 @@ const renderListItems = (
   clickTracker,
   viewTracker,
   isLite,
+  liveTVChannelIdentifier,
 ) =>
   navigation.reduce((listAcc, item, index) => {
     const { title, url, hideOnLiteSite } = item;
     const active = index === activeIndex;
 
     if (hideOnLiteSite && isLite) return listAcc;
+
+    const showLivePulse = isLiveTVNavItem({
+      navItemUrl: url,
+      liveTVChannelIdentifier,
+    });
 
     const listItem = (
       <Li
@@ -41,6 +48,7 @@ const renderListItems = (
         dir={dir}
         clickTracker={clickTracker}
         viewTracker={viewTracker}
+        showLivePulse={showLivePulse}
       >
         {title}
       </Li>
@@ -59,6 +67,7 @@ const NavigationContainer = ({ propsForTopBarOJComponent }) => {
     service,
     dir,
     collapsibleNavigation,
+    liveTVChannelIdentifier,
   } = use(ServiceContext);
 
   const { canonicalLink, origin } = use(RequestContext);
@@ -113,6 +122,7 @@ const NavigationContainer = ({ propsForTopBarOJComponent }) => {
         scrollableNavClickTrackerHandler,
         scrollableNavViewTracker,
         isLite,
+        liveTVChannelIdentifier,
       )}
     </NavigationUl>
   );
@@ -129,6 +139,8 @@ const NavigationContainer = ({ propsForTopBarOJComponent }) => {
         activeIndex,
         dropdownNavClickTrackerHandler,
         dropdownNavViewTracker,
+        isLite, // this took me ages to work out
+        liveTVChannelIdentifier,
       )}
     </DropdownUl>
   );

--- a/src/app/legacy/containers/Navigation/index.jsx
+++ b/src/app/legacy/containers/Navigation/index.jsx
@@ -23,8 +23,8 @@ const renderListItems = (
   activeIndex,
   clickTracker,
   viewTracker,
-  isLite,
   liveTVChannelIdentifier,
+  isLite,
 ) =>
   navigation.reduce((listAcc, item, index) => {
     const { title, url, hideOnLiteSite } = item;
@@ -121,8 +121,8 @@ const NavigationContainer = ({ propsForTopBarOJComponent }) => {
         activeIndex,
         scrollableNavClickTrackerHandler,
         scrollableNavViewTracker,
-        isLite,
         liveTVChannelIdentifier,
+        isLite,
       )}
     </NavigationUl>
   );
@@ -139,7 +139,6 @@ const NavigationContainer = ({ propsForTopBarOJComponent }) => {
         activeIndex,
         dropdownNavClickTrackerHandler,
         dropdownNavViewTracker,
-        isLite, // this took me ages to work out
         liveTVChannelIdentifier,
       )}
     </DropdownUl>

--- a/src/app/legacy/psammead/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/src/app/legacy/psammead/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -11,6 +11,7 @@ import {
   GEL_GROUP_3_SCREEN_WIDTH_MIN,
   GEL_GROUP_B_MIN_WIDTH,
 } from '#psammead/gel-foundations/src/breakpoints';
+import Pulse from '#app/components/LivePulse';
 import VisuallyHiddenText from '../../../../../components/VisuallyHiddenText';
 
 export const NAV_BAR_TOP_BOTTOM_SPACING = 0.75; // 12px
@@ -116,6 +117,7 @@ export const DropdownLi = ({
   url,
   dir = 'ltr',
   viewTracker = null,
+  showLivePulse = null,
 }) => {
   const ariaId = `dropdownNavigation-${children
     .replace(/\s+/g, '-')
@@ -123,6 +125,13 @@ export const DropdownLi = ({
   return (
     // aria-labelledby is a temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
     <StyledDropdownLi role="listitem" {...viewTracker}>
+      {showLivePulse && (
+        <Pulse
+          width="18"
+          height="18"
+          style={{ verticalAlign: 'middle', marginInlineEnd: '0.25em' }}
+        />
+      )}
       <StyledDropdownLink
         script={script}
         service={service}

--- a/src/app/legacy/psammead/psammead-navigation/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-navigation/src/index.jsx
@@ -10,6 +10,7 @@ import {
   GEL_GROUP_3_SCREEN_WIDTH_MAX,
   GEL_GROUP_5_SCREEN_WIDTH_MIN,
 } from '#psammead/gel-foundations/src/breakpoints';
+import Pulse from '#app/components/LivePulse';
 import { NAV_BAR_TOP_BOTTOM_SPACING } from './DropdownNavigation';
 import { focusIndicatorThickness } from '../../../../components/ThemeProvider/focusIndicator';
 import VisuallyHiddenText from '../../../../components/VisuallyHiddenText';
@@ -163,10 +164,18 @@ export const NavigationLi = ({
   service,
   dir = 'ltr',
   viewTracker = null,
+  showLivePulse = false,
   ...props
 }) => {
   return (
     <StyledListItem dir={dir} role="listitem" {...viewTracker}>
+      {showLivePulse && (
+        <Pulse
+          width="18"
+          height="18"
+          style={{ verticalAlign: 'middle', marginInlineEnd: '0.25em' }}
+        />
+      )}
       {active && currentPageText ? (
         <StyledLink
           href={url}

--- a/src/app/lib/config/services/arabic.ts
+++ b/src/app/lib/config/services/arabic.ts
@@ -418,6 +418,7 @@ export const service: DefaultServiceConfig = {
         'بي بي سي. بي بي سي ليست مسؤولة عن محتوى المواقع الخارجية.',
     },
     timezone: 'GMT',
+    liveTVChannelIdentifier: '/arabic/media-49522519',
     navigation: [
       {
         title: 'رئيسية',

--- a/src/app/lib/utilities/navigation/isLiveTVNavItem.js
+++ b/src/app/lib/utilities/navigation/isLiveTVNavItem.js
@@ -1,4 +1,0 @@
-const isLiveTVNavItem = ({ navItemUrl, liveTVChannelIdentifier }) =>
-  liveTVChannelIdentifier && navItemUrl === liveTVChannelIdentifier;
-
-export default isLiveTVNavItem;

--- a/src/app/lib/utilities/navigation/isLiveTVNavItem.js
+++ b/src/app/lib/utilities/navigation/isLiveTVNavItem.js
@@ -1,0 +1,4 @@
+const isLiveTVNavItem = ({ navItemUrl, liveTVChannelIdentifier }) =>
+  liveTVChannelIdentifier && navItemUrl === liveTVChannelIdentifier;
+
+export default isLiveTVNavItem;

--- a/src/app/lib/utilities/navigation/isLiveTVNavItem.test.ts
+++ b/src/app/lib/utilities/navigation/isLiveTVNavItem.test.ts
@@ -1,0 +1,63 @@
+import isLiveTVNavItem from './isLiveTVNavItem';
+
+describe('isLiveTVNavItem', () => {
+  it('returns true when navItemUrl matches liveTVChannelIdentifier', () => {
+    expect(
+      isLiveTVNavItem({
+        navItemUrl: '/arabic/media-49522519',
+        liveTVChannelIdentifier: '/arabic/media-49522519',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when navItemUrl does not match liveTVChannelIdentifier', () => {
+    expect(
+      isLiveTVNavItem({
+        navItemUrl: '/arabic/media-49522519',
+        liveTVChannelIdentifier: '/arabic/media-12345678',
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when liveTVChannelIdentifier is falsy', () => {
+    expect(
+      isLiveTVNavItem({
+        navItemUrl: '/arabic/media-49522519',
+        liveTVChannelIdentifier: '',
+      }),
+    ).toBe(false);
+    expect(
+      isLiveTVNavItem({
+        navItemUrl: '/arabic/media-49522519',
+        liveTVChannelIdentifier: null,
+      }),
+    ).toBe(false);
+    expect(
+      isLiveTVNavItem({
+        navItemUrl: '/arabic/media-49522519',
+        liveTVChannelIdentifier: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when navItemUrl is falsy', () => {
+    expect(
+      isLiveTVNavItem({
+        navItemUrl: '',
+        liveTVChannelIdentifier: '/arabic/media-49522519',
+      }),
+    ).toBe(false);
+    expect(
+      isLiveTVNavItem({
+        navItemUrl: null,
+        liveTVChannelIdentifier: '/arabic/media-49522519',
+      }),
+    ).toBe(false);
+    expect(
+      isLiveTVNavItem({
+        navItemUrl: undefined,
+        liveTVChannelIdentifier: '/arabic/media-49522519',
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/app/lib/utilities/navigation/isLiveTVNavItem.ts
+++ b/src/app/lib/utilities/navigation/isLiveTVNavItem.ts
@@ -1,0 +1,12 @@
+export interface IsLiveTVNavItemArgs {
+  navItemUrl: string | null | undefined;
+  liveTVChannelIdentifier: string | null | undefined;
+}
+
+const isLiveTVNavItem = ({
+  navItemUrl,
+  liveTVChannelIdentifier,
+}: IsLiveTVNavItemArgs): boolean =>
+  Boolean(liveTVChannelIdentifier) && navItemUrl === liveTVChannelIdentifier;
+
+export default isLiveTVNavItem;

--- a/src/app/models/types/serviceConfig.ts
+++ b/src/app/models/types/serviceConfig.ts
@@ -97,6 +97,7 @@ export type ServiceConfig = {
   recommendations?: Recommendations;
   footer: Footer;
   collapsibleNavigation?: CollapsibleNavigationSection[];
+  liveTVChannelIdentifier?: string;
   navigation?: {
     title: string;
     url: string;


### PR DESCRIPTION
Resolves JIRA: N/A (10% time)

Summary
======
Adds a Live Pulse to navigation for Arabic Live Broadcast page link. (A training exercise to use co-pilot agent & prompting)

<img width="320" height="661" alt="Screenshot 2026-01-16 at 14 55 12" src="https://github.com/user-attachments/assets/96ac4970-4d64-4849-994c-924ff1357206" />
<img width="317" height="639" alt="Screenshot 2026-01-16 at 14 55 18" src="https://github.com/user-attachments/assets/e0dbdf87-b497-4fc8-996c-20d29cc003f9" />
<img width="1017" height="732" alt="Screenshot 2026-01-16 at 14 55 26" src="https://github.com/user-attachments/assets/85aa592e-89da-456c-8550-2c03adae0405" />

Code changes
======
- Hardcodes in service config
- Looks for this value in Nav, if it exists then adds a live pulse.

To do
======
- Understand if page is ever not "live". If so, see if can we remove pulse for this
- Add Toggle if desired
- A11y & UX consultation
- Add story/ testing
- Remove on lite?
- Add further services

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [ ] Manual Testing required?
  - [ ] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [ ] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [ ] Live


## Additional Testing Steps
Launch NextJs server locally
Visit http://localhost:7081/arabic?renderer_env=live


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

