### PR TITLE
WS-NA: Disables flakey live page e2e test asset

### DIFF
--- a/ws-nextjs-app/cypress/e2e/livePage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/livePage/index.cy.ts
@@ -18,7 +18,7 @@ const testDetails = [
   {
     path: '/pidgin/live/c7p765ynk9qt',
     id: 'c7p765ynk9qt',
-    runforEnv: ['test', 'local'],
+    runforEnv: ['local'],
     service: 'pidgin',
     tests: [
       testsThatAlwaysRunForAllPages,
@@ -55,7 +55,7 @@ const atiAnalyticsTestSuites = [
   },
   {
     path: '/pidgin/live/c7p765ynk9qt',
-    runforEnv: ['local', 'test'],
+    runforEnv: ['local'],
     service: 'pidgin',
     pageIdentifier: 'live_coverage.c7p765ynk9qt.page',
     siteId: 70,


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Removes tests on test for live page asset:`/pidgin/live/c7p765ynk9qt` that has been causing e2e flakes for ages. (We believe caused by a Lambda cold start)
Noted in Slack canvas in simorgh-alerts channel

Code changes
======
- Removes test asset

Testing
======
1. Run cypress tests locally

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
