### PR TITLE
Bump version of sw and cachename

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -4,9 +4,9 @@
 /* eslint-disable no-undef */
 /* eslint-disable no-restricted-globals */
 
-const version = 'v0.3.2';
+const version = 'v0.3.3';
 // Update cache name when changing caching logic / changes in offlinepage.tsx
-const cacheName = 'simorghCache_v2';
+const cacheName = 'simorghCache_v3';
 const pwaClients = new Map();
 let isPWADeviceOffline = false;
 

--- a/src/sw.test.js
+++ b/src/sw.test.js
@@ -437,8 +437,8 @@ describe('Service Worker', () => {
 
   describe('version', () => {
     const CURRENT_VERSION = {
-      number: 'v0.3.2',
-      fileContentHash: '85665b6155ea328ebdb7df0e8ef0a738',
+      number: 'v0.3.3',
+      fileContentHash: '5cb6c6475b78d85656632455d9c28a87',
     };
 
     it(`version number should be ${CURRENT_VERSION.number}`, async () => {


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
We rolled out the offline page via SW in two stages.
In Stage 2, we expanded the SW scope to include the homepage but didn’t bump the SW version since sw.js itself didn’t change.

**Issue (only seen in test & live not in preview ) :** For users who had previously tested Mundo (Stage 1), offline behaviour from the homepage doesn’t work after Stage 2 and only works after clearing site data.
New users, or services or Users without prior SW installation  work fine.

**Root cause:** changing the SW scope creates a new registration, and old scoped SWs/caches aren’t cleaned up automatically.

**Fix  is this PR** that would be to bump the SW version so cache cleanup/versioning happens for legacy users

