### PR TITLE
Tamil in-article promo and Hindi fit podcast third-party links

### DIFF
--- a/src/app/lib/config/services/tamil.ts
+++ b/src/app/lib/config/services/tamil.ts
@@ -47,6 +47,23 @@ export const service: DefaultServiceConfig = {
     homePageTitle: 'முகப்பு',
     showAdPlaceholder: true,
     showRelatedTopics: true,
+    podcastPromo: {
+      title: 'வாட்ஸ்அப் விளம்பரம்',
+      brandTitle: 'வாட்ஸ்ஆப்பில்',
+      brandDescription: 'பிபிசி தமிழ் செய்திகளை செல்போனிலேயே படிக்கலாம்',
+      image: {
+        src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0n959h0.png',
+        alt: `வாட்ஸ்அப் விளம்பரம் - படம்`,
+      },
+      linkLabel: {
+        text: 'பின்தொடர கிளிக் செய்யவும்',
+        href: 'https://www.whatsapp.com/channel/0029VaaJj0BKLaHwTA7BOi3N',
+      },
+      skipLink: {
+        text: '%title% - ஐ புறக்கணித்துவிட்டு தொடர்ந்து படிக்கவும்',
+        endTextVisuallyHidden: '%title% - முடிவு',
+      },
+    },
     translations: {
       and: 'மற்றும்',
       readTime: {

--- a/src/app/routes/onDemandAudio/podcastExternalLinks/hindi.ts
+++ b/src/app/routes/onDemandAudio/podcastExternalLinks/hindi.ts
@@ -280,4 +280,28 @@ export default {
       linkType: 'gaana',
     },
   ],
+  p08rwt31: [
+    {
+      linkText: 'Spotify',
+      linkUrl: 'https://open.spotify.com/show/5r4uhPPvUI4MNbgXUNflkh',
+      linkType: 'spotify',
+    },
+    {
+      linkText: 'Apple',
+      linkUrl:
+        'https://podcasts.apple.com/in/podcast/fit-%E0%A4%9C-%E0%A4%A6%E0%A4%97/id1532430310',
+      linkType: 'apple',
+    },
+    {
+      linkText: 'Jio Saavn',
+      linkUrl:
+        'https://www.jiosaavn.com/shows/fit-%e0%a4%9c%e0%a4%bc%e0%a4%bf%e0%a4%82%e0%a4%a6%e0%a4%97%e0%a5%80/1/8kUvuq2K1GQ_',
+      linkType: 'jiosaavn',
+    },
+    {
+      linkText: 'Gaana',
+      linkUrl: 'https://gaana.com/podcast/fit-season-1',
+      linkType: 'gaana',
+    },
+  ],
 };


### PR DESCRIPTION
Resolves JIRA: n/a

Summary
======
- added in-article promo to Tamil to promote their WhatsApp channel 
- added third-party links to BBC Hindi fit podcast

Code changes
======
- Added podcastpromo section to src/app/lib/config/services/tamil.ts
- Added thitd party links to src/app/routes/onDemandAudio/podcastExternalLinks/hindi.ts
- 
Testing
======

<img width="914" height="550" alt="image" src="https://github.com/user-attachments/assets/69c71a9d-fdc2-446e-a42e-0e7cdeb5d05d" />





## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
