### PR TITLE
WS-1347: Remove fallback command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "prepare": "husky install",
     "preinstall": "node scripts/check-package-manager.js",
     "start": "NODE_ENV=production node --max-old-space-size=3500 build/server.js",
-    "fallbackStart": "yarn start",
     "stop": "./scripts/killApp.sh",
     "storybook": "storybook dev -p 9001 -c .storybook",
     "test": "yarn build && yarn test:local",

--- a/src/integration/utils/runTests/index.js
+++ b/src/integration/utils/runTests/index.js
@@ -47,20 +47,19 @@ const startApp = () => {
   const pathname = argv.nextJS ? '' : '/status';
 
   const statusCommand = `sleep 20 && curl http://localhost:${portNumber}${pathname}`;
-
   const initialCommand = `yarn ${isDev ? 'dev' : 'start'}`;
-  const fallbackCommand = `yarn ${isDev ? 'dev' : 'fallbackStart'}`;
+  let errorMsg = '';
 
   return new Promise((resolve, reject) => {
     exec(initialCommand, error => {
       if (error) {
-        exec(fallbackCommand);
+        errorMsg = error;
       }
     });
 
     exec(statusCommand, error => {
       if (error) {
-        reject(new Error('Both the initial and fallback start up failed'));
+        reject(new Error(errorMsg));
       }
       resolve();
     });

--- a/ws-nextjs-app/package.json
+++ b/ws-nextjs-app/package.json
@@ -16,7 +16,6 @@
     "dev": "yarn setupDevEnv && next dev -p 7081 --webpack",
     "dev-https": "yarn setupDevEnv && next dev -p 7081 --experimental-https --webpack",
     "start": "NODE_ENV=production HOSTNAME=127.0.0.1 PORT=7081 node build/standalone/ws-nextjs-app/server.js",
-    "fallbackStart": "next start -p 7081",
     "stop": "lsof -t -i:7081 | xargs kill",
     "test": "NODE_OPTIONS=--no-experimental-strip-types jest --ci --colors --selectProjects='Unit Tests'",
     "test:integration": "NODE_OPTIONS=--no-experimental-strip-types jest --ci --colors --selectProjects='Integration Tests - Canonical' --selectProjects='Integration Tests - AMP' --selectProjects='Integration Tests - Lite'",


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1347

Summary
======
Removes fallback command but keeps Error messages. Example error message being propagated:
```
Running /integration/utils/runTests/index.js returned an error => 
 Error: Error: Command failed: yarn start
node:internal/modules/cjs/loader:1228
  throw err;
  ^

Error: Cannot find module '/Users/ahchos01/Desktop/WORLD_NEWS/simorgh/ws-nextjs-app/build/standalone/ws-nextjs-app/server2.js'
    at Function._resolveFilename (node:internal/modules/cjs/loader:1225:15)
    at Function._load (node:internal/modules/cjs/loader:1055:27)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:170:5)
    at node:internal/main/run_main_module:36:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v22.14.0

    at file:///Users/ahchos01/Desktop/WORLD_NEWS/simorgh/src/integration/utils/runTests/index.js:62:16
    at ChildProcess.exithandler (node:child_process:421:5)
    at ChildProcess.emit (node:events:518:28)
    at maybeClose (node:internal/child_process:1101:16)
    at ChildProcess._handle.onexit (node:internal/child_process:304:5)
```

Code changes
======
- _Removed fallback command._


Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
