### PR TITLE
WS-1914: Brazil PWA Install Prompt - render on article pages

### DIFF
--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -190,6 +190,7 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
   const { enabled: continueReadingButtonToggle } = useToggle(
     'continueReadingButton',
   );
+  const { enabled: isTopBarOJsEnabled } = useToggle('topBarOJs');
 
   const {
     palette: { GREY_2 },
@@ -323,7 +324,7 @@ const ArticlePage = ({ pageData }: { pageData: Article }) => {
 
   // EXPERIMENT: PWA Promotional Banner
   const shouldRenderPWAPromotionalBanner =
-    !pageData?.secondaryColumn?.topStories?.length;
+    !isTopBarOJsEnabled || !pageData?.secondaryColumn?.topStories?.length;
 
   return (
     <div css={styles.pageWrapper}>


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1914

Summary
======
We want to prevent rendering both TopBarOJ and the PWA Promotional banner simultaneously. Since TopBarOJ depends not only on the `secondaryColumn?.topStories` data but also on a feature toggle, we need to include that condition as well.

Developer Checklist
======

- [ ] **UX**
  - [ ] UX Criteria met (visual UX & screenreader UX)
- [ ] **Accessibility**
    - [ ] Accessibility Acceptance Criteria met
    - [ ] Accessibility swarm completed
    - [ ] Component Health updated
    - [ ] P1 accessibility bugs resolved 
    - [ ] P2/P3 accessibility bugs planned (if not resolved)
- [ ] **Security**
    - [ ] Security issues addressed
    - [ ] Threat Model updated
- [ ] **Documentation**
    - [ ] Docs updated (runbook, READMEs)
- [ ] **[Testing](#testing)** 
    - [ ] Feature tested on relevant environments
- [ ] **Comms** 
    - [ ] Relevant parties notified of changes


Testing
======

- [x] Manual Testing required?
  - [x] Local (`Ready-For-Test, Local`)
  - [ ] Test  (`Ready-For-Test, Test`)
  - [ ] Preview (`Ready-For-Test, Preview`)
  - [ ] Live (`Ready-For-Test, Live`)
- [x] Manual Testing complete?
  - [ ] Local
  - [ ] Test
  - [ ] Preview
  - [x] Live


## Additional Testing Steps
1. _List the steps required to test this PR._


Useful Links
======
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._

