### PR TITLE
FIX: Only render PV carousel on hydration

### DIFF
--- a/src/app/components/PortraitVideoCarousel/PortraitVideoPromo/index.tsx
+++ b/src/app/components/PortraitVideoCarousel/PortraitVideoPromo/index.tsx
@@ -12,6 +12,7 @@ import useViewTracker from '#app/hooks/useViewTracker';
 import getSrcSets from '#app/utilities/getSrcSets';
 import { PortraitClipMediaBlock } from '#app/components/MediaLoader/types';
 import { EventTrackingData } from '#app/lib/analyticsUtils/types';
+import useHydrationDetection from '#app/hooks/useHydrationDetection';
 import styles from './index.styles';
 
 const DEFAULT_TRANSLATION = {
@@ -37,6 +38,8 @@ export default ({
   // EXPERIMENT: Portrait Video Homepage Play Duration Sizing
   playDurationVariation,
 }: PortraitVideoPromoProps) => {
+  const isHydrated = useHydrationDetection();
+
   const { mq } = useTheme();
   const {
     defaultImage,
@@ -125,6 +128,8 @@ export default ({
     if (clickTrackerHandler) clickTrackerHandler(e);
     if (onClick) onClick();
   };
+
+  if (!isHydrated) return null;
 
   return (
     <li css={styles.container}>


### PR DESCRIPTION
Summary
======
Adds hydration check to `PortraitVideoPromo` to ensure it only renders on client-side hydration. This is in an attempt to fix `NO_LCP` errors we're facing when the PV Carousel renders on Home pages and Article pages

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
