### PR TITLE
INI: get md extension running for articles

### DIFF
--- a/src/app/lib/regex.const.js
+++ b/src/app/lib/regex.const.js
@@ -2,6 +2,7 @@ const regexes = {
   AMP_REGEX: /\.amp$/,
   APP_REGEX: /\.app$/,
   LITE_REGEX: /\.lite$/,
+  MARKDOWN_REGEX: /\.md$/,
   TLD_REGEX: /(\.com|\.co\.uk)/g,
 };
 

--- a/src/app/utilities/blocksToMarkdown/index.ts
+++ b/src/app/utilities/blocksToMarkdown/index.ts
@@ -1,0 +1,25 @@
+export default function blocksToMarkdown(blocks: Block[]): string {
+  return blocks.map(block => renderBlock(block)).join('\n\n');
+}
+
+function renderBlock(block: Block): string {
+  switch (block.type) {
+    case 'paragraph':
+      return block.model?.text ?? '';
+    case 'headline':
+      return `# ${block.model?.blocks[0].model.blocks[0].model.text ?? ''}`;
+    case 'subheadline':
+      return `## ${block.model?.blocks[0].model.blocks[0].model.text ?? ''}`;
+    case 'text':
+      const thisBlock = block.model.blocks;
+      const returnText = thisBlock.reduce((acc, block) => {
+        return acc + `${block.model?.text}\r\r`;
+      }, '');
+      return `${returnText ?? ''}`;
+    case 'image':
+        const imgSrc = block.model.blocks[1].type === 'rawImage' ? block.model.blocks[1].model.locator : block.model.blocks[2].model.locator;
+        return `![${block.model.blocks[0].model.blocks[0].model.blocks[0].model.text}](https://ichef.bbci.co.uk/ace/ws/800/cpsprodpb/${imgSrc}.webp)`;
+    default:
+      // console.log(block.type, block);
+  }
+}

--- a/src/app/utilities/getPathExtension/index.ts
+++ b/src/app/utilities/getPathExtension/index.ts
@@ -1,5 +1,5 @@
 import Url from 'url-parse';
-import { APP_REGEX, AMP_REGEX, LITE_REGEX } from '#app/lib/regex.const';
+import { APP_REGEX, AMP_REGEX, LITE_REGEX, MARKDOWN_REGEX } from '#app/lib/regex.const';
 
 export default (url: string) => {
   const { pathname } = new Url(url, true);
@@ -8,5 +8,6 @@ export default (url: string) => {
     isAmp: AMP_REGEX.test(pathname),
     isApp: APP_REGEX.test(pathname),
     isLite: LITE_REGEX.test(pathname),
+    isMarkdown: MARKDOWN_REGEX.test(pathname),
   };
 };

--- a/ws-nextjs-app/pages/[service]/articles/handleArticleRoute.ts
+++ b/ws-nextjs-app/pages/[service]/articles/handleArticleRoute.ts
@@ -10,6 +10,7 @@ import handleError from '#app/routes/utils/handleError';
 import { PageTypes } from '#app/models/types/global';
 
 import { ArticleMetadata } from '#app/models/types/optimo';
+import blocksToMarkdown from '#app/utilities/blocksToMarkdown';
 import augmentWithDisclaimer from './augmentWithDisclaimer';
 import shouldRender from '../../../utilities/shouldRender';
 import getPageData from '../../../utilities/pageRequests/getPageData';
@@ -40,7 +41,7 @@ export default async (context: GetServerSidePropsContext) => {
 
   const resolvedUrlWithoutQuery = resolvedUrl.split('?')?.[0];
 
-  const { isAmp } = getPathExtension(resolvedUrlWithoutQuery);
+  const { isAmp, isMarkdown } = getPathExtension(resolvedUrlWithoutQuery);
   const { variant } = parseRoute(resolvedUrl);
 
   const { data } = await getPageData({
@@ -95,6 +96,13 @@ export default async (context: GetServerSidePropsContext) => {
     'Cache-Control',
     `public, stale-if-error=90, stale-while-revalidate=30, max-age=${maxAge}`,
   );
+  if (isMarkdown) {
+    const markdown = blocksToMarkdown(data?.pageData?.article.content.model.blocks);
+    context.res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+    context.res.setHeader('x-markdown-tokens', Math.floor(markdown.length / 3));    
+    context.res.end(markdown);
+    return { props: {} };
+  }
 
   const {
     topStories = null,


### PR DESCRIPTION
Based on this blog - https://blog.cloudflare.com/markdown-for-agents/ - we're introducing an `.md` extension for articles.

Run on any article - e.g. http://localhost:7081/hindi/articles/c9w59wnx27ro.md 

todo: 
- find a way to track usage
- put into belfrage 
- ideally with an `accept` header regex and redirect - e.g. if accept is `text/markdown` then redirect to the .md equivalent. Failing that put it the md in as a `rel alternate`
- add more page types