### PR TITLE
WS-NA: Removes remaining flake TC2 MAP test assets

### DIFF
--- a/ws-nextjs-app/cypress/e2e/mediaAssetPage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/mediaAssetPage/index.cy.ts
@@ -270,12 +270,13 @@ const tc2CanonicalTestSuites = Cypress.env('SMOKE')
         runforEnv: ['live'],
         tests: canonicalTests,
       },
-      {
-        path: '/afrique/nos_emissions/2016/06/160622_tc2_testmap1?renderer_env=test', // TC2 MAP
-        service: 'afrique',
-        runforEnv: ['test'],
-        tests: canonicalTests,
-      },
+      // DISABLED DUE TO TC2 MAP 500 ERROR FLAKES ON TEST ENVIRONMENT
+      // {
+      //   path: '/afrique/nos_emissions/2016/06/160622_tc2_testmap1?renderer_env=test', // TC2 MAP
+      //   service: 'afrique',
+      //   runforEnv: ['test'],
+      //   tests: canonicalTests,
+      // },
       {
         path: '/arabic/multimedia/2016/06/160601_qatar_sewika_smoking', // TC2 video
         service: 'arabic',
@@ -308,12 +309,13 @@ const tc2CanonicalTestSuites = Cypress.env('SMOKE')
         runforEnv: ['live'],
         tests: canonicalTests,
       },
-      {
-        path: '/russian/news/2016/05/160510_tc2_testmap3?renderer_env=test', // TC2 video
-        service: 'russian',
-        runforEnv: ['test'],
-        tests: canonicalTests,
-      },
+      // DISABLING TESTS DUE TO TOO MANY FLAKES
+      // {
+      //   path: '/russian/news/2016/05/160510_tc2_testmap3?renderer_env=test', // TC2 video
+      //   service: 'russian',
+      //   runforEnv: ['test'],
+      //   tests: canonicalTests,
+      // },
       {
         path: '/swahili/medianuai/2016/05/160517_apatae_fatacky', // TC2 MAP with video clip
         service: 'swahili',

--- a/ws-nextjs-app/cypress/e2e/mediaAssetPage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/mediaAssetPage/index.cy.ts
@@ -341,12 +341,13 @@ const tc2CanonicalTestSuites = Cypress.env('SMOKE')
         runforEnv: ['live'],
         tests: canonicalTests,
       },
-      {
-        path: '/zhongwen/simp/multimedia/2016/11/161107_tc2_testmap1?renderer_env=test', // TC2 Video
-        service: 'zhongwen',
-        runforEnv: ['test'],
-        tests: canonicalTests,
-      },
+      // DISABLED DUE TO TC2 MAP 500 ERROR FLAKES ON TEST ENVIRONMENT
+      // {
+      //   path: '/zhongwen/simp/multimedia/2016/11/161107_tc2_testmap1?renderer_env=test', // TC2 Video
+      //   service: 'zhongwen',
+      //   runforEnv: ['test'],
+      //   tests: canonicalTests,
+      // },
       {
         path: '/zhongwen/trad/multimedia/2016/06/160608_vid_gaokao_voxpop', // TC2 video
         service: 'zhongwen',


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Disables remaining MAP TC2 assets that are returning 500's on first load. (Causing tests to fail)
Noted in Canvas in simorgh-alerts channel

Code changes
======
- Removes tests

Testing
======
Run against test env/ smoke=false e2e tests locally

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
