### PR TITLE
[WS-2155] - Bump reverb version

### DIFF
--- a/envConfig/live.env
+++ b/envConfig/live.env
@@ -24,7 +24,7 @@ AWS_EMF_LOG_GROUP_NAME=SimorghServer
 AWS_EMF_ENVIRONMENT=EC2
 
 # Reverb Reporting
-SIMORGH_REVERB_SOURCE=https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.10.2.js
+SIMORGH_REVERB_SOURCE=https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.11.0.js
 
 ## WebVitals Reporting
 SIMORGH_WEBVITALS_REPORTING_ENDPOINT=https://ws.bbc-reporting-api.app/report-endpoint 

--- a/envConfig/local.env
+++ b/envConfig/local.env
@@ -25,7 +25,7 @@ AWS_EMF_LOG_GROUP_NAME=SimorghServer
 AWS_EMF_ENVIRONMENT=Local
 
 # Reverb Reporting
-SIMORGH_REVERB_SOURCE= https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.10.2.js
+SIMORGH_REVERB_SOURCE= https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.11.0.js
 
 ## WebVitals Reporting
 SIMORGH_WEBVITALS_REPORTING_ENDPOINT=https://ws.bbc-reporting-api.app/report-endpoint 

--- a/envConfig/preview1.env
+++ b/envConfig/preview1.env
@@ -24,7 +24,7 @@ AWS_EMF_LOG_GROUP_NAME=SimorghServer
 AWS_EMF_ENVIRONMENT=EC2
 
 # Reverb Reporting
-SIMORGH_REVERB_SOURCE=https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.10.2.js
+SIMORGH_REVERB_SOURCE=https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.11.0.js
 
 ## WebVitals Reporting
 SIMORGH_WEBVITALS_REPORTING_ENDPOINT=https://ws.bbc-reporting-api.app/report-endpoint 

--- a/envConfig/preview2.env
+++ b/envConfig/preview2.env
@@ -24,7 +24,7 @@ AWS_EMF_LOG_GROUP_NAME=SimorghServer
 AWS_EMF_ENVIRONMENT=EC2
 
 # Reverb Reporting
-SIMORGH_REVERB_SOURCE=https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.10.2.js
+SIMORGH_REVERB_SOURCE=https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.11.0.js
 
 ## WebVitals Reporting
 SIMORGH_WEBVITALS_REPORTING_ENDPOINT=https://ws.bbc-reporting-api.app/report-endpoint 

--- a/envConfig/test.env
+++ b/envConfig/test.env
@@ -24,7 +24,7 @@ AWS_EMF_LOG_GROUP_NAME=SimorghServer
 AWS_EMF_ENVIRONMENT=EC2
 
 # Reverb Reporting
-SIMORGH_REVERB_SOURCE=https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.10.2.js
+SIMORGH_REVERB_SOURCE=https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.11.0.js
 
 ## WebVitals Reporting
 SIMORGH_WEBVITALS_REPORTING_ENDPOINT=https://ws.bbc-reporting-api.app/report-endpoint 

--- a/public/sw.js
+++ b/public/sw.js
@@ -53,7 +53,7 @@ const cacheOfflinePageAndResources = async service => {
 
 const CACHEABLE_FILES = [
   // Reverb
-  'https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.10.2.js',
+  'https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.11.0.js',
   // Smart Tag
   'https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/smarttag-5.29.4.min.js',
   // Fonts

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 /* eslint-disable no-undef */
 /* eslint-disable no-restricted-globals */
 
-const version = 'v0.3.3';
+const version = 'v0.3.4';
 // Update cache name when changing caching logic / changes in offlinepage.tsx
 const cacheName = 'simorghCache_v3';
 const pwaClients = new Map();

--- a/src/server/Document/__snapshots__/component.test.jsx.snap
+++ b/src/server/Document/__snapshots__/component.test.jsx.snap
@@ -140,7 +140,7 @@ exports[`Document Component should render APP version correctly 1`] = `
               window.__reverb.__rejectReverbLoaded();
             }, 5000);
             const reverbScript = document.createElement('script');
-            reverbScript.setAttribute('src','https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.10.2.js');
+            reverbScript.setAttribute('src','https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.11.0.js');
             document.head.appendChild(reverbScript);
             
     </script>
@@ -150,7 +150,7 @@ exports[`Document Component should render APP version correctly 1`] = `
       .css-7prgni-StyledLink{display:inline-block;}
     </style>
     <script>
-      window.SIMORGH_ENV_VARS={"SIMORGH_APP_ENV":"local","SIMORGH_ATI_BASE_URL":"https://logws1363.ati-host.net?","SIMORGH_BASE_URL":"http://localhost:7080","SIMORGH_CONFIG_CACHE_ITEMS":"400","SIMORGH_CONFIG_CACHE_MAX_AGE_SECONDS":"300","SIMORGH_CONFIG_TIMEOUT_SECONDS":"5","SIMORGH_CONFIG_URL":"https://config.test.api.bbci.co.uk/","SIMORGH_CSP_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_ICHEF_BASE_URL":"https://ichef.bbci.co.uk","SIMORGH_INCLUDES_BASE_URL":"https://www.test.bbc.com/ws/includes","SIMORGH_INCLUDES_BASE_AMP_URL":"https://news.test.files.bbci.co.uk","SIMORGH_MOST_READ_CDN_URL":"http://localhost:7080","SIMORGH_OPTIMIZELY_SDK_KEY":"LptPKDnHyAFu9V12s5xCz","SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN":"http://localhost:7080","SIMORGH_PUBLIC_STATIC_ASSETS_PATH":"/","SIMORGH_REVERB_SOURCE":"https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.10.2.js","SIMORGH_WEBVITALS_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE":"100"}
+      window.SIMORGH_ENV_VARS={"SIMORGH_APP_ENV":"local","SIMORGH_ATI_BASE_URL":"https://logws1363.ati-host.net?","SIMORGH_BASE_URL":"http://localhost:7080","SIMORGH_CONFIG_CACHE_ITEMS":"400","SIMORGH_CONFIG_CACHE_MAX_AGE_SECONDS":"300","SIMORGH_CONFIG_TIMEOUT_SECONDS":"5","SIMORGH_CONFIG_URL":"https://config.test.api.bbci.co.uk/","SIMORGH_CSP_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_ICHEF_BASE_URL":"https://ichef.bbci.co.uk","SIMORGH_INCLUDES_BASE_URL":"https://www.test.bbc.com/ws/includes","SIMORGH_INCLUDES_BASE_AMP_URL":"https://news.test.files.bbci.co.uk","SIMORGH_MOST_READ_CDN_URL":"http://localhost:7080","SIMORGH_OPTIMIZELY_SDK_KEY":"LptPKDnHyAFu9V12s5xCz","SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN":"http://localhost:7080","SIMORGH_PUBLIC_STATIC_ASSETS_PATH":"/","SIMORGH_REVERB_SOURCE":"https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.11.0.js","SIMORGH_WEBVITALS_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE":"100"}
     </script>
     <script
       type="text/javascript"
@@ -394,7 +394,7 @@ exports[`Document Component should render correctly 1`] = `
               window.__reverb.__rejectReverbLoaded();
             }, 5000);
             const reverbScript = document.createElement('script');
-            reverbScript.setAttribute('src','https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.10.2.js');
+            reverbScript.setAttribute('src','https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.11.0.js');
             document.head.appendChild(reverbScript);
             
     </script>
@@ -404,7 +404,7 @@ exports[`Document Component should render correctly 1`] = `
       .css-7prgni-StyledLink{display:inline-block;}
     </style>
     <script>
-      window.SIMORGH_ENV_VARS={"SIMORGH_APP_ENV":"local","SIMORGH_ATI_BASE_URL":"https://logws1363.ati-host.net?","SIMORGH_BASE_URL":"http://localhost:7080","SIMORGH_CONFIG_CACHE_ITEMS":"400","SIMORGH_CONFIG_CACHE_MAX_AGE_SECONDS":"300","SIMORGH_CONFIG_TIMEOUT_SECONDS":"5","SIMORGH_CONFIG_URL":"https://config.test.api.bbci.co.uk/","SIMORGH_CSP_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_ICHEF_BASE_URL":"https://ichef.bbci.co.uk","SIMORGH_INCLUDES_BASE_URL":"https://www.test.bbc.com/ws/includes","SIMORGH_INCLUDES_BASE_AMP_URL":"https://news.test.files.bbci.co.uk","SIMORGH_MOST_READ_CDN_URL":"http://localhost:7080","SIMORGH_OPTIMIZELY_SDK_KEY":"LptPKDnHyAFu9V12s5xCz","SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN":"http://localhost:7080","SIMORGH_PUBLIC_STATIC_ASSETS_PATH":"/","SIMORGH_REVERB_SOURCE":"https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.10.2.js","SIMORGH_WEBVITALS_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE":"100"}
+      window.SIMORGH_ENV_VARS={"SIMORGH_APP_ENV":"local","SIMORGH_ATI_BASE_URL":"https://logws1363.ati-host.net?","SIMORGH_BASE_URL":"http://localhost:7080","SIMORGH_CONFIG_CACHE_ITEMS":"400","SIMORGH_CONFIG_CACHE_MAX_AGE_SECONDS":"300","SIMORGH_CONFIG_TIMEOUT_SECONDS":"5","SIMORGH_CONFIG_URL":"https://config.test.api.bbci.co.uk/","SIMORGH_CSP_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_ICHEF_BASE_URL":"https://ichef.bbci.co.uk","SIMORGH_INCLUDES_BASE_URL":"https://www.test.bbc.com/ws/includes","SIMORGH_INCLUDES_BASE_AMP_URL":"https://news.test.files.bbci.co.uk","SIMORGH_MOST_READ_CDN_URL":"http://localhost:7080","SIMORGH_OPTIMIZELY_SDK_KEY":"LptPKDnHyAFu9V12s5xCz","SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN":"http://localhost:7080","SIMORGH_PUBLIC_STATIC_ASSETS_PATH":"/","SIMORGH_REVERB_SOURCE":"https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.11.0.js","SIMORGH_WEBVITALS_REPORTING_ENDPOINT":"https://ws.bbc-reporting-api.app/report-endpoint","SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE":"100"}
     </script>
     <script
       type="text/javascript"

--- a/src/sw.test.js
+++ b/src/sw.test.js
@@ -434,8 +434,8 @@ describe('Service Worker', () => {
 
   describe('version', () => {
     const CURRENT_VERSION = {
-      number: 'v0.3.3',
-      fileContentHash: '12d09b3ece7b74e4a02658d93fdec703',
+      number: 'v0.3.4',
+      fileContentHash: '11b6c5326742de4ee45a173c71564d2b',
     };
 
     it(`version number should be ${CURRENT_VERSION.number}`, async () => {

--- a/src/sw.test.js
+++ b/src/sw.test.js
@@ -211,7 +211,7 @@ describe('Service Worker', () => {
       'https://static.test.files.bbci.co.uk/ws/simorgh-assets/public/igbo/images/icons/icon-144x144.png?v=2',
       'https://static.files.bbci.co.uk/ws/simorgh-assets/public/igbo/images/icons/icon-144x144.png?v=2',
       // Reverb - preview1, preview2, test & live
-      'https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.10.2.js',
+      'https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.11.0.js',
       // Smart Tag
       'https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/smarttag-5.29.4.min.js',
     ];

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/serviceWorker/assertions/index.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/serviceWorker/assertions/index.ts
@@ -66,7 +66,7 @@ export const serviceWorkerCaching = () => {
       'woff2',
       'moment-lib',
       'frosted_promo',
-      'https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.10.2.js',
+      'https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/reverb-3.11.0.js',
       'https://mybbc-analytics.files.bbci.co.uk/reverb-client-js/smarttag-5.29.4.min.js',
     ];
 


### PR DESCRIPTION
Resolves [WS-2155](https://bbc.atlassian.net/browse/WS-2155)

Summary
======
Update `reverb` version from `3.10.2` to `3.11.0`


Code changes
======
- Update reverb url in config.

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
