### PR TITLE
NOTICKET - Add `force:true` to nav dropdown click e2e

### DIFF
--- a/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
+++ b/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
@@ -68,7 +68,7 @@ export default ({ service, pageType }: ServiceParametersType) => {
         cy.viewport(320, 480);
         cy.get('nav').find('[data-e2e="scrollable-nav"]').should('be.visible');
 
-        cy.get('nav button').click();
+        cy.get('nav button').click({ force: true });
 
         cy.get('nav')
           .find('[data-e2e="scrollable-nav-secondary"] ul')


### PR DESCRIPTION
Summary
======
- Adds `force: true` to mobile nav dropdown button click e2e test to see if it helps with an error about the element being covered by another element. Checking the DOM on Test doesn't show this issue, and the test passes when ran locally

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
