### PR TITLE
WS-2449: Use .com UAS endpoint to prevent 3rd party cookie blocking

### DIFF
--- a/src/app/lib/uasApi/index.test.ts
+++ b/src/app/lib/uasApi/index.test.ts
@@ -32,7 +32,7 @@ describe('uasApiRequest', () => {
     const response = await uasApiRequest('GET', activityType);
 
     expect(global.fetch).toHaveBeenCalledWith(
-      `https://activity.test.api.bbc.co.uk/my/${activityType}`,
+      `https://activity.test.api.bbc.com/my/${activityType}`,
       expect.objectContaining({
         method: 'GET',
         headers: expect.objectContaining({
@@ -57,7 +57,7 @@ describe('uasApiRequest', () => {
     const response = await uasApiRequest('POST', activityType, { body });
 
     expect(global.fetch).toHaveBeenCalledWith(
-      `https://activity.test.api.bbc.co.uk/my/${activityType}`,
+      `https://activity.test.api.bbc.com/my/${activityType}`,
       expect.objectContaining({
         method: 'POST',
         headers: expect.objectContaining({
@@ -83,7 +83,7 @@ describe('uasApiRequest', () => {
     await uasApiRequest('DELETE', activityType, { globalId });
 
     expect(global.fetch).toHaveBeenCalledWith(
-      `https://activity.test.api.bbc.co.uk/my/${activityType}/${encodeURIComponent(globalId)}`,
+      `https://activity.test.api.bbc.com/my/${activityType}/${encodeURIComponent(globalId)}`,
       expect.objectContaining({
         method: 'DELETE',
         headers: expect.objectContaining({

--- a/src/app/lib/uasApi/index.ts
+++ b/src/app/lib/uasApi/index.ts
@@ -22,7 +22,7 @@ interface UasRequestOptions {
 }
 
 const getUasHost = () =>
-  isLive() ? 'activity.api.bbc.co.uk' : 'activity.test.api.bbc.co.uk';
+  isLive() ? 'activity.api.bbc.com' : 'activity.test.api.bbc.com';
 
 const buildUrl = (activityType: string, globalId?: string) => {
   const base = `https://${getUasHost()}/my/${activityType}`;


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2449

Summary
======
- Use international UAS endpoint to prevent 3rd party cookie blocking

Code changes
======
- _List key code changes that have been made._

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
