### PR TITLE
FIX: Disable script switch tests for Most Read pages

### DIFF
--- a/cypress/e2e/specialFeatures/scriptSwitching/index.cy.js
+++ b/cypress/e2e/specialFeatures/scriptSwitching/index.cy.js
@@ -143,40 +143,6 @@ const testSuites = [
     runforEnv: ['test', 'live'],
     tests: [assertScriptSwitch],
   },
-  // Most Read Serbian
-  {
-    path: '/serbian/cyr/popular/read',
-    service: 'serbian',
-    variant: 'cyr',
-    otherVariant: 'lat',
-    runforEnv: ['local', 'test', 'live'],
-    tests: [assertScriptSwitch],
-  },
-  {
-    path: '/serbian/lat/popular/read',
-    service: 'serbian',
-    variant: 'lat',
-    otherVariant: 'cyr',
-    runforEnv: ['local', 'test', 'live'],
-    tests: [assertScriptSwitch],
-  },
-  // Most Read zhongwen
-  {
-    path: '/zhongwen/simp/popular/read',
-    service: 'zhongwen',
-    variant: 'simp',
-    otherVariant: 'trad',
-    runforEnv: ['local', 'test', 'live'],
-    tests: [assertScriptSwitch],
-  },
-  {
-    path: '/zhongwen/trad/popular/read',
-    service: 'zhongwen',
-    variant: 'trad',
-    otherVariant: 'simp',
-    runforEnv: ['local', 'test', 'live'],
-    tests: [assertScriptSwitch],
-  },
 ];
 
 runTestsForPage({

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/scriptSwitching/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/scriptSwitching/index.cy.ts
@@ -223,7 +223,7 @@ const scriptSwitchTestSuites = [
   //   service: 'serbian',
   //   variant: 'cyr',
   //   otherVariant: 'lat',
-  //   runforEnv: ['local', 'test', 'live'],
+  //   runforEnv: ['test', 'live'],
   //   tests: [assertScriptSwitch],
   // },
   // {
@@ -231,7 +231,7 @@ const scriptSwitchTestSuites = [
   //   service: 'serbian',
   //   variant: 'lat',
   //   otherVariant: 'cyr',
-  //   runforEnv: ['local', 'test', 'live'],
+  //   runforEnv: ['test', 'live'],
   //   tests: [assertScriptSwitch],
   // },
   // // Most Read zhongwen
@@ -240,7 +240,7 @@ const scriptSwitchTestSuites = [
   //   service: 'zhongwen',
   //   variant: 'simp',
   //   otherVariant: 'trad',
-  //   runforEnv: ['local', 'test', 'live'],
+  //   runforEnv: ['test', 'live'],
   //   tests: [assertScriptSwitch],
   // },
   // {
@@ -248,7 +248,7 @@ const scriptSwitchTestSuites = [
   //   service: 'zhongwen',
   //   variant: 'trad',
   //   otherVariant: 'simp',
-  //   runforEnv: ['local', 'test', 'live'],
+  //   runforEnv: ['test', 'live'],
   //   tests: [assertScriptSwitch],
   // },
 ];

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/scriptSwitching/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/scriptSwitching/index.cy.ts
@@ -216,6 +216,41 @@ const scriptSwitchTestSuites = [
     runforEnv: ['live'],
     tests: [assertScriptSwitch],
   },
+  // TODO: Re-enable once redirects are in place
+  //   // Most Read Serbian
+  // {
+  //   path: '/serbian/cyr/popular/read',
+  //   service: 'serbian',
+  //   variant: 'cyr',
+  //   otherVariant: 'lat',
+  //   runforEnv: ['local', 'test', 'live'],
+  //   tests: [assertScriptSwitch],
+  // },
+  // {
+  //   path: '/serbian/lat/popular/read',
+  //   service: 'serbian',
+  //   variant: 'lat',
+  //   otherVariant: 'cyr',
+  //   runforEnv: ['local', 'test', 'live'],
+  //   tests: [assertScriptSwitch],
+  // },
+  // // Most Read zhongwen
+  // {
+  //   path: '/zhongwen/simp/popular/read',
+  //   service: 'zhongwen',
+  //   variant: 'simp',
+  //   otherVariant: 'trad',
+  //   runforEnv: ['local', 'test', 'live'],
+  //   tests: [assertScriptSwitch],
+  // },
+  // {
+  //   path: '/zhongwen/trad/popular/read',
+  //   service: 'zhongwen',
+  //   variant: 'trad',
+  //   otherVariant: 'simp',
+  //   runforEnv: ['local', 'test', 'live'],
+  //   tests: [assertScriptSwitch],
+  // },
 ];
 
 runTestsForPage({


### PR DESCRIPTION
Summary
======
Temporarily disables script switch tests on Most Read pages as we need the redirects upstream in place first before the script switch can work.

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
