### PR TITLE
NOTICKET- Fix `parseRoute > extractService` service ordering

### DIFF
--- a/src/app/routes/utils/parseRoute/index.test.ts
+++ b/src/app/routes/utils/parseRoute/index.test.ts
@@ -77,6 +77,17 @@ const EXAMPLE_ROUTES = [
     },
   },
   {
+    route: '/ws/av-embeds/cps/zhongwen/simp/world-53107744/p08hnckg/zh-hans',
+    expectedOutput: {
+      service: 'zhongwen',
+      variant: 'simp',
+      platform: 'cps',
+      assetId: 'world-53107744',
+      mediaId: 'p08hnckg',
+      lang: 'zh-hans',
+    },
+  },
+  {
     route: '/ws/av-embeds/live/c7p765ynk9qt/p01thw20/pcm',
     expectedOutput: {
       service: 'ws',

--- a/src/app/routes/utils/parseRoute/index.ts
+++ b/src/app/routes/utils/parseRoute/index.ts
@@ -76,15 +76,14 @@ const LANGS = [
 
 const LANGS_REGEX = new RegExp(`^(${LANGS.join('|')})$`);
 
+const SERVICES_WITHOUT_WS = SERVICES.filter(s => s !== 'ws');
+
 const VARIANTS = ['lat', 'cyr', 'trad', 'simp'] as Variants[];
 
 const extractService = (query: Query): Services | null => {
-  // Prioritise World Service services over the special case 'ws' service
-  const servicesWithoutWs = SERVICES.filter(s => s !== 'ws');
-
   // Check if a valid service appears first, then check for the presence of 'ws' if no other service is found
   const service =
-    servicesWithoutWs.find(s => query?.includes(s)) ||
+    SERVICES_WITHOUT_WS.find(s => query?.includes(s)) ||
     (query?.includes('ws') ? 'ws' : undefined);
 
   return service ?? null;

--- a/src/app/routes/utils/parseRoute/index.ts
+++ b/src/app/routes/utils/parseRoute/index.ts
@@ -79,7 +79,10 @@ const LANGS_REGEX = new RegExp(`^(${LANGS.join('|')})$`);
 const VARIANTS = ['lat', 'cyr', 'trad', 'simp'] as Variants[];
 
 const extractService = (query: Query): Services | null => {
-  const service = SERVICES.find(s => query?.includes(s));
+  const servicesWithoutWs = SERVICES.filter(s => s !== 'ws');
+  const service =
+    servicesWithoutWs.find(s => query?.includes(s)) ||
+    (query?.includes('ws') ? 'ws' : undefined);
 
   return service ?? null;
 };

--- a/src/app/routes/utils/parseRoute/index.ts
+++ b/src/app/routes/utils/parseRoute/index.ts
@@ -79,7 +79,10 @@ const LANGS_REGEX = new RegExp(`^(${LANGS.join('|')})$`);
 const VARIANTS = ['lat', 'cyr', 'trad', 'simp'] as Variants[];
 
 const extractService = (query: Query): Services | null => {
+  // Prioritise World Service services over the special case 'ws' service
   const servicesWithoutWs = SERVICES.filter(s => s !== 'ws');
+
+  // Check if a valid service appears first, then check for the presence of 'ws' if no other service is found
   const service =
     servicesWithoutWs.find(s => query?.includes(s)) ||
     (query?.includes('ws') ? 'ws' : undefined);


### PR DESCRIPTION
Arises from https://github.com/bbc/simorgh/pull/13719

Summary
======
- Amends the `parseRoute > extractService` function to prioritise World Service services _first_ above the special case `ws` service
- This ensures the likes of `/ws/av-embeds/cps/zhongwen/simp/world-53107744/p08hnckg/zh-hans` will extract `zhongwen` instead of `ws` as the actual service, even though alphabetically `ws` appears in the list first

Testing
======
1. Visit http://localhost.bbc.com:7081/ws/av-embeds/cps/zhongwen/simp/world-53107744/p08hnckg/zh-hans/amp?renderer_env=live
2. Ensure the video player renders as expected

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
