### PR TITLE
NO TICKET Remove persian cps live stream tests

### DIFF
--- a/ws-nextjs-app/cypress/e2e/mediaAssetPage/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/mediaAssetPage/index.cy.ts
@@ -39,12 +39,6 @@ const canonicalSmokeTestSuites = [
     tests: canonicalTests,
   },
   {
-    path: '/persian/media-49522521', // CPS MAP with live stream
-    service: 'persian',
-    runforEnv: ['live'],
-    tests: canonicalTests,
-  },
-  {
     path: '/persian/world-51497110', // CPS MAP with video clip
     service: 'persian',
     runforEnv: ['live'],
@@ -215,16 +209,6 @@ const atiAnalyticsTestSuites = [
     service: 'hausa',
     pageIdentifier: 'hausa.news.media_asset.51622389.page',
     siteId: 51,
-    applicationType: 'responsive',
-    contentType: 'article-media-asset',
-    tests: [...atiAnalyticsTests],
-  },
-  {
-    path: '/persian/media-49522521', // CPS MAP with live stream
-    runforEnv: ['live'],
-    service: 'persian',
-    pageIdentifier: 'persian.embedded_media.media_asset.49522521.page',
-    siteId: 69,
     applicationType: 'responsive',
     contentType: 'article-media-asset',
     tests: [...atiAnalyticsTests],

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/liteSiteWeight/index.cy.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/liteSiteWeight/index.cy.ts
@@ -44,13 +44,6 @@ const articleRelatedTestSuites = [
     headers,
   },
   {
-    path: '/persian/media-49522521.lite',
-    runforEnv,
-    pageType: 'CPS Media Article with Live Stream',
-    tests,
-    headers,
-  },
-  {
     path: '/arabic/art-and-culture-38260491.lite',
     runforEnv,
     pageType: 'CPS Photo Gallery (PGL)',


### PR DESCRIPTION
Resolves failing E2E Tests

Summary
======

Now that our [redirect](https://github.com/bbc/belfrage/pull/4507/changes) from the old persian CPS MAP to our new live tv page is deployed, the E2Es are failing as they are expecting the old page in the tests. 

Removing these should fix it.  I have chosen to remove them rather than replace them as we are moving from CPS MAPS -> Live TV pages overall, and the tests should be covered by the oher CPS MAP assets that don't have live streams.

Code changes
======
- _List key code changes that have been made._

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
