### PR TITLE
TEMP: Skip media player e2e tests on Local/Test env

### DIFF
--- a/ws-nextjs-app/cypress/e2e/articlePage/testsForAMPOnly.ts
+++ b/ws-nextjs-app/cypress/e2e/articlePage/testsForAMPOnly.ts
@@ -46,11 +46,11 @@ export default ({
       }
     });
 
-    describe('Media Player: AMP', () => {
-      // TODO: Remove once Test env assets are fixed
-      const itOrSkip = getAppEnv() !== 'live' ? it.skip : it;
+    // TODO: Remove once Test env assets are fixed
+    const describeOrSkip = getAppEnv() !== 'live' ? describe.skip : describe;
 
-      itOrSkip('should render an iframe with a valid URL', () => {
+    describeOrSkip('Media Player: AMP', () => {
+      it('should render an iframe with a valid URL', () => {
         if (articleHasPlayer(articleId)) {
           cy.get('[data-e2e="media-player"]').should('be.visible');
           cy.get('[data-e2e="media-player"]')

--- a/ws-nextjs-app/cypress/e2e/articlePage/testsForAMPOnly.ts
+++ b/ws-nextjs-app/cypress/e2e/articlePage/testsForAMPOnly.ts
@@ -1,4 +1,5 @@
 import { Services } from '#app/models/types/global';
+import getAppEnv from '#cypress/support/helpers/getAppEnv';
 import skipOnLocal from '../../support/helpers/skipOnLocal';
 import { ServiceParametersType } from '../../types';
 import { ampOnly as crossPlatform } from '../assertions/crossPlatformAssertion';
@@ -46,7 +47,10 @@ export default ({
     });
 
     describe('Media Player: AMP', () => {
-      it('should render an iframe with a valid URL', () => {
+      // TODO: Remove once Test env assets are fixed
+      const itOrSkip = getAppEnv() !== 'live' ? it.skip : it;
+
+      itOrSkip('should render an iframe with a valid URL', () => {
         if (articleHasPlayer(articleId)) {
           cy.get('[data-e2e="media-player"]').should('be.visible');
           cy.get('[data-e2e="media-player"]')

--- a/ws-nextjs-app/cypress/e2e/articlePage/testsForCanonicalOnly.ts
+++ b/ws-nextjs-app/cypress/e2e/articlePage/testsForCanonicalOnly.ts
@@ -8,6 +8,7 @@ import {
   AresMediaMetadataBlock,
   CaptionBlock,
 } from '#app/components/MediaLoader/types';
+import getAppEnv from '#cypress/support/helpers/getAppEnv';
 import { ServiceParametersType } from '../../types';
 import { getBlockData, getBlockByType, getVideoEmbedUrl } from './helpers';
 import runIfToggleEnabled from '../../support/helpers/runIfToggleEnabled';
@@ -101,115 +102,118 @@ export default ({
       cy.go('back');
     });
 
-    describe('Media Player: Canonical', () => {
-      it('should render a visible placeholder image', () => {
-        cy.window()
-          .getPageDataFromWindow()
-          .then(pageData => {
-            const media = getBlockData('video', pageData);
-
-            if (media) {
-              cy.get('[data-e2e="media-loader__container"]')
-                .first()
-                .within(() => {
-                  cy.get('[data-e2e="media-loader__placeholder"] img')
-                    .should('be.visible')
-                    .should('have.attr', 'src')
-                    .should('not.be.empty');
-                });
-            }
-          });
-      });
-
-      it('should render a visible guidance message', () => {
-        cy.window()
-          .getPageDataFromWindow()
-          .then(pageData => {
-            const media = getBlockData('video', pageData);
-
-            if (media) {
-              const aresMediaMetadata = (
-                media.model.blocks[1] as ArticleContent
-              ).model.blocks[0] as AresMediaMetadataBlock;
-
-              const longGuidanceWarning =
-                aresMediaMetadata.model.versions[0].warnings?.long;
-
-              cy.get('[data-e2e="media-loader__container"]')
-                .eq(0)
-                .within(() => {
-                  // Check for video with guidance message
-                  if (longGuidanceWarning) {
-                    cy.get('[data-e2e="media-player__guidance"] strong')
-                      .should('be.visible')
-                      .and('contain', longGuidanceWarning);
-                    // Check for video with no guidance message
-                  } else {
-                    cy.get('[data-e2e="media-player__guidance"] strong').should(
-                      'not.exist',
-                    );
-                  }
-                });
-            }
-          });
-      });
-
-      it('should have a visible play button and valid duration', () => {
-        cy.window()
-          .getPageDataFromWindow()
-          .then(pageData => {
-            const media = getBlockData<ArticleContent & { type: string }>(
-              'video',
-              pageData,
-            );
-
-            if (media && media.type === 'video') {
-              const aresMediaMetaDataBlock = (
-                media.model.blocks[1] as AresMediaBlock
-              ).model.blocks[0] as AresMediaMetadataBlock;
-
-              const { durationISO8601 } =
-                aresMediaMetaDataBlock.model.versions[0];
-
-              cy.get('[data-e2e="media-loader__container"]')
-                .first()
-                .within(() => {
-                  cy.get('button')
-                    .should('be.visible')
-                    .within(() => {
-                      cy.get('svg').should('be.visible');
-                      cy.get('time')
-                        .should('be.visible')
-                        .should('have.attr', 'datetime')
-                        .and('eq', durationISO8601);
-                    });
-                });
-            }
-          });
-      });
-      if (service === 'pidgin') {
-        it('should render a media player with a valid embed URL when a user clicks play', () => {
+    // TODO: Remove once Test env assets are fixed
+    if (getAppEnv() === 'live') {
+      describe('Media Player: Canonical', () => {
+        it('should render a visible placeholder image', () => {
           cy.window()
             .getPageDataFromWindow()
             .then(pageData => {
-              const media = getBlockData<OptimoBlock>('video', pageData);
-              if (media && media.type === 'video') {
-                const { lang } = appConfig[service][variant];
-                const embedUrl = getVideoEmbedUrl(pageData, lang);
-                cy.get('[data-e2e="media-loader__container"] button')
-                  .first()
-                  .click();
-                cy.get('[data-e2e="media-player"]').should('be.visible');
+              const media = getBlockData('video', pageData);
 
-                cy.testResponseCodeAndRetry({
-                  url: embedUrl,
-                  allowFallback: true,
-                });
+              if (media) {
+                cy.get('[data-e2e="media-loader__container"]')
+                  .first()
+                  .within(() => {
+                    cy.get('[data-e2e="media-loader__placeholder"] img')
+                      .should('be.visible')
+                      .should('have.attr', 'src')
+                      .should('not.be.empty');
+                  });
               }
             });
         });
-      }
-    });
+
+        it('should render a visible guidance message', () => {
+          cy.window()
+            .getPageDataFromWindow()
+            .then(pageData => {
+              const media = getBlockData('video', pageData);
+
+              if (media) {
+                const aresMediaMetadata = (
+                  media.model.blocks[1] as ArticleContent
+                ).model.blocks[0] as AresMediaMetadataBlock;
+
+                const longGuidanceWarning =
+                  aresMediaMetadata.model.versions[0].warnings?.long;
+
+                cy.get('[data-e2e="media-loader__container"]')
+                  .eq(0)
+                  .within(() => {
+                    // Check for video with guidance message
+                    if (longGuidanceWarning) {
+                      cy.get('[data-e2e="media-player__guidance"] strong')
+                        .should('be.visible')
+                        .and('contain', longGuidanceWarning);
+                      // Check for video with no guidance message
+                    } else {
+                      cy.get(
+                        '[data-e2e="media-player__guidance"] strong',
+                      ).should('not.exist');
+                    }
+                  });
+              }
+            });
+        });
+
+        it('should have a visible play button and valid duration', () => {
+          cy.window()
+            .getPageDataFromWindow()
+            .then(pageData => {
+              const media = getBlockData<ArticleContent & { type: string }>(
+                'video',
+                pageData,
+              );
+
+              if (media && media.type === 'video') {
+                const aresMediaMetaDataBlock = (
+                  media.model.blocks[1] as AresMediaBlock
+                ).model.blocks[0] as AresMediaMetadataBlock;
+
+                const { durationISO8601 } =
+                  aresMediaMetaDataBlock.model.versions[0];
+
+                cy.get('[data-e2e="media-loader__container"]')
+                  .first()
+                  .within(() => {
+                    cy.get('button')
+                      .should('be.visible')
+                      .within(() => {
+                        cy.get('svg').should('be.visible');
+                        cy.get('time')
+                          .should('be.visible')
+                          .should('have.attr', 'datetime')
+                          .and('eq', durationISO8601);
+                      });
+                  });
+              }
+            });
+        });
+        if (service === 'pidgin') {
+          it('should render a media player with a valid embed URL when a user clicks play', () => {
+            cy.window()
+              .getPageDataFromWindow()
+              .then(pageData => {
+                const media = getBlockData<OptimoBlock>('video', pageData);
+                if (media && media.type === 'video') {
+                  const { lang } = appConfig[service][variant];
+                  const embedUrl = getVideoEmbedUrl(pageData, lang);
+                  cy.get('[data-e2e="media-loader__container"] button')
+                    .first()
+                    .click();
+                  cy.get('[data-e2e="media-player"]').should('be.visible');
+
+                  cy.testResponseCodeAndRetry({
+                    url: embedUrl,
+                    allowFallback: true,
+                  });
+                }
+              });
+          });
+        }
+      });
+    }
 
     describe('Continue Reading Button', () => {
       const CONTINUE_READING_BUTTON_ID = '#continue-reading-button';

--- a/ws-nextjs-app/cypress/e2e/articlePage/testsForCanonicalOnly.ts
+++ b/ws-nextjs-app/cypress/e2e/articlePage/testsForCanonicalOnly.ts
@@ -103,117 +103,117 @@ export default ({
     });
 
     // TODO: Remove once Test env assets are fixed
-    if (getAppEnv() === 'live') {
-      describe('Media Player: Canonical', () => {
-        it('should render a visible placeholder image', () => {
-          cy.window()
-            .getPageDataFromWindow()
-            .then(pageData => {
-              const media = getBlockData('video', pageData);
+    const describeOrSkip = getAppEnv() !== 'live' ? describe.skip : describe;
 
-              if (media) {
-                cy.get('[data-e2e="media-loader__container"]')
-                  .first()
-                  .within(() => {
-                    cy.get('[data-e2e="media-loader__placeholder"] img')
-                      .should('be.visible')
-                      .should('have.attr', 'src')
-                      .should('not.be.empty');
-                  });
-              }
-            });
-        });
+    describeOrSkip('Media Player: Canonical', () => {
+      it('should render a visible placeholder image', () => {
+        cy.window()
+          .getPageDataFromWindow()
+          .then(pageData => {
+            const media = getBlockData('video', pageData);
 
-        it('should render a visible guidance message', () => {
-          cy.window()
-            .getPageDataFromWindow()
-            .then(pageData => {
-              const media = getBlockData('video', pageData);
-
-              if (media) {
-                const aresMediaMetadata = (
-                  media.model.blocks[1] as ArticleContent
-                ).model.blocks[0] as AresMediaMetadataBlock;
-
-                const longGuidanceWarning =
-                  aresMediaMetadata.model.versions[0].warnings?.long;
-
-                cy.get('[data-e2e="media-loader__container"]')
-                  .eq(0)
-                  .within(() => {
-                    // Check for video with guidance message
-                    if (longGuidanceWarning) {
-                      cy.get('[data-e2e="media-player__guidance"] strong')
-                        .should('be.visible')
-                        .and('contain', longGuidanceWarning);
-                      // Check for video with no guidance message
-                    } else {
-                      cy.get(
-                        '[data-e2e="media-player__guidance"] strong',
-                      ).should('not.exist');
-                    }
-                  });
-              }
-            });
-        });
-
-        it('should have a visible play button and valid duration', () => {
-          cy.window()
-            .getPageDataFromWindow()
-            .then(pageData => {
-              const media = getBlockData<ArticleContent & { type: string }>(
-                'video',
-                pageData,
-              );
-
-              if (media && media.type === 'video') {
-                const aresMediaMetaDataBlock = (
-                  media.model.blocks[1] as AresMediaBlock
-                ).model.blocks[0] as AresMediaMetadataBlock;
-
-                const { durationISO8601 } =
-                  aresMediaMetaDataBlock.model.versions[0];
-
-                cy.get('[data-e2e="media-loader__container"]')
-                  .first()
-                  .within(() => {
-                    cy.get('button')
-                      .should('be.visible')
-                      .within(() => {
-                        cy.get('svg').should('be.visible');
-                        cy.get('time')
-                          .should('be.visible')
-                          .should('have.attr', 'datetime')
-                          .and('eq', durationISO8601);
-                      });
-                  });
-              }
-            });
-        });
-        if (service === 'pidgin') {
-          it('should render a media player with a valid embed URL when a user clicks play', () => {
-            cy.window()
-              .getPageDataFromWindow()
-              .then(pageData => {
-                const media = getBlockData<OptimoBlock>('video', pageData);
-                if (media && media.type === 'video') {
-                  const { lang } = appConfig[service][variant];
-                  const embedUrl = getVideoEmbedUrl(pageData, lang);
-                  cy.get('[data-e2e="media-loader__container"] button')
-                    .first()
-                    .click();
-                  cy.get('[data-e2e="media-player"]').should('be.visible');
-
-                  cy.testResponseCodeAndRetry({
-                    url: embedUrl,
-                    allowFallback: true,
-                  });
-                }
-              });
+            if (media) {
+              cy.get('[data-e2e="media-loader__container"]')
+                .first()
+                .within(() => {
+                  cy.get('[data-e2e="media-loader__placeholder"] img')
+                    .should('be.visible')
+                    .should('have.attr', 'src')
+                    .should('not.be.empty');
+                });
+            }
           });
-        }
       });
-    }
+
+      it('should render a visible guidance message', () => {
+        cy.window()
+          .getPageDataFromWindow()
+          .then(pageData => {
+            const media = getBlockData('video', pageData);
+
+            if (media) {
+              const aresMediaMetadata = (
+                media.model.blocks[1] as ArticleContent
+              ).model.blocks[0] as AresMediaMetadataBlock;
+
+              const longGuidanceWarning =
+                aresMediaMetadata.model.versions[0].warnings?.long;
+
+              cy.get('[data-e2e="media-loader__container"]')
+                .eq(0)
+                .within(() => {
+                  // Check for video with guidance message
+                  if (longGuidanceWarning) {
+                    cy.get('[data-e2e="media-player__guidance"] strong')
+                      .should('be.visible')
+                      .and('contain', longGuidanceWarning);
+                    // Check for video with no guidance message
+                  } else {
+                    cy.get('[data-e2e="media-player__guidance"] strong').should(
+                      'not.exist',
+                    );
+                  }
+                });
+            }
+          });
+      });
+
+      it('should have a visible play button and valid duration', () => {
+        cy.window()
+          .getPageDataFromWindow()
+          .then(pageData => {
+            const media = getBlockData<ArticleContent & { type: string }>(
+              'video',
+              pageData,
+            );
+
+            if (media && media.type === 'video') {
+              const aresMediaMetaDataBlock = (
+                media.model.blocks[1] as AresMediaBlock
+              ).model.blocks[0] as AresMediaMetadataBlock;
+
+              const { durationISO8601 } =
+                aresMediaMetaDataBlock.model.versions[0];
+
+              cy.get('[data-e2e="media-loader__container"]')
+                .first()
+                .within(() => {
+                  cy.get('button')
+                    .should('be.visible')
+                    .within(() => {
+                      cy.get('svg').should('be.visible');
+                      cy.get('time')
+                        .should('be.visible')
+                        .should('have.attr', 'datetime')
+                        .and('eq', durationISO8601);
+                    });
+                });
+            }
+          });
+      });
+      if (service === 'pidgin') {
+        it('should render a media player with a valid embed URL when a user clicks play', () => {
+          cy.window()
+            .getPageDataFromWindow()
+            .then(pageData => {
+              const media = getBlockData<OptimoBlock>('video', pageData);
+              if (media && media.type === 'video') {
+                const { lang } = appConfig[service][variant];
+                const embedUrl = getVideoEmbedUrl(pageData, lang);
+                cy.get('[data-e2e="media-loader__container"] button')
+                  .first()
+                  .click();
+                cy.get('[data-e2e="media-player"]').should('be.visible');
+
+                cy.testResponseCodeAndRetry({
+                  url: embedUrl,
+                  allowFallback: true,
+                });
+              }
+            });
+        });
+      }
+    });
 
     describe('Continue Reading Button', () => {
       const CONTINUE_READING_BUTTON_ID = '#continue-reading-button';

--- a/ws-nextjs-app/cypress/e2e/mediaAssetPage/testsForAMPOnly.ts
+++ b/ws-nextjs-app/cypress/e2e/mediaAssetPage/testsForAMPOnly.ts
@@ -5,10 +5,10 @@ import { ServiceParametersType } from '../../types';
 export default ({ service, pageType, path }: ServiceParametersType) => {
   describe(`AMP tests for ${service} ${pageType} ${path}`, () => {
     // TODO: Remove once Test env assets are fixed
-    const itOrSkip = getAppEnv() !== 'live' ? it.skip : it;
+    const describeOrSkip = getAppEnv() !== 'live' ? describe.skip : describe;
 
-    describe('Media Player', () => {
-      itOrSkip('should render an iframe with a valid URL', () => {
+    describeOrSkip('Media Player', () => {
+      it('should render an iframe with a valid URL', () => {
         if (!`${Cypress.env('currentPath')}`.includes('/russian/av/')) {
           cy.get(`amp-iframe`).should('be.visible');
 

--- a/ws-nextjs-app/cypress/e2e/mediaAssetPage/testsForAMPOnly.ts
+++ b/ws-nextjs-app/cypress/e2e/mediaAssetPage/testsForAMPOnly.ts
@@ -1,10 +1,14 @@
+import getAppEnv from '#cypress/support/helpers/getAppEnv';
 import { ServiceParametersType } from '../../types';
 
 // For testing features that may differ across services but share a common logic e.g. translated strings.
 export default ({ service, pageType, path }: ServiceParametersType) => {
   describe(`AMP tests for ${service} ${pageType} ${path}`, () => {
+    // TODO: Remove once Test env assets are fixed
+    const itOrSkip = getAppEnv() !== 'live' ? it.skip : it;
+
     describe('Media Player', () => {
-      it('should render an iframe with a valid URL', () => {
+      itOrSkip('should render an iframe with a valid URL', () => {
         if (!`${Cypress.env('currentPath')}`.includes('/russian/av/')) {
           cy.get(`amp-iframe`).should('be.visible');
 


### PR DESCRIPTION
Summary
======
Temporarily disables media player related e2es on Local/Test as the media player isn't working for Test assets currently

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
