### PR TITLE
FIX: Refactor top navigation e2e test

### DIFF
--- a/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
+++ b/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
@@ -118,8 +118,7 @@ export default ({ service, pageType }: ServiceParametersType) => {
           });
         });
 
-        // eslint-disable-next-line func-names
-        it('navigates to a new page and secondary nav changes when clicking a non-home item in top nav', function () {
+        it('navigates to a new page and secondary nav changes when clicking a non-home item in top nav', function test() {
           cy.get('[data-e2e="scrollable-nav"] li').then($items => {
             if ($items.length < 2) {
               this.skip();

--- a/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
+++ b/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
@@ -118,9 +118,12 @@ export default ({ service, pageType }: ServiceParametersType) => {
           });
         });
 
-        it('navigates to a new page and secondary nav changes when clicking a non-home item in top nav', () => {
+        it('navigates to a new page and secondary nav changes when clicking a non-home item in top nav', function () {
           cy.get('[data-e2e="scrollable-nav"] li').then($items => {
-            if ($items.length < 2) return;
+            if ($items.length < 2) {
+              this.skip();
+              return;
+            }
             cy.location('pathname').then(previousUrl => {
               cy.wrap($items).eq(1).find('a').click();
               cy.location('pathname').should('not.eq', previousUrl);

--- a/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
+++ b/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
@@ -118,37 +118,23 @@ export default ({ service, pageType }: ServiceParametersType) => {
           });
         });
 
-        it('navigates to new page and secondary nav changes when clicking 2nd item in top nav', () => {
-          cy.location('pathname').then(previousUrl => {
-            cy.get('[data-e2e="scrollable-nav"] li').eq(1).find('a').click();
-            cy.location('pathname').should('not.eq', previousUrl);
-            cy.get('[data-e2e="scrollable-nav-secondary"] li a').then(
-              $links => {
-                const newTexts = $links
-                  .toArray()
-                  .map(link => link.textContent || '');
-                expect(newTexts).to.not.deep.equal(
-                  initialSecondaryNavItemLinkTexts,
-                );
-              },
-            );
-          });
-        });
-
-        it('navigates to another new page and secondary nav changes when clicking 3rd item in top nav', () => {
-          cy.location('pathname').then(previousUrl => {
-            cy.get('[data-e2e="scrollable-nav"] li').eq(2).find('a').click();
-            cy.location('pathname').should('not.eq', previousUrl);
-            cy.get('[data-e2e="scrollable-nav-secondary"] li a').then(
-              $links => {
-                const newTexts = $links
-                  .toArray()
-                  .map(link => link.textContent || '');
-                expect(newTexts).to.not.deep.equal(
-                  initialSecondaryNavItemLinkTexts,
-                );
-              },
-            );
+        it('navigates to a new page and secondary nav changes when clicking a non-home item in top nav', () => {
+          cy.get('[data-e2e="scrollable-nav"] li').then($items => {
+            if ($items.length < 2) return;
+            cy.location('pathname').then(previousUrl => {
+              cy.wrap($items).eq(1).find('a').click();
+              cy.location('pathname').should('not.eq', previousUrl);
+              cy.get('[data-e2e="scrollable-nav-secondary"] li a').then(
+                $links => {
+                  const newTexts = $links
+                    .toArray()
+                    .map(link => link.textContent || '');
+                  expect(newTexts).to.not.deep.equal(
+                    initialSecondaryNavItemLinkTexts,
+                  );
+                },
+              );
+            });
           });
         });
 

--- a/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
+++ b/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
@@ -118,11 +118,11 @@ export default ({ service, pageType }: ServiceParametersType) => {
           });
         });
 
+        // eslint-disable-next-line func-names
         it('navigates to a new page and secondary nav changes when clicking a non-home item in top nav', function () {
           cy.get('[data-e2e="scrollable-nav"] li').then($items => {
             if ($items.length < 2) {
               this.skip();
-              return;
             }
             cy.location('pathname').then(previousUrl => {
               cy.wrap($items).eq(1).find('a').click();


### PR DESCRIPTION
Summary
======
Refactors the tests to check the top navigation changes the secondary nav correctly. These were 2 separate tests, but now combined into 1 which also checks to ensure multiple 'top nav' items exist before running the assertion. This is because editorial can curate the navigation, so some services may not always have more than 1 top nav item

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
