### PR TITLE
FIX: Navigation bg colour + bbc block alignment

### DIFF
--- a/src/app/components/Navigation/__snapshots__/index.amp.test.tsx.snap
+++ b/src/app/components/Navigation/__snapshots__/index.amp.test.tsx.snap
@@ -79,6 +79,7 @@ exports[`AMP Navigation Snapshots should correctly render AMP navigation 1`] = `
   justify-content: space-between;
   position: relative;
   z-index: 0;
+  background-color: #B80000;
 }
 
 .emotion-6::before {

--- a/src/app/components/Navigation/__snapshots__/index.canonical.test.tsx.snap
+++ b/src/app/components/Navigation/__snapshots__/index.canonical.test.tsx.snap
@@ -73,6 +73,7 @@ exports[`Navigation - Canonical snapshots should correctly render Canonical navi
   justify-content: space-between;
   position: relative;
   z-index: 0;
+  background-color: #B80000;
 }
 
 .emotion-6::before {

--- a/src/app/components/Navigation/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Navigation/__snapshots__/index.test.tsx.snap
@@ -87,6 +87,7 @@ exports[`Navigation should correctly render amp navigation 1`] = `
   justify-content: space-between;
   position: relative;
   z-index: 0;
+  background-color: #B80000;
 }
 
 .emotion-7::before {
@@ -973,6 +974,7 @@ exports[`Navigation should correctly render amp navigation on a URL not associat
   justify-content: space-between;
   position: relative;
   z-index: 0;
+  background-color: #B80000;
 }
 
 .emotion-7::before {
@@ -1770,6 +1772,7 @@ exports[`Navigation should correctly render amp navigation on non-home navigatio
   justify-content: space-between;
   position: relative;
   z-index: 0;
+  background-color: #B80000;
 }
 
 .emotion-7::before {
@@ -2650,6 +2653,7 @@ exports[`Navigation should correctly render canonical navigation 1`] = `
   justify-content: space-between;
   position: relative;
   z-index: 0;
+  background-color: #B80000;
 }
 
 .emotion-7::before {
@@ -3518,6 +3522,7 @@ exports[`Navigation should correctly render canonical navigation on a URL not as
   justify-content: space-between;
   position: relative;
   z-index: 0;
+  background-color: #B80000;
 }
 
 .emotion-7::before {
@@ -4297,6 +4302,7 @@ exports[`Navigation should correctly render canonical navigation on non-home nav
   justify-content: space-between;
   position: relative;
   z-index: 0;
+  background-color: #B80000;
 }
 
 .emotion-7::before {

--- a/src/app/components/Navigation/index.styles.ts
+++ b/src/app/components/Navigation/index.styles.ts
@@ -55,6 +55,7 @@ export default {
       justifyContent: 'space-between',
       position: 'relative',
       zIndex: 0,
+      backgroundColor: palette.POSTBOX,
 
       '&::before': {
         content: "''",

--- a/src/app/legacy/containers/Header/index.styles.ts
+++ b/src/app/legacy/containers/Header/index.styles.ts
@@ -24,7 +24,7 @@ export default {
       },
 
       a: {
-        marginTop: `${pixelsToRem(6)}rem`,
+        marginTop: `${pixelsToRem(5)}rem`,
       },
     }),
   headerBrand: ({ mq, spacings }: Theme) =>

--- a/src/app/legacy/containers/Header/index.styles.ts
+++ b/src/app/legacy/containers/Header/index.styles.ts
@@ -24,7 +24,7 @@ export default {
       },
 
       a: {
-        lineHeight: 0,
+        marginTop: `${pixelsToRem(6)}rem`,
       },
     }),
   headerBrand: ({ mq, spacings }: Theme) =>


### PR DESCRIPTION
Summary
======
Fixes some display issues of the new navigation found on Opera Mini browsers

Code changes
======
- Adds `background-color: palette.POSTBOX` to the `topRow` element so that the background is visible. Using the pseudo `before` selector works for most browsers, but Opera Mini appears to not support it
- Replaces `line-height` with `margin-top` to set the positioning of the BBC blocks

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
