### PR TITLE
WS-NA: Removes Zhongwen readtime translations

### DIFF
--- a/src/app/lib/config/services/zhongwen.ts
+++ b/src/app/lib/config/services/zhongwen.ts
@@ -163,10 +163,6 @@ export const service: ZhongwenConfig = {
     },
     translations: {
       and: '和',
-      readTime: {
-        readTimePrefix: '阅读时间',
-        minute: '分钟',
-      },
       pagination: {
         previousPage: '前页',
         nextPage: '后页',

--- a/src/app/lib/config/services/zhongwen.ts
+++ b/src/app/lib/config/services/zhongwen.ts
@@ -481,10 +481,6 @@ export const service: ZhongwenConfig = {
     },
     translations: {
       and: '和',
-      readTime: {
-        readTimePrefix: '閱讀時間',
-        minute: '分鐘',
-      },
       pagination: {
         previousPage: '前页',
         nextPage: '后页',


### PR DESCRIPTION
Resolves JIRA: WS-NA

Summary
======
Removes Zhongwen article readtime upon editorial request

Code changes
======
- Removes translations, meaning component will not render

Testing
======
Visit http://localhost:7081/zhongwen/articles/c4g0xgydnx4o/simp?renderer_env=live and http://localhost:7081/zhongwen/articles/c4g0xgydnx4o/trad?renderer_env=live and see no readtime

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
