### PR TITLE
[NO TICKET] Eslint advisory temporary resolution

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -13,7 +13,7 @@ nodeLinker: node-modules
 npmAuditExcludePackages: []
 
 npmAuditIgnoreAdvisories:
-  - GHSA-p5wg-g6qr-c7cg
+  - 1112686 # https://github.com/advisories/GHSA-p5wg-g6qr-c7cg
 
 plugins:
   - checksum: 5e73a1acbb9741fce1e8335e243c9480ea2107b9b4b65ed7643785ddea9e3019aee254a92a853b1cd71023b16fff5b7d3afd5256fe57cd35a54f8785b8c30281

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,7 +12,8 @@ nodeLinker: node-modules
 
 npmAuditExcludePackages: []
 
-npmAuditIgnoreAdvisories: []
+npmAuditIgnoreAdvisories:
+  - GHSA-p5wg-g6qr-c7cg
 
 plugins:
   - checksum: 5e73a1acbb9741fce1e8335e243c9480ea2107b9b4b65ed7643785ddea9e3019aee254a92a853b1cd71023b16fff5b7d3afd5256fe57cd35a54f8785b8c30281


### PR DESCRIPTION
Resolves JIRA:  N/A

Temporary resolution for eslint vulnerability for versions < 9.26.0 highlighted in GitHub checks, more information in the below screenshot and [here](https://github.com/advisories/GHSA-p5wg-g6qr-c7cg)

<img width="726" height="322" alt="Screenshot 2026-01-30 at 10 06 05" src="https://github.com/user-attachments/assets/b076b91f-2a56-43a0-b708-26c4ae650aa6" />
