### PR TITLE
Adds escape hatch for live posts with no headline

### DIFF
--- a/ws-nextjs-app/pages/[service]/live/[id]/Post/index.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Post/index.test.tsx
@@ -265,5 +265,35 @@ describe('Post', () => {
 
       expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
+
+    it('should not render share button when first heading text is missing', async () => {
+      const postWithMissingFirstHeadingText = {
+        ...samplePost,
+        header: {
+          ...samplePost.header,
+          model: {
+            ...samplePost.header.model,
+            blocks: [
+              {
+                ...samplePost.header.model.blocks[0],
+                model: {
+                  ...samplePost.header.model.blocks[0].model,
+                  blocks: [undefined],
+                },
+              },
+              ...samplePost.header.model.blocks.slice(1),
+            ],
+          },
+        },
+      };
+
+      await act(async () => {
+        render(
+          <Post post={postWithMissingFirstHeadingText as never} hasShareApi />,
+        );
+      });
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
   });
 });

--- a/ws-nextjs-app/pages/[service]/live/[id]/Post/index.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Post/index.test.tsx
@@ -113,6 +113,34 @@ describe('Post', () => {
       expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(1);
     });
 
+    it('should not crash when the first headline text block is missing', async () => {
+      const postWithMissingFirstHeadlineBlock = {
+        ...samplePost,
+        header: {
+          ...samplePost.header,
+          model: {
+            ...samplePost.header.model,
+            blocks: [
+              {
+                ...samplePost.header.model.blocks[0],
+                model: {
+                  ...samplePost.header.model.blocks[0].model,
+                  blocks: [undefined],
+                },
+              },
+              ...samplePost.header.model.blocks.slice(1),
+            ],
+          },
+        },
+      };
+
+      await act(async () => {
+        render(<Post post={postWithMissingFirstHeadlineBlock as never} />);
+      });
+
+      expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument();
+    });
+
     it('should render a span with role=text to avoid text splitting in screenreaders', async () => {
       await act(async () => {
         render(<Post post={singlePostWithTitle} />);

--- a/ws-nextjs-app/pages/[service]/live/[id]/Post/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Post/index.tsx
@@ -293,7 +293,7 @@ const Post = ({
       <div css={styles.postContent}>
         <PostContent contentBlocks={contentBlocks} />
       </div>
-      {hasShareApi && (
+      {hasShareApi && firstHeadingText && (
         <ShareButton
           eventTrackingData={{
             componentName: urn,

--- a/ws-nextjs-app/pages/[service]/live/[id]/Post/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Post/index.tsx
@@ -130,7 +130,7 @@ const PostHeading = ({
     headline: (props: { blocks: PostHeadline['model'] }) => {
       const { blocks } = props;
 
-      const headingText = blocks?.[0].model?.blocks?.[0]?.model?.text;
+      const headingText = blocks?.[0]?.model?.blocks?.[0]?.model?.text;
 
       return (
         <Text
@@ -146,7 +146,7 @@ const PostHeading = ({
     subheadline: (props: { blocks: PostHeadline['model'] }) => {
       const { blocks } = props;
 
-      const headingText = blocks?.[0].model?.blocks?.[0]?.model?.text;
+      const headingText = blocks?.[0]?.model?.blocks?.[0]?.model?.text;
 
       return (
         <>


### PR DESCRIPTION
Resolves JIRA: N/A

https://bbc-tpg.slack.com/archives/G03T00R76KX/p1777716254178159

Summary
======
Adds optional chaining check for empty block array for live post headlines

Code changes
======
- Adds a magic ? for headlines and subheadlines
- Adds check to only show share button when headline exists

Testing
======
1. This now renders http://localhost.bbc.com:7081/urdu/live/pakistan-61546283?page=24&renderer_env=live

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
