### PR TITLE
WS-2206: Detect IDCTA signed-in state client-side

### DIFF
--- a/src/app/contexts/AccountContext/index.test.tsx
+++ b/src/app/contexts/AccountContext/index.test.tsx
@@ -30,14 +30,9 @@ describe('AccountContext', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (onClient as jest.Mock).mockReturnValue(true);
-    jest.spyOn(Cookie, 'get').mockReturnValue('some-cookie-value' as any);
 
     delete (window as any).location;
     window.location = { href: 'https://example.com/current-page' } as any;
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
   });
 
   const TestComponent = () => {
@@ -92,18 +87,6 @@ describe('AccountContext', () => {
     expect(context.isIdctaAvailable).toBe(false);
   });
 
-  it('should set isSignedIn to false on the server when IDCTA is available', () => {
-    (onClient as jest.Mock).mockReturnValue(false);
-    (Cookie.get as jest.Mock).mockClear();
-    render(<TestComponent />, {
-      idctaConfig: mockIdctaConfig,
-      service: 'hindi',
-    });
-    const testEl = screen.getByTestId('test-component');
-    const context = JSON.parse(testEl.textContent as string);
-    expect(context.isSignedIn).toBe(false);
-  });
-
   it('should set isIdctaAvailable to false when initialConfig is null', () => {
     render(<TestComponent />, {
       idctaConfig: null,
@@ -152,11 +135,21 @@ describe('AccountContext', () => {
     expect(context.forYouUrl).toBe(mockIdctaConfig.unavailable_url);
   });
 
-  it('should set isSignedIn to false when IDCTA is available and ckns_id cookie is absent', () => {
-    (Cookie.get as jest.Mock).mockReturnValue(undefined as any);
-
+  it('should set isSignedIn to true when IDCTA is available and initialIsSignedIn is true', () => {
     render(<TestComponent />, {
       idctaConfig: mockIdctaConfig,
+      service: 'hindi',
+    });
+
+    const testEl = screen.getByTestId('test-component');
+    const context = JSON.parse(testEl.textContent as string);
+
+    expect(context.isSignedIn).toBe(true);
+  });
+
+  it('should set isSignedIn to false when IDCTA is available but initialIsSignedIn is false', () => {
+    render(<TestComponent />, {
+      idctaConfig: { ...mockIdctaConfig, initialIsSignedIn: false },
       service: 'hindi',
     });
 
@@ -166,7 +159,7 @@ describe('AccountContext', () => {
     expect(context.isSignedIn).toBe(false);
   });
 
-  it('should set isSignedIn to false when IDCTA is not available regardless of cookie ckns_id', () => {
+  it('should set isSignedIn to false when IDCTA is not available regardless of initialIsSignedIn', () => {
     const config = {
       ...mockIdctaConfig,
       'id-availability': 'RED',
@@ -183,9 +176,11 @@ describe('AccountContext', () => {
     expect(context.isSignedIn).toBe(false);
   });
 
-  it('should set isSignedIn to true when IDCTA is available and ckns_id cookie is present', () => {
+  it('should set isSignedIn to true when ckns_id cookie is present', () => {
+    jest.spyOn(Cookie, 'get').mockReturnValue('ckns_id_cookie_value' as any);
+
     render(<TestComponent />, {
-      idctaConfig: mockIdctaConfig,
+      idctaConfig: { ...mockIdctaConfig, initialIsSignedIn: false },
       service: 'hindi',
     });
 

--- a/src/app/contexts/AccountContext/index.test.tsx
+++ b/src/app/contexts/AccountContext/index.test.tsx
@@ -2,6 +2,7 @@
 import { use } from 'react';
 import onClient from '#app/lib/utilities/onClient';
 import { IdctaConfig } from '#app/models/types/account';
+import Cookie from 'js-cookie';
 import { AccountContext } from '.';
 import {
   render,
@@ -29,6 +30,7 @@ describe('AccountContext', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (onClient as jest.Mock).mockReturnValue(true);
+    jest.spyOn(Cookie, 'get').mockReturnValue('some-cookie-value' as any);
 
     delete (window as any).location;
     window.location = { href: 'https://example.com/current-page' } as any;
@@ -146,7 +148,9 @@ describe('AccountContext', () => {
     expect(context.isSignedIn).toBe(true);
   });
 
-  it('should set isSignedIn to false when IDCTA is available but initialIsSignedIn is false', () => {
+  it('should set isSignedIn to false when IDCTA is available but initialIsSignedIn is false and ckns_id cookie is absent', () => {
+    jest.spyOn(Cookie, 'get').mockReturnValue(undefined as any);
+
     render(<TestComponent />, {
       idctaConfig: { ...mockIdctaConfig, initialIsSignedIn: false },
       service: 'hindi',
@@ -172,6 +176,34 @@ describe('AccountContext', () => {
     const testEl = screen.getByTestId('test-component');
     const context = JSON.parse(testEl.textContent as string);
 
+    expect(context.isSignedIn).toBe(false);
+  });
+
+  it('should set isSignedIn to true when IDCTA is available and ckns_id cookie is present', () => {
+    render(<TestComponent />, {
+      idctaConfig: { ...mockIdctaConfig, initialIsSignedIn: false },
+      service: 'hindi',
+    });
+
+    const testEl = screen.getByTestId('test-component');
+    const context = JSON.parse(testEl.textContent as string);
+
+    expect(Cookie.get).toHaveBeenCalledWith('ckns_id');
+    expect(context.isSignedIn).toBe(true);
+  });
+
+  it('should set isSignedIn to false when IDCTA is available but ckns_id cookie is absent', () => {
+    jest.spyOn(Cookie, 'get').mockReturnValue(undefined as any);
+
+    render(<TestComponent />, {
+      idctaConfig: { ...mockIdctaConfig, initialIsSignedIn: false },
+      service: 'hindi',
+    });
+
+    const testEl = screen.getByTestId('test-component');
+    const context = JSON.parse(testEl.textContent as string);
+
+    expect(Cookie.get).toHaveBeenCalledWith('ckns_id');
     expect(context.isSignedIn).toBe(false);
   });
 

--- a/src/app/contexts/AccountContext/index.test.tsx
+++ b/src/app/contexts/AccountContext/index.test.tsx
@@ -136,23 +136,11 @@ describe('AccountContext', () => {
     expect(context.forYouUrl).toBe(mockIdctaConfig.unavailable_url);
   });
 
-  it('should set isSignedIn to true when IDCTA is available and initialIsSignedIn is true', () => {
-    render(<TestComponent />, {
-      idctaConfig: mockIdctaConfig,
-      service: 'hindi',
-    });
-
-    const testEl = screen.getByTestId('test-component');
-    const context = JSON.parse(testEl.textContent as string);
-
-    expect(context.isSignedIn).toBe(true);
-  });
-
-  it('should set isSignedIn to false when IDCTA is available but initialIsSignedIn is false and ckns_id cookie is absent', () => {
+  it('should set isSignedIn to false when IDCTA is available and ckns_id cookie is absent', () => {
     jest.spyOn(Cookie, 'get').mockReturnValue(undefined as any);
 
     render(<TestComponent />, {
-      idctaConfig: { ...mockIdctaConfig, initialIsSignedIn: false },
+      idctaConfig: mockIdctaConfig,
       service: 'hindi',
     });
 
@@ -162,7 +150,7 @@ describe('AccountContext', () => {
     expect(context.isSignedIn).toBe(false);
   });
 
-  it('should set isSignedIn to false when IDCTA is not available regardless of initialIsSignedIn', () => {
+  it('should set isSignedIn to false when IDCTA is not available regardless of cookie ckns_id', () => {
     const config = {
       ...mockIdctaConfig,
       'id-availability': 'RED',
@@ -181,7 +169,7 @@ describe('AccountContext', () => {
 
   it('should set isSignedIn to true when IDCTA is available and ckns_id cookie is present', () => {
     render(<TestComponent />, {
-      idctaConfig: { ...mockIdctaConfig, initialIsSignedIn: false },
+      idctaConfig: mockIdctaConfig,
       service: 'hindi',
     });
 
@@ -196,7 +184,7 @@ describe('AccountContext', () => {
     jest.spyOn(Cookie, 'get').mockReturnValue(undefined as any);
 
     render(<TestComponent />, {
-      idctaConfig: { ...mockIdctaConfig, initialIsSignedIn: false },
+      idctaConfig: mockIdctaConfig,
       service: 'hindi',
     });
 

--- a/src/app/contexts/AccountContext/index.test.tsx
+++ b/src/app/contexts/AccountContext/index.test.tsx
@@ -36,6 +36,10 @@ describe('AccountContext', () => {
     window.location = { href: 'https://example.com/current-page' } as any;
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   const TestComponent = () => {
     const context = use(AccountContext);
     return <div data-testid="test-component">{JSON.stringify(context)}</div>;
@@ -86,6 +90,18 @@ describe('AccountContext', () => {
     const context = JSON.parse(testEl.textContent as string);
 
     expect(context.isIdctaAvailable).toBe(false);
+  });
+
+  it('should set isSignedIn to false on the server when IDCTA is available', () => {
+    (onClient as jest.Mock).mockReturnValue(false);
+    (Cookie.get as jest.Mock).mockClear();
+    render(<TestComponent />, {
+      idctaConfig: mockIdctaConfig,
+      service: 'hindi',
+    });
+    const testEl = screen.getByTestId('test-component');
+    const context = JSON.parse(testEl.textContent as string);
+    expect(context.isSignedIn).toBe(false);
   });
 
   it('should set isIdctaAvailable to false when initialConfig is null', () => {

--- a/src/app/contexts/AccountContext/index.test.tsx
+++ b/src/app/contexts/AccountContext/index.test.tsx
@@ -137,7 +137,7 @@ describe('AccountContext', () => {
   });
 
   it('should set isSignedIn to false when IDCTA is available and ckns_id cookie is absent', () => {
-    jest.spyOn(Cookie, 'get').mockReturnValue(undefined as any);
+    (Cookie.get as jest.Mock).mockReturnValue(undefined as any);
 
     render(<TestComponent />, {
       idctaConfig: mockIdctaConfig,
@@ -178,21 +178,6 @@ describe('AccountContext', () => {
 
     expect(Cookie.get).toHaveBeenCalledWith('ckns_id');
     expect(context.isSignedIn).toBe(true);
-  });
-
-  it('should set isSignedIn to false when IDCTA is available but ckns_id cookie is absent', () => {
-    jest.spyOn(Cookie, 'get').mockReturnValue(undefined as any);
-
-    render(<TestComponent />, {
-      idctaConfig: mockIdctaConfig,
-      service: 'hindi',
-    });
-
-    const testEl = screen.getByTestId('test-component');
-    const context = JSON.parse(testEl.textContent as string);
-
-    expect(Cookie.get).toHaveBeenCalledWith('ckns_id');
-    expect(context.isSignedIn).toBe(false);
   });
 
   it('should handle null initialConfig gracefully', () => {

--- a/src/app/contexts/AccountContext/index.tsx
+++ b/src/app/contexts/AccountContext/index.tsx
@@ -49,7 +49,8 @@ export const AccountProvider = ({
   const signOutUrl = buildAccountUrl(initialConfig?.signout_url);
   const forYouUrl = buildAccountUrl(initialConfig?.foryou_url);
 
-  // TODO: Only checks client-side cookie presence, it will be improved to detect signed-in status server side
+  // TODO: initialIsSignedIn is always false in test/live env due to filtered cookie header,
+  // it will be improved to detect signed-in status server side in the future
   // Ticket: https://bbc.atlassian.net/browse/WS-2388
   const clientSignedInState = getSignedInCookie(
     initialConfig?.identity?.idSignedInCookieName,

--- a/src/app/contexts/AccountContext/index.tsx
+++ b/src/app/contexts/AccountContext/index.tsx
@@ -9,6 +9,8 @@ import {
 import { AccountContextProps, IdctaConfig } from '#app/models/types/account';
 import appendCtaQueryParams from '#app/lib/idcta/appendCtaQueryParams';
 import { ServiceContext } from '#app/contexts/ServiceContext';
+import onClient from '#app/lib/utilities/onClient';
+import Cookie from 'js-cookie';
 
 export const AccountContext = createContext<AccountContextProps>(
   {} as AccountContextProps,
@@ -16,6 +18,10 @@ export const AccountContext = createContext<AccountContextProps>(
 
 type AccountProviderProps = {
   initialConfig: IdctaConfig | null;
+};
+
+const getSignedInCookie = (cookieName = 'ckns_id') => {
+  return onClient() ? Cookie.get(cookieName) : false;
 };
 
 export const AccountProvider = ({
@@ -43,8 +49,10 @@ export const AccountProvider = ({
   const signOutUrl = buildAccountUrl(initialConfig?.signout_url);
   const forYouUrl = buildAccountUrl(initialConfig?.foryou_url);
 
-  const isSignedIn =
-    isIdctaAvailable && Boolean(initialConfig?.initialIsSignedIn);
+  // TODO: Only checks client-side cookie presence, it will be improved to detect signed-in status server side
+  // Ticket: https://bbc.atlassian.net/browse/WS-2388
+  const cookieName = initialConfig?.identity?.idSignedInCookieName;
+  const isSignedIn = isIdctaAvailable && Boolean(getSignedInCookie(cookieName));
 
   const value = useMemo(
     () => ({

--- a/src/app/contexts/AccountContext/index.tsx
+++ b/src/app/contexts/AccountContext/index.tsx
@@ -51,8 +51,12 @@ export const AccountProvider = ({
 
   // TODO: Only checks client-side cookie presence, it will be improved to detect signed-in status server side
   // Ticket: https://bbc.atlassian.net/browse/WS-2388
-  const cookieName = initialConfig?.identity?.idSignedInCookieName;
-  const isSignedIn = isIdctaAvailable && Boolean(getSignedInCookie(cookieName));
+  const clientSignedInState = getSignedInCookie(
+    initialConfig?.identity?.idSignedInCookieName,
+  );
+  const isSignedIn =
+    isIdctaAvailable &&
+    Boolean(initialConfig?.initialIsSignedIn || clientSignedInState);
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2206

Summary
======
- Identify whether the user is signed in on the client side. Server‑side detection will be added in the future after the Belfrage changes to whitelist IDCTA cookies and/or the signed‑in identifying HTTP header.

Code changes
======
- Detect Signed-in state client side
- Update unit tests

Testing
======
Add a new cookie (using `DevTools -> Application -> Cookies`):
- Name: ckns_id
- Value: any non-empty string e.g. test123
- Refresh the page — the Account Header should now display "Your Account"

To test signed-out state, delete the ckns_id cookie and refresh.


## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
