### PR TITLE
Brasil in article promo: tweak description

### DIFF
--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -51,7 +51,7 @@ export const service: DefaultServiceConfig = {
     podcastPromo: {
       title: 'Promoção Agregador de pesquisas',
       brandTitle: 'Veja Agregador de Pesquisas da BBC News Brasil',
-      brandDescription: '',
+      brandDescription: ' ',
       image: {
         src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0njcpky.jpg',
         alt: 'O agregador de pesquisas da BBC News Brasil',


### PR DESCRIPTION
n/a

Summary
======
Added space to description so that the in-article promo is displayed on articles. 
NB: The editorial team just want the title of the in-article promo as Call to action and no additional description under it.


Code changes
======
Update description on Podcast promo section of src/app/lib/config/services/portuguese.ts


Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
