### PR TITLE
Remove unneeded nav dropdown e2e test

### DIFF
--- a/ws-nextjs-app/cypress/e2e/testsForAllAMPPages.ts
+++ b/ws-nextjs-app/cypress/e2e/testsForAllAMPPages.ts
@@ -8,8 +8,6 @@ export default ({ service, pageType }: ServiceParametersType) => {
   describe(`testsThatFollowSmokeTestConfigForAllAMPPages to run for ${service} ${pageType}`, () => {
     describe('Header Tests', () => {
       const serviceName = config[service]?.name || service;
-      // limit number to Zhongwen for navigation toggling
-      const testMobileNav = serviceName === 'zhongwen';
 
       const twoTierNavServices = {
         local: null, // Don't test two tier nav locally as the local environment can't fetch config
@@ -21,21 +19,6 @@ export default ({ service, pageType }: ServiceParametersType) => {
 
       const testTwoTierNav =
         twoTierNavServices[cypressAppEnv]?.includes(serviceName) ?? false;
-
-      if (testMobileNav) {
-        it('should show dropdown menu and hide scrollable menu when menu button is clicked', () => {
-          cy.viewport(320, 480);
-          cy.get('nav')
-            .find('[data-e2e="scrollable-nav"]')
-            .should('be.visible');
-
-          cy.get('nav button').click();
-
-          cy.get('nav')
-            .find('[data-e2e="dropdown-nav"] ul')
-            .should('be.visible');
-        });
-      }
 
       if (testTwoTierNav) {
         it('should show two tier navigation on mobile', () => {

--- a/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
+++ b/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
@@ -28,8 +28,6 @@ export default ({ service, pageType }: ServiceParametersType) => {
 
   describe('Header Tests', () => {
     const serviceName = config[service]?.name || service;
-    // limit number to Zhongwen for navigation toggling
-    const testMobileNav = serviceName === 'zhongwen';
 
     const twoTierNavServices = {
       local: null, // Don't test two tier nav locally as the local environment can't fetch config
@@ -43,19 +41,6 @@ export default ({ service, pageType }: ServiceParametersType) => {
       twoTierNavServices[cypressAppEnv]?.includes(serviceName) ?? false;
 
     let initialSecondaryNavItemLinkTexts: string[] = [];
-
-    if (testMobileNav) {
-      it('should show dropdown menu and hide scrollable menu when menu button is clicked', () => {
-        cy.viewport(320, 480);
-        cy.get('nav').find('[data-e2e="scrollable-nav"]').should('be.visible');
-
-        cy.get('nav button').click();
-
-        cy.get('nav').find('[data-e2e="dropdown-nav"] ul').should('be.visible');
-
-        cy.get('nav button').click();
-      });
-    }
 
     if (testTwoTierNav) {
       it('should show two tier navigation on desktop', () => {


### PR DESCRIPTION
Summary
======
Removes e2e test that clicks the nav button on only the Zhongwen service. These tests are already handled by the logic below them, so they are no longer needed.


Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
