### PR TITLE
Revert "WS-NA: Removes Zhongwen readtime translations"

### DIFF
--- a/src/app/lib/config/services/zhongwen.ts
+++ b/src/app/lib/config/services/zhongwen.ts
@@ -135,6 +135,10 @@ export const service: ZhongwenConfig = {
     },
     translations: {
       and: '和',
+      readTime: {
+        readTimePrefix: '阅读时间',
+        minute: '分钟',
+      },
       pagination: {
         previousPage: '前页',
         nextPage: '后页',
@@ -427,6 +431,10 @@ export const service: ZhongwenConfig = {
     },
     translations: {
       and: '和',
+      readTime: {
+        readTimePrefix: '閱讀時間',
+        minute: '分鐘',
+      },
       pagination: {
         previousPage: '前页',
         nextPage: '后页',


### PR DESCRIPTION
Reverts bbc/simorgh#13714

Readtime should be more accurate now, this needs to be reverted to show it on the frontend.