### PR TITLE
NOTICKET - add `routing_info` logging to non-200 responses

### DIFF
--- a/ws-nextjs-app/pages/[service]/articles/handleArticleRoute.ts
+++ b/ws-nextjs-app/pages/[service]/articles/handleArticleRoute.ts
@@ -68,6 +68,12 @@ export default async (context: GetServerSidePropsContext) => {
   if (!hasRequestSucceeded && renderStatus !== OK) {
     routingInfoLogger = logger.error;
 
+    routingInfoLogger(ROUTING_INFORMATION, {
+      url: resolvedUrlWithoutQuery,
+      status: renderStatus,
+      pageType: ARTICLE_PAGE,
+    });
+
     return {
       props: {
         service,

--- a/ws-nextjs-app/pages/[service]/articles/handleArticleRoute.ts
+++ b/ws-nextjs-app/pages/[service]/articles/handleArticleRoute.ts
@@ -60,7 +60,7 @@ export default async (context: GetServerSidePropsContext) => {
   let routingInfoLogger = logger.debug;
 
   const { hasRequestSucceeded, status: renderStatus } = shouldRender(
-    { pageData, status },
+    { pageData: pageData?.article, status },
     service,
   );
 

--- a/ws-nextjs-app/pages/[service]/articles/handleArticleRoute.ts
+++ b/ws-nextjs-app/pages/[service]/articles/handleArticleRoute.ts
@@ -62,6 +62,7 @@ export default async (context: GetServerSidePropsContext) => {
   const { hasRequestSucceeded, status: renderStatus } = shouldRender(
     { pageData: pageData?.article, status },
     service,
+    ['brasil', 'BBCScotland'], // Passport homes to ignore for service validation
   );
 
   // If request has fails or should not be rendered, return non-200 status

--- a/ws-nextjs-app/pages/[service]/homepage/handleHomepageRoute.test.ts
+++ b/ws-nextjs-app/pages/[service]/homepage/handleHomepageRoute.test.ts
@@ -1,17 +1,9 @@
 import { GetServerSidePropsContext } from 'next';
 import pidginHomepageFixtureData from '#data/pidgin/homePage/index.json';
-import * as shouldRender from '../../../utilities/shouldRender';
 import * as getPageDataModule from '../../../utilities/pageRequests/getPageData';
 import handleHomepageRoute from './handleHomepageRoute';
 
 jest.mock('../../../utilities/pageRequests/getPageData');
-jest.mock('../../../utilities/shouldRender', () => {
-  const originalModule = jest.requireActual('../../../utilities/shouldRender');
-  return {
-    __esModule: true,
-    ...originalModule,
-  };
-});
 
 describe('handleHomepageRoute', () => {
   const mockSetHeader = jest.fn();
@@ -38,7 +30,7 @@ describe('handleHomepageRoute', () => {
     });
   });
 
-  it('returns expected props if shouldRender succeeds', async () => {
+  it('returns expected props if data fetch succeeds', async () => {
     jest.spyOn(Date, 'now').mockImplementation(() => 1234567890000);
 
     const result = await handleHomepageRoute(mockGetServerSidePropsContext);
@@ -47,10 +39,12 @@ describe('handleHomepageRoute', () => {
     expect(result.props.pageType).toEqual('home');
   });
 
-  it('returns error props if shouldRender fails - 500', async () => {
-    jest.spyOn(shouldRender, 'default').mockReturnValue({
-      hasRequestSucceeded: false,
-      status: 500,
+  it('returns error props if data fetch returns 500', async () => {
+    jest.spyOn(getPageDataModule, 'default').mockResolvedValue({
+      data: {
+        pageData: pidginHomepageFixtureData.data,
+        status: 500,
+      },
     });
 
     jest.spyOn(Date, 'now').mockImplementation(() => 1234567890000);
@@ -66,10 +60,12 @@ describe('handleHomepageRoute', () => {
     });
   });
 
-  it('returns error props if shouldRender fails - 404', async () => {
-    jest.spyOn(shouldRender, 'default').mockReturnValue({
-      hasRequestSucceeded: false,
-      status: 404,
+  it('returns error props if data fetch returns 404', async () => {
+    jest.spyOn(getPageDataModule, 'default').mockResolvedValue({
+      data: {
+        pageData: pidginHomepageFixtureData.data,
+        status: 404,
+      },
     });
 
     jest.spyOn(Date, 'now').mockImplementation(() => 1234567890000);

--- a/ws-nextjs-app/pages/[service]/homepage/handleHomepageRoute.ts
+++ b/ws-nextjs-app/pages/[service]/homepage/handleHomepageRoute.ts
@@ -60,6 +60,12 @@ export default async (context: GetServerSidePropsContext) => {
   if (!hasRequestSucceeded && renderStatus !== OK) {
     routingInfoLogger = logger.error;
 
+    routingInfoLogger(ROUTING_INFORMATION, {
+      url: resolvedUrlWithoutQuery,
+      status: renderStatus,
+      pageType: HOME_PAGE,
+    });
+
     return {
       props: {
         service,

--- a/ws-nextjs-app/pages/[service]/homepage/handleHomepageRoute.ts
+++ b/ws-nextjs-app/pages/[service]/homepage/handleHomepageRoute.ts
@@ -7,7 +7,6 @@ import { ROUTING_INFORMATION } from '#app/lib/logger.const';
 import PageDataParams from '#app/models/types/pageDataParams';
 import handleError from '#app/routes/utils/handleError';
 import { getServerExperiments } from '#server/utilities/experimentHeader';
-import shouldRender from '../../../utilities/shouldRender';
 import getPageData from '../../../utilities/pageRequests/getPageData';
 
 const logger = nodeLogger(__filename);
@@ -52,24 +51,19 @@ export default async (context: GetServerSidePropsContext) => {
 
   let routingInfoLogger = logger.debug;
 
-  const { hasRequestSucceeded, status: renderStatus } = shouldRender(
-    { pageData, status },
-    service,
-  );
-
-  if (!hasRequestSucceeded && renderStatus !== OK) {
+  if (status !== OK) {
     routingInfoLogger = logger.error;
 
     routingInfoLogger(ROUTING_INFORMATION, {
       url: resolvedUrlWithoutQuery,
-      status: renderStatus,
+      status,
       pageType: HOME_PAGE,
     });
 
     return {
       props: {
         service,
-        status: renderStatus,
+        status,
         timeOnServer: Date.now(),
         variant: variant || null,
         pageType: HOME_PAGE,

--- a/ws-nextjs-app/pages/[service]/onDemandAudio/handleOnDemandAudioRoute.test.ts
+++ b/ws-nextjs-app/pages/[service]/onDemandAudio/handleOnDemandAudioRoute.test.ts
@@ -1,18 +1,10 @@
 import { GetServerSidePropsContext } from 'next';
 import gahuzaOnDemandAudio from '#data/gahuza/bbc_gahuza_radio/p02pcb5c.json';
 import * as isTest from '#app/lib/utilities/isTest';
-import * as shouldRender from '../../../utilities/shouldRender';
 import * as getPageDataModule from '../../../utilities/pageRequests/getPageData';
 import handleOnDemandAudioRoute from './handleOnDemandAudioRoute';
 
 jest.mock('../../../utilities/pageRequests/getPageData');
-jest.mock('../../../utilities/shouldRender', () => {
-  const originalModule = jest.requireActual('../../../utilities/shouldRender');
-  return {
-    __esModule: true,
-    ...originalModule,
-  };
-});
 
 jest.mock('#app/lib/utilities/isTest', () => {
   const originalModule = jest.requireActual('#app/lib/utilities/isTest');
@@ -47,7 +39,7 @@ describe('handleOnDemandAudioRoute', () => {
     });
   });
 
-  it('returns expected props if shouldRender succeeds', async () => {
+  it('returns expected props if data fetch succeeds', async () => {
     jest.spyOn(Date, 'now').mockImplementation(() => 1234567890000);
 
     const result = await handleOnDemandAudioRoute(
@@ -58,10 +50,12 @@ describe('handleOnDemandAudioRoute', () => {
     expect(result.props.pageType).toEqual('audio');
   });
 
-  it('returns error props if shouldRender fails - 500', async () => {
-    jest.spyOn(shouldRender, 'default').mockReturnValue({
-      hasRequestSucceeded: false,
-      status: 500,
+  it('returns error props if data fetch returns 500', async () => {
+    jest.spyOn(getPageDataModule, 'default').mockResolvedValue({
+      data: {
+        pageData: gahuzaOnDemandAudio,
+        status: 500,
+      },
     });
 
     jest.spyOn(Date, 'now').mockImplementation(() => 1234567890000);
@@ -79,10 +73,12 @@ describe('handleOnDemandAudioRoute', () => {
     });
   });
 
-  it('returns error props if shouldRender fails - 404', async () => {
-    jest.spyOn(shouldRender, 'default').mockReturnValue({
-      hasRequestSucceeded: false,
-      status: 404,
+  it('returns error props if data fetch returns 404', async () => {
+    jest.spyOn(getPageDataModule, 'default').mockResolvedValue({
+      data: {
+        pageData: gahuzaOnDemandAudio,
+        status: 404,
+      },
     });
 
     jest.spyOn(Date, 'now').mockImplementation(() => 1234567890000);

--- a/ws-nextjs-app/pages/[service]/onDemandAudio/handleOnDemandAudioRoute.ts
+++ b/ws-nextjs-app/pages/[service]/onDemandAudio/handleOnDemandAudioRoute.ts
@@ -5,7 +5,6 @@ import parseRoute from '#app/routes/utils/parseRoute';
 import { NOT_FOUND, OK } from '#app/lib/statusCodes.const';
 import getPageData from '#nextjs/utilities/pageRequests/getPageData';
 import nodeLogger from '#lib/logger.node';
-import shouldRender from '#nextjs/utilities/shouldRender';
 import { ROUTING_INFORMATION } from '#app/lib/logger.const';
 import handleError from '#app/routes/utils/handleError';
 import getPodcastExternalLinks from '#app/routes/onDemandAudio/podcastExternalLinks';
@@ -64,24 +63,19 @@ export default async (context: GetServerSidePropsContext) => {
 
   let routingInfoLogger = logger.debug;
 
-  const { hasRequestSucceeded, status: renderStatus } = shouldRender(
-    { pageData, status },
-    service,
-  );
-
-  if (!hasRequestSucceeded && renderStatus !== OK) {
+  if (status !== OK) {
     routingInfoLogger = logger.error;
 
     routingInfoLogger(ROUTING_INFORMATION, {
       url: resolvedUrlWithoutQuery,
-      status: renderStatus,
+      status,
       pageType: AUDIO_PAGE,
     });
 
     return {
       props: {
         service,
-        status: renderStatus,
+        status,
         timeOnServer: Date.now(),
         variant: variant || null,
         pageType: AUDIO_PAGE,

--- a/ws-nextjs-app/pages/[service]/onDemandAudio/handleOnDemandAudioRoute.ts
+++ b/ws-nextjs-app/pages/[service]/onDemandAudio/handleOnDemandAudioRoute.ts
@@ -72,6 +72,12 @@ export default async (context: GetServerSidePropsContext) => {
   if (!hasRequestSucceeded && renderStatus !== OK) {
     routingInfoLogger = logger.error;
 
+    routingInfoLogger(ROUTING_INFORMATION, {
+      url: resolvedUrlWithoutQuery,
+      status: renderStatus,
+      pageType: AUDIO_PAGE,
+    });
+
     return {
       props: {
         service,

--- a/ws-nextjs-app/pages/[service]/onDemandAudio/index.test.tsx
+++ b/ws-nextjs-app/pages/[service]/onDemandAudio/index.test.tsx
@@ -18,7 +18,6 @@ import { GetServerSidePropsContext } from 'next';
 import { ToggleContextProvider } from '#app/contexts/ToggleContext';
 import _OnDemandAudioPage from './OnDemandAudioLayout';
 import { OnDemandAudioProps } from './types';
-import * as shouldRender from '../../../utilities/shouldRender';
 import * as getPageDataModule from '../../../utilities/pageRequests/getPageData';
 import handleOnDemandAudioRoute from './handleOnDemandAudioRoute';
 
@@ -39,23 +38,13 @@ const mockToggles = {
 };
 
 jest.mock('../../../utilities/pageRequests/getPageData');
-jest.mock('../../../utilities/shouldRender', () => {
-  const originalModule = jest.requireActual('../../../utilities/shouldRender');
-  return {
-    __esModule: true,
-    ...originalModule,
-  };
-});
+
 jest.mock('react-helmet', () => {
   return {
     Helmet: ({ children }: { children: React.ReactNode }) => (
       <div>{children}</div>
     ),
   };
-});
-jest.spyOn(shouldRender, 'default').mockReturnValue({
-  hasRequestSucceeded: true,
-  status: 200,
 });
 
 interface PageProps {

--- a/ws-nextjs-app/pages/[service]/topics/[id]/[[...variant]].page.test.tsx
+++ b/ws-nextjs-app/pages/[service]/topics/[id]/[[...variant]].page.test.tsx
@@ -1,19 +1,9 @@
 import { GetServerSidePropsContext } from 'next';
 import pidginTopicFixtureData from '#data/pidgin/topics/c95y35941vrt.json';
-import * as shouldRender from '../../../../utilities/shouldRender';
 import * as getPageDataModule from '../../../../utilities/pageRequests/getPageData';
 import { getServerSideProps as handleTopicRoute } from './[[...variant]].page';
 
 jest.mock('../../../../utilities/pageRequests/getPageData');
-jest.mock('../../../../utilities/shouldRender', () => {
-  const originalModule = jest.requireActual(
-    '../../../../utilities/shouldRender',
-  );
-  return {
-    __esModule: true,
-    ...originalModule,
-  };
-});
 
 describe('handleTopicRoute', () => {
   const mockSetHeader = jest.fn();
@@ -41,7 +31,7 @@ describe('handleTopicRoute', () => {
     });
   });
 
-  it('returns expected props if shouldRender succeeds', async () => {
+  it('returns expected props if data fetch succeeds', async () => {
     jest.spyOn(Date, 'now').mockImplementation(() => 1234567890000);
 
     const result = await handleTopicRoute(mockGetServerSidePropsContext);
@@ -50,10 +40,12 @@ describe('handleTopicRoute', () => {
     expect(result.props.pageType).toEqual('topic');
   });
 
-  it('returns error props if shouldRender fails - 500', async () => {
-    jest.spyOn(shouldRender, 'default').mockReturnValue({
-      hasRequestSucceeded: false,
-      status: 500,
+  it('returns error props if data fetch returns 500', async () => {
+    jest.spyOn(getPageDataModule, 'default').mockResolvedValue({
+      data: {
+        pageData: pidginTopicFixtureData.data,
+        status: 500,
+      },
     });
 
     jest.spyOn(Date, 'now').mockImplementation(() => 1234567890000);
@@ -69,10 +61,12 @@ describe('handleTopicRoute', () => {
     });
   });
 
-  it('returns error props if shouldRender fails - 404', async () => {
-    jest.spyOn(shouldRender, 'default').mockReturnValue({
-      hasRequestSucceeded: false,
-      status: 404,
+  it('returns error props if data fetch returns 404', async () => {
+    jest.spyOn(getPageDataModule, 'default').mockResolvedValue({
+      data: {
+        pageData: pidginTopicFixtureData.data,
+        status: 404,
+      },
     });
 
     jest.spyOn(Date, 'now').mockImplementation(() => 1234567890000);

--- a/ws-nextjs-app/pages/[service]/topics/[id]/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/topics/[id]/[[...variant]].page.tsx
@@ -8,7 +8,6 @@ import { OK } from '#app/lib/statusCodes.const';
 import PageDataParams from '#app/models/types/pageDataParams';
 import deriveVariant from '#nextjs/utilities/deriveVariant';
 import isTest from '#app/lib/utilities/isTest';
-import shouldRender from '#nextjs/utilities/shouldRender';
 import handleError from '#app/routes/utils/handleError';
 import getPageData from '../../../../utilities/pageRequests/getPageData';
 
@@ -54,24 +53,19 @@ export const getServerSideProps = async (
 
   let routingInfoLogger = logger.debug;
 
-  const { hasRequestSucceeded, status: renderStatus } = shouldRender(
-    { pageData: data.pageData, status: data.status },
-    service,
-  );
-
-  if (!hasRequestSucceeded && renderStatus !== OK) {
+  if (status !== OK) {
     routingInfoLogger = logger.error;
 
     routingInfoLogger(ROUTING_INFORMATION, {
       url: resolvedUrlWithoutQuery,
-      status: renderStatus,
+      status,
       pageType: TOPIC_PAGE,
     });
 
     return {
       props: {
         service,
-        status: renderStatus,
+        status,
         timeOnServer: Date.now(),
         variant,
         pageType: TOPIC_PAGE,

--- a/ws-nextjs-app/pages/[service]/topics/[id]/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/topics/[id]/[[...variant]].page.tsx
@@ -84,7 +84,7 @@ export const getServerSideProps = async (
   );
 
   routingInfoLogger(ROUTING_INFORMATION, {
-    url: context.resolvedUrl,
+    url: resolvedUrlWithoutQuery,
     status: data.status,
     pageType: TOPIC_PAGE,
   });
@@ -102,7 +102,7 @@ export const getServerSideProps = async (
         },
       },
       pageType: TOPIC_PAGE,
-      pathname: context.resolvedUrl,
+      pathname: resolvedUrlWithoutQuery,
       service,
       status: data.status,
       timeOnServer: Date.now(),

--- a/ws-nextjs-app/pages/[service]/topics/[id]/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/topics/[id]/[[...variant]].page.tsx
@@ -19,7 +19,9 @@ const logger = nodeLogger(__filename);
 export const getServerSideProps = async (
   context: GetServerSidePropsContext,
 ) => {
-  logResponseTime({ path: context.resolvedUrl }, context.res, () => null);
+  const { resolvedUrl } = context;
+
+  logResponseTime({ path: resolvedUrl }, context.res, () => null);
 
   const {
     id,
@@ -34,13 +36,15 @@ export const getServerSideProps = async (
   const rendererEnv =
     isTest() && !rendererEnvFromQuery ? 'live' : rendererEnvFromQuery;
 
+  const resolvedUrlWithoutQuery = resolvedUrl.split('?')?.[0];
+
   const { data } = await getPageData({
     id,
     page,
     service,
     variant,
     rendererEnv,
-    resolvedUrl: context.resolvedUrl,
+    resolvedUrl: resolvedUrlWithoutQuery,
     pageType: TOPIC_PAGE,
   });
 
@@ -58,6 +62,12 @@ export const getServerSideProps = async (
   if (!hasRequestSucceeded && renderStatus !== OK) {
     routingInfoLogger = logger.error;
 
+    routingInfoLogger(ROUTING_INFORMATION, {
+      url: resolvedUrlWithoutQuery,
+      status: renderStatus,
+      pageType: TOPIC_PAGE,
+    });
+
     return {
       props: {
         service,
@@ -65,7 +75,7 @@ export const getServerSideProps = async (
         timeOnServer: Date.now(),
         variant,
         pageType: TOPIC_PAGE,
-        pathname: context.resolvedUrl,
+        pathname: resolvedUrlWithoutQuery,
       },
     };
   }


### PR DESCRIPTION
Summary
======
- Adds `routing_info` logging events for non-200 responses for Article/Homepage/Topic/ODAudio routes as these routes didn't log this event 
- Removes `shouldRender` function from Homepage/Topic/ODAudio routes as this function didn't actually check anything. This part of the condition always returned `true` for these page types, so its not really needed: https://github.com/bbc/simorgh/blob/d03d06e0a0e3025b46c1546d297a3f4da93ff0e9/src/app/lib/utilities/passport/index.js#L19-L20
- Passes the correct article metadata to the `shouldRender` function as it too always passed this check prior to this change
- Passes in `passportHomeOverrides` array to the article `shouldRender` function to ensure services with a different valid 'home' still work

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
