### PR TITLE
WS-2051 - Roll out to Live for Indonesia Service

### DIFF
--- a/src/app/lib/utilities/fetchConfig/index.test.ts
+++ b/src/app/lib/utilities/fetchConfig/index.test.ts
@@ -38,20 +38,6 @@ describe('fetchConfig', () => {
     expect(data).toBeNull();
   });
 
-  it('should return null when in live environment', async () => {
-    process.env.SIMORGH_APP_ENV = 'live';
-
-    const { default: fetchConfig } = await import('.');
-
-    const data = await fetchConfig({
-      service: 'indonesia',
-      pagePath: '/indonesia',
-      configType: 'navigation',
-    });
-
-    expect(data).toBeNull();
-  });
-
   it('should fetch configuration data', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,

--- a/src/app/lib/utilities/fetchConfig/index.ts
+++ b/src/app/lib/utilities/fetchConfig/index.ts
@@ -7,7 +7,6 @@ import certsRequired from '#app/routes/utils/certsRequired';
 import { FetchError } from '#app/models/types/fetch';
 import getEnvironment from '#app/routes/utils/getEnvironment';
 import { PRIMARY_DATA_TIMEOUT } from '../getFetchTimeouts';
-import isLive from '../isLive';
 
 const logger = nodeLogger(__filename);
 

--- a/src/app/lib/utilities/fetchConfig/index.ts
+++ b/src/app/lib/utilities/fetchConfig/index.ts
@@ -32,7 +32,7 @@ const fetchConfig = async <T>({
   configType,
 }: FetchConfigParams): Promise<T | null> => {
   // TODO: Remove this restriction once we're ready to roll out to all services
-  const shouldFetchConfig = service !== 'indonesia' && !isLive();
+  const shouldFetchConfig = service === 'indonesia';
 
   if (!shouldFetchConfig) return Promise.resolve(null);
 

--- a/src/app/lib/utilities/fetchConfig/index.ts
+++ b/src/app/lib/utilities/fetchConfig/index.ts
@@ -32,7 +32,7 @@ const fetchConfig = async <T>({
   configType,
 }: FetchConfigParams): Promise<T | null> => {
   // TODO: Remove this restriction once we're ready to roll out to all services
-  const shouldFetchConfig = service === 'indonesia' && !isLive();
+  const shouldFetchConfig = service !== 'indonesia' && !isLive();
 
   if (!shouldFetchConfig) return Promise.resolve(null);
 


### PR DESCRIPTION
Resolves JIRA: [WS-2051 ](https://bbc.atlassian.net/browse/WS-2051)

Summary
======
Removes `isLive` check for `serviceConfig` to roll out navigation to be served via iSite for Indonesia service only

Code changes
======

======
- _List key code changes that have been made._

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
