### PR TITLE
FIX: Set `scrollSnapAlign` on hydration for PV Promos

### DIFF
--- a/src/app/components/PortraitVideoCarousel/PortraitVideoPromo/index.styles.ts
+++ b/src/app/components/PortraitVideoCarousel/PortraitVideoPromo/index.styles.ts
@@ -14,7 +14,6 @@ const styles = {
   container: ({ mq, spacings, gridWidths }: Theme) =>
     css({
       all: 'unset',
-      scrollSnapAlign: 'start',
       textDecoration: 'none',
       display: 'block',
       position: 'relative',

--- a/src/app/components/PortraitVideoCarousel/PortraitVideoPromo/index.tsx
+++ b/src/app/components/PortraitVideoCarousel/PortraitVideoPromo/index.tsx
@@ -12,6 +12,7 @@ import useViewTracker from '#app/hooks/useViewTracker';
 import getSrcSets from '#app/utilities/getSrcSets';
 import { PortraitClipMediaBlock } from '#app/components/MediaLoader/types';
 import { EventTrackingData } from '#app/lib/analyticsUtils/types';
+import useHydrationDetection from '#app/hooks/useHydrationDetection';
 import styles from './index.styles';
 
 const DEFAULT_TRANSLATION = {
@@ -37,6 +38,8 @@ export default ({
   // EXPERIMENT: Portrait Video Homepage Play Duration Sizing
   playDurationVariation,
 }: PortraitVideoPromoProps) => {
+  const isHydrated = useHydrationDetection();
+
   const { mq } = useTheme();
   const {
     defaultImage,
@@ -127,7 +130,7 @@ export default ({
   };
 
   return (
-    <li css={styles.container}>
+    <li css={[styles.container, isHydrated && { scrollSnapAlign: 'start' }]}>
       <Image
         alt={alt}
         src={imageUrl}

--- a/src/app/components/PortraitVideoCarousel/PortraitVideoPromo/index.tsx
+++ b/src/app/components/PortraitVideoCarousel/PortraitVideoPromo/index.tsx
@@ -12,7 +12,6 @@ import useViewTracker from '#app/hooks/useViewTracker';
 import getSrcSets from '#app/utilities/getSrcSets';
 import { PortraitClipMediaBlock } from '#app/components/MediaLoader/types';
 import { EventTrackingData } from '#app/lib/analyticsUtils/types';
-import useHydrationDetection from '#app/hooks/useHydrationDetection';
 import styles from './index.styles';
 
 const DEFAULT_TRANSLATION = {
@@ -24,6 +23,7 @@ const DEFAULT_TRANSLATION = {
 type PortraitVideoPromoProps = {
   block: PortraitClipMediaBlock;
   eventTrackingData: EventTrackingData;
+  isHydrated?: boolean;
   blockPosition?: number;
   // EXPERIMENT: Portrait Video Homepage Play Duration Sizing
   playDurationVariation?: string;
@@ -37,9 +37,8 @@ export default ({
   onClick,
   // EXPERIMENT: Portrait Video Homepage Play Duration Sizing
   playDurationVariation,
+  isHydrated,
 }: PortraitVideoPromoProps) => {
-  const isHydrated = useHydrationDetection();
-
   const { mq } = useTheme();
   const {
     defaultImage,

--- a/src/app/components/PortraitVideoCarousel/index.tsx
+++ b/src/app/components/PortraitVideoCarousel/index.tsx
@@ -6,6 +6,7 @@ import { EventTrackingData } from '#app/lib/analyticsUtils/types';
 import useOptimizelyVariation, {
   ExperimentType,
 } from '#app/hooks/useOptimizelyVariation';
+import useHydrationDetection from '#app/hooks/useHydrationDetection';
 import styles from './index.styles';
 import PortraitVideoModal from '../PortraitVideoModal';
 import { BumpLoader } from '../MediaLoader';
@@ -37,6 +38,8 @@ const PortraitVideoCarousel = ({
   );
 
   const { isLite, isAmp, nonce } = use(RequestContext);
+
+  const isHydrated = useHydrationDetection();
 
   // EXPERIMENT: Homepage Portrait Video 2
   const playDurationExperimentName = 'newswb_ws_homepage_portrait_video';
@@ -117,6 +120,7 @@ const PortraitVideoCarousel = ({
                 blockPosition={index}
                 eventTrackingData={eventTrackingDataExtended}
                 playDurationVariation={playDurationVariation}
+                isHydrated={isHydrated}
               />
             ))}
           </ul>


### PR DESCRIPTION
Summary
======
Attempts to fix `NO_LCP` Lighthouse error seemingly caused by the PortraitVideoPromo container and its `scrollSnapAlign: 'start'` style.

This changes it to only set that style when the client hydrates.

Testing
======
1. Visit http://localhost:7081/igbo?renderer_env=live
2. Run Lighthouse in incognito on 'mobile'
3. Confirm the 'Performance' metric returns a figure and not an `!` error
4. Visit http://localhost:7081/serbian/cyr?renderer_env=live
5. Repeat the steps

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
