### PR TITLE
Remove broken AMP media player e2e

### DIFF
--- a/ws-nextjs-app/cypress/e2e/articlePage/testsForAMPOnly.ts
+++ b/ws-nextjs-app/cypress/e2e/articlePage/testsForAMPOnly.ts
@@ -12,7 +12,6 @@ const articleHasPlayer = (articleId: string) =>
     'cgwk9w4zlg8o', // pidgin/articles/cgwk9w4zlg8o on LIVE
     'cj7xrxz0e8zo', // news/articles/cj7xrxz0e8zo on LIVE
     'c25rp5glj5qo', // persian/articles/c25rp5glj5qo on LIVE
-    'cwl08rd38l6o', // pidgin/articles/cwl08rd38l6o on TEST
     'cej3lzd5e0go', // persian/articles/cej3lzd5e0go on TEST
   ].includes(articleId);
 


### PR DESCRIPTION
Summary
======
- Remove broken test for AMP media player as media player is 404ing now

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
