### PR TITLE
NOTICKET - Fix article links block title on darkUi

### DIFF
--- a/src/app/components/ArticleLinksBlock/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/ArticleLinksBlock/__snapshots__/index.test.tsx.snap
@@ -64,11 +64,10 @@ exports[`Article Links Block Mid Page Article Links Block it should match a11y s
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #F6F6F6;
   width: 100%;
   height: 2rem;
   color: #3F3F42;
-  padding: 0 0.5rem;
+  padding: 0 1rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -92,18 +91,9 @@ exports[`Article Links Block Mid Page Article Links Block it should match a11y s
   }
 }
 
-@media (max-width: 14.9375rem) {
+@media (min-width: 63rem) {
   .emotion-4 {
-    margin-inline: 0.5rem;
-    margin: 0;
-  }
-}
-
-@media (min-width: 25rem) {
-  .emotion-4 {
-    margin-inline: 1rem;
-    padding: 0 1rem;
-    margin: 0 -0.2rem;
+    padding: 0;
   }
 }
 
@@ -687,11 +677,10 @@ exports[`Article Links Block Mid Page Article Links Block it should match a11y s
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #F6F6F6;
   width: 100%;
   height: 2rem;
   color: #3F3F42;
-  padding: 0 0.5rem;
+  padding: 0 1rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -715,18 +704,9 @@ exports[`Article Links Block Mid Page Article Links Block it should match a11y s
   }
 }
 
-@media (max-width: 14.9375rem) {
+@media (min-width: 63rem) {
   .emotion-4 {
-    margin-inline: 0.5rem;
-    margin: 0;
-  }
-}
-
-@media (min-width: 25rem) {
-  .emotion-4 {
-    margin-inline: 1rem;
-    padding: 0 1rem;
-    margin: 0 -0.2rem;
+    padding: 0;
   }
 }
 

--- a/src/app/components/ArticleLinksBlock/index.styles.tsx
+++ b/src/app/components/ArticleLinksBlock/index.styles.tsx
@@ -26,24 +26,18 @@ export default {
       ...fontVariants.sansRegular,
       display: 'flex',
       alignItems: 'center',
-      backgroundColor: palette.GREY_2,
       width: '100%',
       height: `${spacings.QUADRUPLE}rem`,
       color: isDarkUi ? palette.GREY_2 : palette.SHADOW,
-      padding: `0 ${spacings.FULL}rem`,
+      padding: `0 ${spacings.DOUBLE}rem`,
+
       [mq.FORCED_COLOURS]: {
         border: `solid ${pixelsToRem(3)}rem transparent`,
         borderBottom: 'transparent',
       },
 
-      [mq.GROUP_0_MAX_WIDTH]: {
-        marginInline: `${spacings.FULL}rem`,
-        margin: 0,
-      },
-      [mq.GROUP_2_MIN_WIDTH]: {
-        marginInline: `${spacings.DOUBLE}rem`,
-        padding: `0 ${spacings.DOUBLE}rem`,
-        margin: '0 -0.2rem',
+      [mq.GROUP_4_MIN_WIDTH]: {
+        padding: 0,
       },
     }),
 };


### PR DESCRIPTION
Summary
======
Fixes the background colour of the article links block title/label on dark backgrounds

| Before      | After |
| ----------- | ----------- |
|<img width="768" height="739" alt="Screenshot 2026-03-11 at 08 59 16" src="https://github.com/user-attachments/assets/b5387ceb-7ff8-47a4-902b-b69e9b62c5fa" />|<img width="780" height="693" alt="Screenshot 2026-03-11 at 08 58 53" src="https://github.com/user-attachments/assets/8d13ce3d-165d-4935-986a-1b83d9f12713" />|

Code changes
======
- Removes `backgroundColor` from label styling to make it transparent and use the background colour of the article itself
- Fixes some padding/margins on the title to align it with the link blocks

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
