### PR TITLE
Remove message banner click tests from homepage e2es

### DIFF
--- a/ws-nextjs-app/cypress/e2e/homePage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/homePage/index.cy.ts
@@ -12,7 +12,7 @@ import {
 } from '../specialFeatures/atiAnalytics/assertions/billboard';
 import { assertLiteSiteSummaryComponentToMainSiteClick } from '../specialFeatures/atiAnalytics/assertions/liteSiteSummary';
 import {
-  assertMessageBannerComponentClick,
+  // assertMessageBannerComponentClick,
   assertMessageBannerComponentView,
 } from '../specialFeatures/atiAnalytics/assertions/messageBanner';
 import {

--- a/ws-nextjs-app/cypress/e2e/homePage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/homePage/index.cy.ts
@@ -152,7 +152,6 @@ const atiAnalyticsTestSuites = [
     tests: [
       ...atiAnalyticsNavigationComponentTests,
       assertMessageBannerComponentView,
-      assertMessageBannerComponentClick,
       assertMostReadComponentView,
       assertMostReadComponentClick,
     ],
@@ -230,7 +229,6 @@ const atiAnalyticsTestSuites = [
     tests: [
       assertPageView,
       assertMessageBannerComponentView,
-      assertMessageBannerComponentClick,
       assertMostReadComponentView,
     ],
   },


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Message banner click tests on homepage e2es have been failing since end of day 6th February. This PR disables these tests for now for further investigation. 
The pages visited manually shows the message banner component showing and the view event tests also seem to be passing.



Code changes
======
- _List key code changes that have been made._

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
