### PR TITLE
FIX: Resolve failing Podcast Promo E2E

### DIFF
--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/podcastPromo.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/podcastPromo.ts
@@ -43,6 +43,20 @@ export const assertPodcastPromoComponentClick = ({
 }: AtiAssertionFnProps) => {
   it('should send a click event for the Podcast Promo component', () => {
     interceptATIAnalyticsBeacons();
+
+    cy.intercept('GET', 'https://www.whatsapp.com/channel/**', request => {
+      request.reply({ statusCode: 200 });
+    }).as('getWhatsAppChannel');
+
+    // cy.intercept(
+    //   {
+    //     url: 'https://www.whatsapp.com/channel/**',
+    //   },
+    //   request => {
+    //     request.reply({ statusCode: 200 });
+    //   },
+    // ).as('getWhatsAppChannel');
+
     cy.visit(path);
 
     cy.get('[data-e2e="podcast-promo"]').scrollIntoView({


### PR DESCRIPTION
Resolves JIRA: 

Summary
======
Resolve failing Gahuza podcast promo click tracking e2e.

Code changes
======
- Intercept navigation to the respective WhatsApp channel for a given service. 

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
