### PR TITLE
WS-NA: Adds missing 'and' translations

### DIFF
--- a/src/app/lib/config/services/arabic.ts
+++ b/src/app/lib/config/services/arabic.ts
@@ -66,6 +66,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      and: 'و',
       readTime: {
         readTimePrefix: 'مدة القراءة',
         minute: 'دقائق',

--- a/src/app/lib/config/services/dari.ts
+++ b/src/app/lib/config/services/dari.ts
@@ -46,6 +46,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: true,
     showRelatedTopics: true,
     translations: {
+      and: 'و',
       readTime: {
         readTimePrefix: 'زمان مطالعه',
         minute: 'دقیقه',

--- a/src/app/lib/config/services/magyarul.ts
+++ b/src/app/lib/config/services/magyarul.ts
@@ -45,6 +45,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: false,
     showRelatedTopics: true,
     translations: {
+      and: 'és',
       pagination: {
         page: 'Lap',
         previousPage: 'Előző oldal',

--- a/src/app/lib/config/services/pashto.ts
+++ b/src/app/lib/config/services/pashto.ts
@@ -49,6 +49,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: true,
     showRelatedTopics: true,
     translations: {
+      and: 'او',
       pagination: {
         page: 'پاڼه',
         previousPage: 'مخکينۍ پاڼه',

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -67,6 +67,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      and: 'و',
       pagination: {
         page: 'صفحه',
         previousPage: 'قبلی',


### PR DESCRIPTION
Resolves JIRA: Ws-NA

Summary
======
Adds missing 'and' translations. Most taken from https://bbc.atlassian.net/browse/WS-1832, copilot used to generate magyarul. See [slack](https://bbc-tpg.slack.com/archives/C03S8UQJZ6U/p1774454064583319) for context.

Code changes
======
- Config translation updates

Testing
======
See arabic article: http://localhost:7081/arabic/articles/cwydxw41k3mo?renderer_env=live

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
