### PR TITLE
NOTICKET- `next.config` isLocal tidy up

### DIFF
--- a/ws-nextjs-app/next.config.js
+++ b/ws-nextjs-app/next.config.js
@@ -1,9 +1,5 @@
 /* eslint-disable no-param-reassign */
-const dotenv = require('dotenv');
 const MomentTimezoneInclude = require('../src/app/legacy/psammead/moment-timezone-include/src');
-const { getClientEnvVars } = require('../src/clientEnvVars');
-
-const DOT_ENV_CONFIG = dotenv.config({ quiet: true });
 
 const assetPrefix =
   process.env.SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN +
@@ -70,7 +66,6 @@ module.exports = {
   generateEtags: false,
   transpilePackages: ['simorgh'],
   env: {
-    ...(isLocal && getClientEnvVars(DOT_ENV_CONFIG, { stringify: false })),
     LOG_TO_CONSOLE: 'true',
     NEXTJS: 'true',
   },

--- a/ws-nextjs-app/next.config.js
+++ b/ws-nextjs-app/next.config.js
@@ -65,7 +65,7 @@ module.exports = {
   reactStrictMode: true,
   distDir: 'build',
   output: 'standalone',
-  assetPrefix: isLocal ? undefined : assetPrefix,
+  assetPrefix,
   poweredByHeader: false,
   generateEtags: false,
   transpilePackages: ['simorgh'],

--- a/ws-nextjs-app/next.config.js
+++ b/ws-nextjs-app/next.config.js
@@ -20,7 +20,6 @@ module.exports = {
           },
         ],
       },
-
       // Service worker headers to allow scope to be set correctly */
       {
         source: '/:service/sw.js',
@@ -58,24 +57,24 @@ module.exports = {
       },
     ];
   },
-  reactStrictMode: true,
-  distDir: 'build',
-  output: 'standalone',
   assetPrefix,
-  poweredByHeader: false,
-  generateEtags: false,
-  transpilePackages: ['simorgh'],
+  compiler: { emotion: true },
+  distDir: 'build',
   env: {
     LOG_TO_CONSOLE: 'true',
     NEXTJS: 'true',
   },
-  compiler: { emotion: true },
+  generateEtags: false,
+  output: 'standalone',
   /*
    Requires pages that are routed to have the .page extension, e.g. [variant].page.tsx,
    which allows for co-locating components within the pages directory, e.g. styles.ts
    - https://nextjs.org/docs/api-reference/next.config.js/custom-page-extensions#including-non-page-files-in-the-pages-directory
   */
   pageExtensions: ['page.tsx', 'page.ts', 'api.tsx', 'api.ts'],
+  poweredByHeader: false,
+  reactStrictMode: true,
+  transpilePackages: ['simorgh'],
   webpack: (config, { webpack, isServer }) => {
     config.resolve.fallback = {
       ...config.resolve.fallback,


### PR DESCRIPTION
Summary
======
Tidies up the `next.config` file by removing specific `isLocal` configurations that are no longer required

Code Changes
======
- Removes `assetPrefix: undefined` when `isLocal` is true, favouring setting `assetPrefix` all the time. This is fine because `.env` file references the asset paths locally and is now being copied across to the Next app correctly with: https://github.com/bbc/simorgh/blob/c739bf27296d87228bcff4e08d243552d1db5227/ws-nextjs-app/package.json#L6. This changes the local asset paths from absolute to relative paths, but is still functionally the same
- Removes setting environment variables explicitly when `isLocal` is true. Similar to above, the `.env` file is copied across to the Next app with https://github.com/bbc/simorgh/blob/c739bf27296d87228bcff4e08d243552d1db5227/ws-nextjs-app/package.json#L6 Next automatically pulls in `.env` file values, so we don't need to explicitly add them in ourselves anymore
- Orders `next.config` values for better readability

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
