### PR TITLE
[WS-2177]: Add translations for Hindi to all BBC Account features on Simorgh

### DIFF
--- a/src/app/components/Account/AccountHeader/index.test.tsx
+++ b/src/app/components/Account/AccountHeader/index.test.tsx
@@ -53,7 +53,7 @@ describe('AccountHeader', () => {
   it('shows Your Account when signed in', async () => {
     renderWithProviders({ initialIsSignedIn: true });
 
-    const link = await screen.findByRole('link', { name: 'Your Account' });
+    const link = await screen.findByRole('link', { name: 'आपका अकाउंट' });
     expect(link).toHaveAttribute(
       'href',
       expect.stringContaining('https://example.com/foryou'),

--- a/src/app/components/Account/AccountHeader/index.test.tsx
+++ b/src/app/components/Account/AccountHeader/index.test.tsx
@@ -56,7 +56,7 @@ describe('AccountHeader', () => {
     const link = await screen.findByRole('link', { name: 'आपका अकाउंट' });
     expect(link).toHaveAttribute(
       'href',
-      expect.stringContaining('https://example.com/foryou'),
+      expect.stringContaining('https://example.com/settings'),
     );
     const icon = link.querySelector('svg');
     expect(icon).toBeInTheDocument();

--- a/src/app/components/Account/AccountHeader/index.test.tsx
+++ b/src/app/components/Account/AccountHeader/index.test.tsx
@@ -32,7 +32,7 @@ describe('AccountHeader', () => {
   it('shows Sign in when signed out and account toggle is enabled for service', async () => {
     renderWithProviders();
 
-    const link = await screen.findByRole('link', { name: 'साइन‑इन' });
+    const link = await screen.findByRole('link', { name: 'लॉग‑इन' });
     expect(link).toHaveAttribute(
       'href',
       expect.stringContaining('https://example.com/signin'),

--- a/src/app/components/Account/AccountHeader/index.tsx
+++ b/src/app/components/Account/AccountHeader/index.tsx
@@ -8,13 +8,13 @@ import styles from './index.styles';
 
 const AccountHeader = () => {
   const isHydrated = useHydrationDetection();
-  const { isSignedIn, signInUrl, forYouUrl, isIdctaAvailable } =
+  const { isSignedIn, signInUrl, settingsUrl, isIdctaAvailable } =
     use(AccountContext);
   const { translations } = use(ServiceContext);
 
   if (!isHydrated || !isIdctaAvailable) return null;
 
-  const href = isSignedIn ? forYouUrl : signInUrl;
+  const href = isSignedIn ? settingsUrl : signInUrl;
   const label = isSignedIn
     ? translations?.account?.forYou
     : translations?.account?.signIn;

--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -109,8 +109,8 @@ export const service: DefaultServiceConfig = {
         title: 'File Download',
       },
       account: {
-        signIn: 'साइन‑इन',
-        forYou: 'Your Account',
+        signIn: 'लॉग‑इन',
+        forYou: 'आपका अकाउंट',
         register: 'रजिस्टर करें',
       },
       accountPromoBanner: {

--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -117,7 +117,7 @@ export const service: DefaultServiceConfig = {
         title: 'अपना BBC खोजिए',
         description:
           'देखने, सुनने और भाग लेने के लिए साइन‑इन करें या खाता बनाएं',
-        closeLabel: 'Close',
+        closeLabel: 'बंद करें',
         buttonSeparatorText: 'या',
       },
       gist: 'सारांश',

--- a/src/app/lib/config/services/ws.ts
+++ b/src/app/lib/config/services/ws.ts
@@ -74,6 +74,7 @@ export const service: DefaultServiceConfig = {
         signIn: 'Sign In',
         forYou: 'Your Account',
         register: 'Register',
+        settings: 'Settings',
       },
       accountPromoBanner: {
         title: 'Discover your BBC',

--- a/src/app/models/types/translations.ts
+++ b/src/app/models/types/translations.ts
@@ -46,6 +46,7 @@ export interface Translations {
     signIn?: string;
     forYou?: string;
     register?: string;
+    settings?: string;
   };
   accountPromoBanner?: {
     title: string;


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2177

Summary
======
Added Hindi translations for several BBC Account UI strings on the Hindi service. Previously, some labels were either in English or used a transliterated form ("साइन‑इन"). They have now been replaced with more natural Hindi equivalents ("लॉग‑इन", "आपका अकाउंट", "बंद करें"). 
Additionally, updated the `AccountHeader` component to use `settingsUrl` instead of `forYouUrl` for signed-in users.

Code changes
======
- **`src/app/lib/config/services/hindi.ts`**:
  - `account.signIn`: `'साइन‑इन'` → `'लॉग‑इन'`
  - `account.forYou`: `'Your Account'` (English) → `'आपका अकाउंट'`
  - `accountPromoBanner.closeLabel`: `'Close'` (English) → `'बंद करें'`

- **`src/app/components/Account/AccountHeader/index.tsx`**:
  - Updated logic to use `settingsUrl` instead of `forYouUrl` when signed in.

- **`src/app/components/Account/AccountHeader/index.test.tsx`**:
  - Updated test assertions to match the new translations:
    - Sign-in link label: `'साइन‑इन'` → `'लॉग‑इन'`
    - Signed-in link label: `'Your Account'` → `'आपका अकाउंट'`
    - Updated URL expectations to check for `settingsUrl` instead of `forYouUrl`.

Testing
======
1. Ensure the local dev server is running (`yarn dev` from `ws-nextjs-app/`).
2. Navigate to a Hindi service page (e.g. `http://localhost:7081/hindi`).
3. When signed out, verify the account header link reads "लॉग‑इन".
4. Sign in and verify the account header link reads "आपका अकाउंट" and points to the `settingsUrl`.
5. Enable VoiceOver and verify the close button reads "बंद करें" in the account promotional banner.
6. Run the unit tests:
   ```bash
   ./node_modules/.bin/jest src/app/components/Account/AccountHeader/index.test.tsx --no-coverage