### PR TITLE
WS-2276 Add translations for the Latest Post Button

### DIFF
--- a/src/app/lib/config/services/afaanoromoo.ts
+++ b/src/app/lib/config/services/afaanoromoo.ts
@@ -106,6 +106,8 @@ export const service: DefaultServiceConfig = {
         postedAt: '...tti maxxanfame',
         summary: 'Guduunfaa',
         shareButtonText: 'Qoodi',
+        refreshButtonText: 'Poostii Haaraa',
+        visuallyHiddenButtonText: 'Poostiin haaraa jira',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -111,6 +111,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Posté à',
         summary: 'Points clés',
         shareButtonText: 'Partager',
+        refreshButtonText: 'Dernier message',
+        visuallyHiddenButtonText: 'Nouveau message disponible',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/amharic.ts
+++ b/src/app/lib/config/services/amharic.ts
@@ -104,6 +104,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'የታተመዉ',
         summary: 'ጭምቅ ሃሳብ',
         shareButtonText: 'ያጋሩ',
+        refreshButtonText: 'የቅርብ መልዕክት',
+        visuallyHiddenButtonText: 'አዲስ ፖስት ዝግጁ ነው',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/arabic.ts
+++ b/src/app/lib/config/services/arabic.ts
@@ -100,6 +100,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'توقيت النشر',
         summary: 'ملخص',
         shareButtonText: 'شارك',
+        refreshButtonText: 'أحدث منشور',
+        visuallyHiddenButtonText: 'منشور جديد متاح',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/azeri.ts
+++ b/src/app/lib/config/services/azeri.ts
@@ -99,6 +99,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Xəbərin vaxtı',
         summary: 'Xülasə',
         shareButtonText: 'Paylaş',
+        refreshButtonText: 'Ən son post',
+        visuallyHiddenButtonText: 'Yeni paylaşım mövcuddur',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -111,6 +111,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'পোস্ট করা হয়েছে',
         summary: 'সার সংক্ষেপ',
         shareButtonText: 'শেয়ার করুন',
+        refreshButtonText: 'সর্বশেষ পোস্ট',
+        visuallyHiddenButtonText: 'নতুন পোস্ট উপলব্ধ',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/burmese.ts
+++ b/src/app/lib/config/services/burmese.ts
@@ -105,6 +105,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'ပို့စ် တင်တဲ့အချိန်',
         summary: 'အနှစ်ချုပ်',
         shareButtonText: 'ဝေမျှပါ',
+        refreshButtonText: 'နောက်ဆုံးပိုစ့်',
+        visuallyHiddenButtonText: 'ပိုစ့်အသစ်',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/dari.ts
+++ b/src/app/lib/config/services/dari.ts
@@ -89,6 +89,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'به روزشده در',
         summary: 'خلاصه',
         shareButtonText: 'هم‌رسانی',
+        refreshButtonText: 'آخرین پست',
+        visuallyHiddenButtonText: 'پست تازه در دسترس است',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/gahuza.ts
+++ b/src/app/lib/config/services/gahuza.ts
@@ -103,6 +103,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Vyashizwe isaha',
         summary: 'Incamake',
         shareButtonText: 'Sangira',
+        refreshButtonText: 'Inkuru ya vuba',
+        visuallyHiddenButtonText: 'Raba inkuru ya vuba',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/gujarati.ts
+++ b/src/app/lib/config/services/gujarati.ts
@@ -99,6 +99,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'અહીં પોસ્ટ કર્યું',
         summary: 'સારાંશ',
         shareButtonText: 'શેર કરો',
+        refreshButtonText: 'છેલ્લી પોસ્ટ',
+        visuallyHiddenButtonText: 'નવો પોસ્ટ ઉપલબ્ધ છે',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/hausa.ts
+++ b/src/app/lib/config/services/hausa.ts
@@ -109,6 +109,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'An wallafa a',
         summary: 'Taƙaitattu',
         shareButtonText: 'Aika',
+        refreshButtonText: 'Sabon bayani',
+        visuallyHiddenButtonText: 'Sabon bayanin ya samu',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -101,6 +101,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'पोस्ट किया गया',
         summary: 'सारांश',
         shareButtonText: 'साझा कीजिए',
+        refreshButtonText: 'नवीनतम पोस्ट',
+        visuallyHiddenButtonText: 'नया पोस्ट उपलब्ध है',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/igbo.ts
+++ b/src/app/lib/config/services/igbo.ts
@@ -99,6 +99,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Ebisara na',
         summary: 'Nchịkọta',
         shareButtonText: 'Kekọrịta',
+        refreshButtonText: 'Ọhụrụ ihe e dere',
+        visuallyHiddenButtonText: 'E nwere ozi ọhụrụ dị',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/indonesia.ts
+++ b/src/app/lib/config/services/indonesia.ts
@@ -101,6 +101,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Diterbitkan di',
         summary: 'Rangkuman',
         shareButtonText: 'Kirim',
+        refreshButtonText: 'Postingan terbaru',
+        visuallyHiddenButtonText: 'Postingan baru tersedia',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/japanese.ts
+++ b/src/app/lib/config/services/japanese.ts
@@ -81,6 +81,8 @@ export const service: DefaultServiceConfig = {
         postedAt: '投稿時間',
         summary: '要点',
         shareButtonText: '共有する',
+        refreshButtonText: '最新の投稿',
+        visuallyHiddenButtonText: '新しい投稿があります',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -80,6 +80,8 @@ export const service: DefaultServiceConfig = {
         postedAt: '작성',
         summary: '요약',
         shareButtonText: '공유',
+        refreshButtonText: '최신 게시',
+        visuallyHiddenButtonText: '새 게시물이 있습니다',
       },
       downloads: {
         instructions: '오늘의 뉴스를 다운받아 보실 수 있습니다',

--- a/src/app/lib/config/services/kyrgyz.ts
+++ b/src/app/lib/config/services/kyrgyz.ts
@@ -99,6 +99,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Чыгарылган убакыт',
         summary: 'Корутунду',
         shareButtonText: 'Бөлүшүү',
+        refreshButtonText: 'Акыркы маалымат',
+        visuallyHiddenButtonText: 'Жаңы маалымат жарыяланды',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -96,6 +96,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'वाजता पोस्ट केलं',
         summary: 'थोडक्यात',
         shareButtonText: 'शेअर करा',
+        refreshButtonText: 'ताज्या पोस्ट',
+        visuallyHiddenButtonText: 'नवीन पोस्ट उपलब्ध आहे',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -126,6 +126,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Publicado',
         summary: 'Puntos clave',
         shareButtonText: 'Compartir',
+        refreshButtonText: 'Última publicación',
+        visuallyHiddenButtonText: 'Nueva publicación disponible',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/nepali.ts
+++ b/src/app/lib/config/services/nepali.ts
@@ -92,6 +92,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'पोस्ट गरिएको',
         summary: 'सारांश',
         shareButtonText: 'शेयर गर्नुहोस्',
+        refreshButtonText: 'नयाँ पोस्ट',
+        visuallyHiddenButtonText: 'नयाँ पोस्ट उपलब्ध छ',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/pashto.ts
+++ b/src/app/lib/config/services/pashto.ts
@@ -93,6 +93,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'د خپرېدو نیټه',
         summary: 'لنډیز',
         shareButtonText: 'شریک یې کړئ',
+        refreshButtonText: 'وروستی پوسټ',
+        visuallyHiddenButtonText: 'نوی پوست شتون لري',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -112,6 +112,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'به روزشده در',
         summary: 'خلاصه',
         shareButtonText: 'هم‌رسانی',
+        refreshButtonText: 'تازه‌ترین خبر',
+        visuallyHiddenButtonText: 'خبر تازه در دسترس است',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/pidgin.ts
+++ b/src/app/lib/config/services/pidgin.ts
@@ -82,6 +82,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Posted at',
         summary: 'Summary',
         shareButtonText: 'Share dis tori',
+        refreshButtonText: 'Las post',
+        visuallyHiddenButtonText: 'New post dey',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/polska.ts
+++ b/src/app/lib/config/services/polska.ts
@@ -95,6 +95,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Opublikowano o',
         summary: 'Podsumowanie',
         shareButtonText: 'Udostępnij',
+        refreshButtonText: 'Najnowszy wpis',
+        visuallyHiddenButtonText: 'Nowy wpis dostępny',
       },
       downloads: {
         instructions: 'Możesz pobrać i obejrzeć dzisiejsze wiadomości.',

--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -103,6 +103,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Publicado às',
         summary: 'Pontos-chave',
         shareButtonText: 'Compartilhar',
+        refreshButtonText: 'Última postagem',
+        visuallyHiddenButtonText: 'Nova publicação disponível',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/punjabi.ts
+++ b/src/app/lib/config/services/punjabi.ts
@@ -81,6 +81,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'ਇਸ ‘ਤੇ ਪੋਸਟ ਕੀਤਾ',
         summary: 'ਸਾਰ',
         shareButtonText: 'ਸਾਂਝਾ ਕਰੋ',
+        refreshButtonText: 'ਤਾਜਾ ਪੋਸਟ',
+        visuallyHiddenButtonText: 'ਨਵਾਂ ਪੋਸਟ ਉਪਲਬਧ ਹੈ',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/romania.ts
+++ b/src/app/lib/config/services/romania.ts
@@ -96,6 +96,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Postat la',
         summary: 'Sumar',
         shareButtonText: 'Trimite',
+        refreshButtonText: 'Ultima actualizare',
+        visuallyHiddenButtonText: 'O nouă actualizare',
       },
       downloads: {
         instructions: 'Puteți descărca și vizualiza știrile de astăzi.',

--- a/src/app/lib/config/services/russianUkrainianSharedTranslations.ts
+++ b/src/app/lib/config/services/russianUkrainianSharedTranslations.ts
@@ -25,6 +25,8 @@ export default {
     postedAt: 'Отправлено в',
     summary: 'Коротко',
     shareButtonText: 'Поделиться',
+    refreshButtonText: 'Последний пост',
+    visuallyHiddenButtonText: 'Вышел новый пост',
   },
   downloads: {
     instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -161,6 +161,8 @@ export const service: SerbianConfig = {
         postedAt: 'Objavljeno u',
         summary: 'Sažetak',
         shareButtonText: 'Deli',
+        refreshButtonText: 'Najnoviji post',
+        visuallyHiddenButtonText: 'Dostupan je novi post',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',
@@ -549,6 +551,8 @@ export const service: SerbianConfig = {
         postedAt: 'Објављено у',
         summary: 'Сажетак',
         shareButtonText: 'Дели',
+        refreshButtonText: 'Последњи пост',
+        visuallyHiddenButtonText: 'Доступан је нови пост',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/sinhala.ts
+++ b/src/app/lib/config/services/sinhala.ts
@@ -107,6 +107,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'යාවත්කාලීන කළේ',
         summary: 'සාරාංශය',
         shareButtonText: 'යවන්න',
+        refreshButtonText: 'නවතම පළ කිරීම',
+        visuallyHiddenButtonText: 'නව පළ කිරීමක් තිබේ',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/somali.ts
+++ b/src/app/lib/config/services/somali.ts
@@ -100,6 +100,8 @@ export const service: DefaultServiceConfig = {
         postedAt: '',
         summary: 'Kooban',
         shareButtonText: 'La wadaag',
+        refreshButtonText: 'Qoraalka ugu dambeeya',
+        visuallyHiddenButtonText: 'Qoraal cusub ayaa diyaar ah',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/swahili.ts
+++ b/src/app/lib/config/services/swahili.ts
@@ -113,6 +113,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Imepakiwa mnamo',
         summary: 'Muhtasari',
         shareButtonText: 'Mshirikishe mwenzako',
+        refreshButtonText: 'Chapisho jipya',
+        visuallyHiddenButtonText: 'Chapisho jipya kinapatikana',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/tamil.ts
+++ b/src/app/lib/config/services/tamil.ts
@@ -83,6 +83,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'பிரசுரிக்கப்பட்ட நேரம்',
         summary: 'முக்கிய சாராம்சம்',
         shareButtonText: 'பகிர்க',
+        refreshButtonText: 'சமீபத்திய பதிவு',
+        visuallyHiddenButtonText: 'புதிய பதிவு கிடைக்கிறது',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/telugu.ts
+++ b/src/app/lib/config/services/telugu.ts
@@ -81,6 +81,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'పోస్ట్ చేసిన సమయం',
         summary: 'సారాంశం',
         shareButtonText: 'షేర్ చేయండి',
+        refreshButtonText: 'తాజా పోสต์',
+        visuallyHiddenButtonText: 'కొత్త పోస్ట్ అందుబాటులో ఉంది',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/thai.ts
+++ b/src/app/lib/config/services/thai.ts
@@ -80,6 +80,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'โพสต์ทาง',
         summary: 'สรุป',
         shareButtonText: 'แชร์"',
+        refreshButtonText: 'โพสต์ล่าสุด',
+        visuallyHiddenButtonText: 'มีโพสต์ใหม่',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/tigrinya.ts
+++ b/src/app/lib/config/services/tigrinya.ts
@@ -108,6 +108,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'ዝተለጠፈሉ',
         summary: 'ጽማቝ ሓበሬታ',
         shareButtonText: 'ኣባፅሑ',
+        refreshButtonText: 'መጨረሻ ፖስት',
+        visuallyHiddenButtonText: 'ፖስት ሓድሽ ኣሎ',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -84,6 +84,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Basım saati',
         summary: 'Özet',
         shareButtonText: 'Paylaş',
+        refreshButtonText: 'Son gönderi',
+        visuallyHiddenButtonText: 'Yeni gönderi mevcut',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/ukrainian.ts
+++ b/src/app/lib/config/services/ukrainian.ts
@@ -94,6 +94,8 @@ const baseServiceConfig = {
       postedAt: 'Опубілковано о',
       summary: 'Стисло',
       shareButtonText: 'Поділитися',
+      refreshButtonText: 'Останній допис',
+      visuallyHiddenButtonText: 'Доступний новий допис',
     },
     downloads: {
       instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/urdu.ts
+++ b/src/app/lib/config/services/urdu.ts
@@ -112,6 +112,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'پوسٹ کیا گیا',
         summary: 'خلاصہ',
         shareButtonText: 'شیئر',
+        refreshButtonText: 'تازہ ترین پوسٹ',
+        visuallyHiddenButtonText: 'نئی پوسٹ دستیاب ہے',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -93,6 +93,8 @@ const defaultCyrillicConfig = {
       postedAt: '...да чоп этилган',
       summary: 'Қисқача',
       shareButtonText: 'Баҳам кўринг',
+      refreshButtonText: 'Охирги пост',
+      visuallyHiddenButtonText: 'Янги пост мавжуд',
     },
     downloads: {
       instructions: 'You can download and view today’s news.',
@@ -419,6 +421,8 @@ export const service: UzbekConfig = {
         postedAt: '...da chop etilgan',
         summary: 'Qisqacha',
         shareButtonText: 'Baham ko‘rinг',
+        refreshButtonText: 'Oxirgi post',
+        visuallyHiddenButtonText: 'Yangi post mavjud',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/vietnamese.ts
+++ b/src/app/lib/config/services/vietnamese.ts
@@ -82,6 +82,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Đăng ở',
         summary: 'Tóm tắt',
         shareButtonText: 'Chia sẻ',
+        refreshButtonText: 'Bài viết mới nhất',
+        visuallyHiddenButtonText: 'Có bài viết mới',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/yoruba.ts
+++ b/src/app/lib/config/services/yoruba.ts
@@ -94,6 +94,8 @@ export const service: DefaultServiceConfig = {
         postedAt: 'Tí a fiṣọwọ́ ní',
         summary: 'Ìsọníṣókí',
         shareButtonText: 'Ṣe alábàápín',
+        refreshButtonText: 'Ifiweranṣẹ tuntun',
+        visuallyHiddenButtonText: 'Ifiweranṣẹ tuntun wa',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',

--- a/src/app/lib/config/services/zhongwen.ts
+++ b/src/app/lib/config/services/zhongwen.ts
@@ -165,6 +165,8 @@ export const service: ZhongwenConfig = {
         shareButtonText: '分享',
         postDateTimeFormat: 'YYYY年M月DD日',
         postDateFormat: 'YYYY年M月D日',
+        refreshButtonText: '最新消息',
+        visuallyHiddenButtonText: '已新增内容',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',
@@ -454,6 +456,8 @@ export const service: ZhongwenConfig = {
         shareButtonText: '分享',
         postDateTimeFormat: 'YYYY年M月DD日',
         postDateFormat: 'YYYY年M月D日',
+        refreshButtonText: '最新消息',
+        visuallyHiddenButtonText: '已新增內容',
       },
       downloads: {
         instructions: 'You can download and view today’s news.',


### PR DESCRIPTION
Resolves JIRA: [WS-2276](https://bbc.atlassian.net/browse/WS-2276)

Summary
======

Adds translations for ‘New Post Available’ and ‘Latest Post’ on all services for the [Latest Post Button](https://github.com/bbc/simorgh/blob/f4c0fd6df376e0efc1f5ce49be1414ad0590afc6/ws-nextjs-app/pages/%5Bservice%5D/live/%5Bid%5D/LatestPostButton/index.tsx#L25C3-L32C27)

Code changes
======
- _List key code changes that have been made._

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._


[WS-2276]: https://bbc.atlassian.net/browse/WS-2276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ