### PR TITLE
WS-NA: Disables PV Caorusel on amp

### DIFF
--- a/src/app/components/PortraitVideoCarousel/index.test.tsx
+++ b/src/app/components/PortraitVideoCarousel/index.test.tsx
@@ -51,4 +51,14 @@ describe('PortraitVideoCarousel', () => {
 
     expect(screen.queryByTestId('portrait-video-carousel')).toBeNull();
   });
+
+  it('Should not render anything when isAmp is true', async () => {
+    await act(async () => {
+      render(<Component {...fixture} eventTrackingData={eventTrackingData} />, {
+        isAmp: true,
+      });
+    });
+
+    expect(screen.queryByTestId('portrait-video-carousel')).toBeNull();
+  });
 });

--- a/src/app/components/PortraitVideoCarousel/index.tsx
+++ b/src/app/components/PortraitVideoCarousel/index.tsx
@@ -36,7 +36,7 @@ const PortraitVideoCarousel = ({
     null,
   );
 
-  const { isLite, nonce } = use(RequestContext);
+  const { isLite, isAmp, nonce } = use(RequestContext);
 
   // EXPERIMENT: Homepage Portrait Video 2
   const playDurationExperimentName = 'newswb_ws_homepage_portrait_video';
@@ -61,7 +61,7 @@ const PortraitVideoCarousel = ({
 
   const viewTracker = useViewTracker(eventTrackingDataExtended);
 
-  if (isLite) return null;
+  if (isLite || isAmp) return null;
 
   const handlePromoClick = (index: number) => {
     if (blocks?.[index]?.model?.video) {


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Hides PV Carousel on amp articles. (Should have done this before. E.g. https://www.bbc.com/portuguese/articles/cp817772k2go.amp)

Will not affect homePages since we do not support these on .amp

Code changes
======
- Disables PV Carousel on isAmp
- Adds unit test

Testing
======
Visit http://localhost:7081/portuguese/articles/cp817772k2go.amp?renderer_env=live - see PV Carousel does not render
Visit non-amp http://localhost:7081/portuguese/articles/cp817772k2go?renderer_env=live - see PV Carousel renders as normal

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
