### PR TITLE
Add `allowedDevOrigins` to `next.config`

### DIFF
--- a/ws-nextjs-app/next.config.js
+++ b/ws-nextjs-app/next.config.js
@@ -57,7 +57,7 @@ module.exports = {
       },
     ];
   },
-  allowedDevOrigins: ['localhost', 'localhost.bbc.com'],
+  allowedDevOrigins: ['localhost.bbc.com'],
   assetPrefix,
   compiler: { emotion: true },
   distDir: 'build',

--- a/ws-nextjs-app/next.config.js
+++ b/ws-nextjs-app/next.config.js
@@ -57,6 +57,7 @@ module.exports = {
       },
     ];
   },
+  allowedDevOrigins: ['localhost', 'localhost.bbc.com'],
   assetPrefix,
   compiler: { emotion: true },
   distDir: 'build',


### PR DESCRIPTION
Summary
======
Not sure when this started getting enforced, but I cannot accessing `localhost.bbc.com` in the Next app without adding it to the `allowedDevOrigins` list. Otherwise an error is thrown: https://nextjs.org/docs/app/api-reference/config/next-config-js/allowedDevOrigins

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
