### PR TITLE
Add japanese to list of services with no colon for read time

### DIFF
--- a/src/app/components/ReadTime/index.tsx
+++ b/src/app/components/ReadTime/index.tsx
@@ -34,7 +34,12 @@ const formatReadTime = ({
     'sinhala',
     'yoruba',
   ];
-  const servicesWithoutColon: Services[] = ['igbo', 'pidgin', 'turkce'];
+  const servicesWithoutColon: Services[] = [
+    'igbo',
+    'pidgin',
+    'turkce',
+    'japanese',
+  ];
 
   const separator = servicesWithoutColon.includes(service) ? ' ' : ': ';
 


### PR DESCRIPTION
Resolves JIRA: [WS-1489](https://bbc.atlassian.net/browse/WS-1489)

Summary
======
Add japanese to list of services with no colon

Code changes
======
- Add japanese to list of services with no colon in read time component

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
