### PR TITLE
Udpate Korean 'and' translation

### DIFF
--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -47,7 +47,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: false,
     showRelatedTopics: true,
     translations: {
-      and: '그리고',
+      and: ', ',
       pagination: {
         previousPage: '이전',
         nextPage: '다음',


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
- Updates current translation for 'and' in bylines with just a comma.

Code changes
======

- Edited and string in traslations section of src/app/lib/config/services/korean.ts


Testing
======
1. Open a Korean article with a multiple byline, there should be just a comma between the author's names.




## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
