### PR TITLE
WS-2215 - Analytics tracking on UAS and IDCTA events

### DIFF
--- a/src/app/components/ATIAnalytics/atiUrl/index.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.ts
@@ -55,6 +55,8 @@ export const buildReverbAnalyticsModel = ({
   timeUpdated,
   experimentName,
   experimentVariant,
+  isSignedIn = false,
+  hashedId = null,
 }: ATIPageTrackingProps): ReverbBeaconConfig => {
   const href = getHref(platform);
   const referrer = getReferrer(platform);
@@ -104,7 +106,8 @@ export const buildReverbAnalyticsModel = ({
         },
       },
       user: {
-        isSignedIn: false,
+        isSignedIn,
+        hashedId,
       },
     },
     eventDetails,
@@ -127,6 +130,8 @@ export const buildReverbEventModel = ({
   itemTracker = {},
   groupTracker = {},
   eventGroupingName,
+  isSignedIn = false,
+  hashedId = null,
 }: ATIEventTrackingProps): ReverbBeaconConfig => {
   const {
     type: itemType,
@@ -160,7 +165,8 @@ export const buildReverbEventModel = ({
         },
       },
       user: {
-        isSignedIn: false,
+        isSignedIn,
+        hashedId,
       },
     },
     eventDetails: {

--- a/src/app/components/ATIAnalytics/beacon/index.ts
+++ b/src/app/components/ATIAnalytics/beacon/index.ts
@@ -17,6 +17,8 @@ export const sendEventBeacon = async ({
   itemTracker,
   groupTracker,
   eventGroupingName,
+  isSignedIn,
+  hashedId,
 }: ATIEventTrackingProps) => {
   const reverbParams = buildReverbEventModel({
     pageIdentifier,
@@ -33,6 +35,8 @@ export const sendEventBeacon = async ({
     itemTracker,
     groupTracker,
     eventGroupingName,
+    isSignedIn,
+    hashedId,
   });
 
   await sendBeacon(reverbParams);

--- a/src/app/components/ATIAnalytics/index.tsx
+++ b/src/app/components/ATIAnalytics/index.tsx
@@ -6,16 +6,20 @@ import AmpATIAnalytics from './amp';
 import AmpGeo from '../../legacy/components/AmpGeo';
 import { ATIProps } from './types';
 import buildReverbParams from './params';
+import useUserTrackingData from '../../hooks/useUserTrackingData';
 
 const ATIAnalytics = ({ atiData = {} }: ATIProps) => {
   const requestContext = use(RequestContext);
   const serviceContext = use(ServiceContext);
   const { isAmp } = requestContext;
+  const { isSignedIn, hashedId } = useUserTrackingData();
 
   const reverbParams = buildReverbParams({
     requestContext,
     serviceContext,
     atiData,
+    isSignedIn,
+    hashedId,
   });
 
   return isAmp ? (

--- a/src/app/components/ATIAnalytics/params/buildParams/index.ts
+++ b/src/app/components/ATIAnalytics/params/buildParams/index.ts
@@ -6,7 +6,12 @@ export const buildPageATIParams = ({
   atiData,
   requestContext,
   serviceContext,
-}: ATIDataWithContexts) => {
+  isSignedIn = false,
+  hashedId = null,
+}: ATIDataWithContexts & {
+  isSignedIn?: boolean;
+  hashedId?: string | null;
+}) => {
   const { isUK, platform, statsDestination } = requestContext;
   const {
     atiAnalyticsAppName,
@@ -55,6 +60,8 @@ export const buildPageATIParams = ({
     statsDestination,
     timePublished,
     timeUpdated,
+    isSignedIn,
+    hashedId,
     ...(ampExperimentName && { ampExperimentName }),
     ...(experimentName && { experimentName }),
     ...(experimentVariant && { experimentVariant }),
@@ -65,7 +72,18 @@ export const buildPageReverbParams = ({
   atiData,
   requestContext,
   serviceContext,
-}: ATIDataWithContexts) =>
+  isSignedIn,
+  hashedId,
+}: ATIDataWithContexts & {
+  isSignedIn?: boolean;
+  hashedId?: string | null;
+}) =>
   buildReverbAnalyticsModel(
-    buildPageATIParams({ atiData, requestContext, serviceContext }),
+    buildPageATIParams({
+      atiData,
+      requestContext,
+      serviceContext,
+      isSignedIn,
+      hashedId,
+    }),
   );

--- a/src/app/components/ATIAnalytics/params/index.ts
+++ b/src/app/components/ATIAnalytics/params/index.ts
@@ -5,6 +5,17 @@ export default ({
   requestContext,
   serviceContext,
   atiData,
-}: ReverbDetailsProviders) => {
-  return buildPageReverbParams({ atiData, requestContext, serviceContext });
+  isSignedIn,
+  hashedId,
+}: ReverbDetailsProviders & {
+  isSignedIn?: boolean;
+  hashedId?: string | null;
+}) => {
+  return buildPageReverbParams({
+    atiData,
+    requestContext,
+    serviceContext,
+    isSignedIn,
+    hashedId,
+  });
 };

--- a/src/app/components/ATIAnalytics/types.ts
+++ b/src/app/components/ATIAnalytics/types.ts
@@ -115,6 +115,7 @@ export type ReverbPageVars = {
 
 export type ReverbUserVars = {
   isSignedIn: boolean;
+  hashedId?: string | null;
 };
 
 export type ReverbEventDetails = {
@@ -167,6 +168,8 @@ export interface ATIEventTrackingProps {
   groupTracker?: GroupTracker;
   viewThreshold?: number;
   eventGroupingName?: string;
+  isSignedIn?: boolean;
+  hashedId?: string | null;
 }
 
 export interface ItemTracker {
@@ -210,6 +213,8 @@ export interface ATIPageTrackingProps {
   ampExperimentName?: string;
   experimentName?: string | null;
   experimentVariant?: string | null;
+  isSignedIn?: boolean;
+  hashedId?: string | null;
 }
 
 export interface ATIProps {

--- a/src/app/components/Account/AccountHeader/index.tsx
+++ b/src/app/components/Account/AccountHeader/index.tsx
@@ -1,9 +1,11 @@
-import { use } from 'react';
+import { use, useMemo } from 'react';
 import { AccountContext } from '#contexts/AccountContext';
 import { ServiceContext } from '#contexts/ServiceContext';
 import useHydrationDetection from '#hooks/useHydrationDetection';
 import Text from '#app/components/Text';
 import { AccountIcon } from '#app/components/icons';
+import useViewTracker from '#app/hooks/useViewTracker';
+import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import styles from './index.styles';
 
 const AccountHeader = () => {
@@ -11,6 +13,19 @@ const AccountHeader = () => {
   const { isSignedIn, signInUrl, settingsUrl, isIdctaAvailable } =
     use(AccountContext);
   const { translations } = use(ServiceContext);
+
+  const clickComponentName = useMemo(
+    () => (isSignedIn ? 'account-header-settings' : 'account-header-sign-in'),
+    [isSignedIn],
+  );
+
+  const viewTracker = useViewTracker({
+    componentName: 'account-header',
+  });
+
+  const { onClick: onClickTrack } = useClickTrackerHandler({
+    componentName: clickComponentName,
+  });
 
   if (!isHydrated || !isIdctaAvailable) return null;
 
@@ -22,8 +37,14 @@ const AccountHeader = () => {
   if (!href || !label) return null;
 
   return (
-    <div css={styles.wrapper}>
-      <Text as="a" css={styles.link} href={href} fontVariant="sansBold">
+    <div css={styles.wrapper} {...viewTracker}>
+      <Text
+        as="a"
+        css={styles.link}
+        href={href}
+        fontVariant="sansBold"
+        onClick={onClickTrack}
+      >
         <AccountIcon css={styles.icon} />
         {label}
       </Text>

--- a/src/app/components/Account/AccountPromotionalBanner/index.tsx
+++ b/src/app/components/Account/AccountPromotionalBanner/index.tsx
@@ -1,4 +1,4 @@
-import { use, useState } from 'react';
+import { use, useState, useCallback } from 'react';
 import Paragraph from '#app/components/Paragraph';
 import PromotionalBanner from '#app/components/PromotionalBanner';
 import CallToActionLink from '#app/components/CallToActionLink';
@@ -6,6 +6,8 @@ import { AccountIcon } from '#app/components/icons';
 import { AccountContext } from '#contexts/AccountContext';
 import { ServiceContext } from '#app/contexts/ServiceContext';
 import useToggle from '#app/hooks/useToggle';
+import useViewTracker from '#app/hooks/useViewTracker';
+import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import styles from './index.styles';
 import { setAccountPromoBannerDismissed } from './utilities';
 
@@ -24,6 +26,25 @@ const AccountPromotionalBanner = () => {
   const registerText = translations?.account?.register;
   const [isDismissed, setIsDismissed] = useState(!isAccountPromoBannerVisible);
 
+  const viewTracker = useViewTracker({
+    componentName: 'account-promotional-banner',
+  });
+
+  const { onClick: onCloseClickTrack } = useClickTrackerHandler({
+    componentName: 'account-promotional-banner-close',
+  });
+
+  const handleCloseClick = useCallback(
+    async (event?: React.MouseEvent) => {
+      if (onCloseClickTrack) {
+        await onCloseClickTrack(event);
+      }
+      setAccountPromoBannerDismissed();
+      setIsDismissed(true);
+    },
+    [onCloseClickTrack],
+  );
+
   if (
     isDismissed ||
     isSignedIn ||
@@ -40,48 +61,54 @@ const AccountPromotionalBanner = () => {
     accountPromoBannerTranslations;
 
   return (
-    <PromotionalBanner
-      id="account-promotional-banner"
-      title={title}
-      description={description}
-      bannerLabel={title}
-      closeLabel={closeLabel}
-      buttonSeparatorText={buttonSeparatorText}
-      isDismissible
-      onClose={() => {
-        setAccountPromoBannerDismissed();
-        setIsDismissed(true);
-      }}
-    >
-      <CallToActionLink
-        url={signInUrl}
-        className="focusIndicatorInvert"
-        css={[styles.callToActionLink, styles.signInLink]}
+    <div {...viewTracker}>
+      <PromotionalBanner
+        id="account-promotional-banner"
+        title={title}
+        description={description}
+        bannerLabel={title}
+        closeLabel={closeLabel}
+        buttonSeparatorText={buttonSeparatorText}
+        isDismissible
+        onClose={handleCloseClick}
+        {...viewTracker}
       >
-        <CallToActionLink.ButtonLikeWrapper>
-          <AccountIcon css={styles.accountIcon} />
-          <CallToActionLink.Text shouldUnderlineOnHoverFocus>
-            {signInText}
-          </CallToActionLink.Text>
-        </CallToActionLink.ButtonLikeWrapper>
-      </CallToActionLink>
+        <CallToActionLink
+          url={signInUrl}
+          className="focusIndicatorInvert"
+          css={[styles.callToActionLink, styles.signInLink]}
+          eventTrackingData={{
+            componentName: 'account-promotional-banner-sign-in',
+          }}
+        >
+          <CallToActionLink.ButtonLikeWrapper>
+            <AccountIcon css={styles.accountIcon} />
+            <CallToActionLink.Text shouldUnderlineOnHoverFocus>
+              {signInText}
+            </CallToActionLink.Text>
+          </CallToActionLink.ButtonLikeWrapper>
+        </CallToActionLink>
 
-      <Paragraph size="bodyCopy" css={styles.buttonSeparatorText}>
-        {buttonSeparatorText}
-      </Paragraph>
+        <Paragraph size="bodyCopy" css={styles.buttonSeparatorText}>
+          {buttonSeparatorText}
+        </Paragraph>
 
-      <CallToActionLink
-        url={registerUrl}
-        className="focusIndicatorInvert"
-        css={[styles.callToActionLink, styles.registerLink]}
-      >
-        <CallToActionLink.ButtonLikeWrapper>
-          <CallToActionLink.Text shouldUnderlineOnHoverFocus>
-            {registerText}
-          </CallToActionLink.Text>
-        </CallToActionLink.ButtonLikeWrapper>
-      </CallToActionLink>
-    </PromotionalBanner>
+        <CallToActionLink
+          url={registerUrl}
+          className="focusIndicatorInvert"
+          css={[styles.callToActionLink, styles.registerLink]}
+          eventTrackingData={{
+            componentName: 'account-promotional-banner-register',
+          }}
+        >
+          <CallToActionLink.ButtonLikeWrapper>
+            <CallToActionLink.Text shouldUnderlineOnHoverFocus>
+              {registerText}
+            </CallToActionLink.Text>
+          </CallToActionLink.ButtonLikeWrapper>
+        </CallToActionLink>
+      </PromotionalBanner>
+    </div>
   );
 };
 

--- a/src/app/components/SaveArticleButton/index.tsx
+++ b/src/app/components/SaveArticleButton/index.tsx
@@ -1,9 +1,11 @@
 import useUASButton, { UASAction } from '#app/hooks/useUASButton';
-import { use, useContext } from 'react';
+import { use, useContext, useMemo } from 'react';
 import { ServiceContext } from '#contexts/ServiceContext';
 import { RequestContext } from '#app/contexts/RequestContext';
 import parseRoute from '#app/routes/utils/parseRoute';
 import { Article } from '#app/models/types/optimo';
+import useClickTracker from '#app/hooks/useClickTrackerHandler';
+import useViewTracker from '#app/hooks/useViewTracker';
 import SaveButton from '../SaveButton';
 import styles from './index.styles';
 
@@ -27,6 +29,25 @@ const SaveArticleButton = ({
       articlePageData,
     });
 
+  const clickComponentName = useMemo(
+    () =>
+      `save-article-button-click-${
+        isSaved ? UASAction.REMOVE : UASAction.SAVE
+      }`,
+    [isSaved],
+  );
+
+  const viewTracker = useViewTracker({
+    componentName: 'save-article-button-view',
+  });
+
+  const { onClick: onClickTrack } = useClickTracker({
+    componentName: clickComponentName,
+    itemTracker: {
+      resourceId: articleId,
+    },
+  });
+
   if (!showButton) return null;
 
   if (!saveArticleButton) return null;
@@ -45,12 +66,13 @@ const SaveArticleButton = ({
 
   const buttonText = isLoading ? saveArticleButton.saving : buttonLabel;
 
-  const handleClick = () => {
+  const handleClick = (event?: React.MouseEvent) => {
+    onClickTrack?.(event);
     handleSaveAction(isSaved ? UASAction.REMOVE : UASAction.SAVE);
   };
 
   return (
-    <div css={styles.buttonWrapper}>
+    <div css={styles.buttonWrapper} {...viewTracker}>
       <SaveButton
         onClick={handleClick}
         isLoading={isLoading}

--- a/src/app/contexts/EventTrackingContext/index.tsx
+++ b/src/app/contexts/EventTrackingContext/index.tsx
@@ -2,6 +2,7 @@ import { createContext, PropsWithChildren, use, useMemo } from 'react';
 
 import { RequestContext } from '../RequestContext';
 import useToggle from '../../hooks/useToggle';
+import useUserTrackingData from '../../hooks/useUserTrackingData';
 import {
   ARTICLE_PAGE,
   MOST_READ_PAGE,
@@ -85,6 +86,8 @@ export const EventTrackingContextProvider = ({
   const serviceContext = use(ServiceContext);
   const { atiAnalyticsProducerId, atiAnalyticsProducerName } = serviceContext;
 
+  const { isSignedIn, hashedId } = useUserTrackingData();
+
   const { enabled: eventTrackingIsEnabled } = useToggle('eventTracking');
 
   const trackingProps = useMemo(() => {
@@ -99,6 +102,8 @@ export const EventTrackingContextProvider = ({
         producerId: atiAnalyticsProducerId,
         producerName: atiAnalyticsProducerName,
         statsDestination,
+        isSignedIn,
+        hashedId,
       };
     }
     return null;
@@ -110,6 +115,8 @@ export const EventTrackingContextProvider = ({
     pageType,
     platform,
     statsDestination,
+    isSignedIn,
+    hashedId,
   ]);
 
   if (!eventTrackingIsEnabled || !atiData) {
@@ -120,9 +127,16 @@ export const EventTrackingContextProvider = ({
     );
   }
 
-  const hasRequiredProps = Object.values(
-    trackingProps as EventTrackingContextProps,
-  ).every(Boolean);
+  const hasRequiredProps =
+    trackingProps &&
+    [
+      trackingProps.campaignID,
+      trackingProps.pageIdentifier,
+      trackingProps.platform,
+      trackingProps.producerId,
+      trackingProps.producerName,
+      trackingProps.statsDestination,
+    ].every(Boolean);
 
   return (
     <EventTrackingContext.Provider

--- a/src/app/hooks/useClickTrackerHandler/index.jsx
+++ b/src/app/hooks/useClickTrackerHandler/index.jsx
@@ -54,6 +54,8 @@ const useClickTrackerHandler = (eventTrackingData = {}) => {
     experimentVariant,
     groupTracker,
     itemTracker,
+    isSignedIn,
+    hashedId,
   } = extractATITrackingProps({ eventTrackingData, eventType: CLICK_EVENT });
 
   const { trackingIsEnabled } = useTrackingToggle(componentName);
@@ -87,6 +89,7 @@ const useClickTrackerHandler = (eventTrackingData = {}) => {
           service,
           statsDestination,
         ].every(Boolean);
+
         if (shouldSendEvent) {
           event.stopPropagation();
           event.preventDefault();
@@ -132,6 +135,8 @@ const useClickTrackerHandler = (eventTrackingData = {}) => {
               detailedPlacement,
               ...(groupTracker && { groupTracker }),
               ...(itemTracker && { itemTracker }),
+              isSignedIn,
+              hashedId,
               ...(experimentVariant &&
                 experimentVariant !== 'off' && {
                   experimentName,
@@ -171,6 +176,8 @@ const useClickTrackerHandler = (eventTrackingData = {}) => {
       itemTracker,
       experimentName,
       preventNavigation,
+      isSignedIn,
+      hashedId,
     ],
   );
 };

--- a/src/app/hooks/useCustomEventTracker/index.tsx
+++ b/src/app/hooks/useCustomEventTracker/index.tsx
@@ -34,6 +34,8 @@ const useCustomEventTracker = ({
     statsDestination,
     campaignID,
     producerName,
+    isSignedIn,
+    hashedId,
   } = extractATITrackingProps({
     eventType: VIEW_EVENT,
   });
@@ -71,6 +73,8 @@ const useCustomEventTracker = ({
             statsDestination,
             experimentName,
             experimentVariant,
+            isSignedIn,
+            hashedId,
           });
         } catch (error) {
           // eslint-disable-next-line no-console
@@ -90,6 +94,8 @@ const useCustomEventTracker = ({
       statsDestination,
       experimentName,
       experimentVariant,
+      isSignedIn,
+      hashedId,
     ],
   );
 

--- a/src/app/hooks/useUserTrackingData/index.ts
+++ b/src/app/hooks/useUserTrackingData/index.ts
@@ -1,0 +1,46 @@
+import { use, useMemo } from 'react';
+import Cookie from 'js-cookie';
+import { AccountContext } from '#app/contexts/AccountContext';
+import onClient from '#lib/utilities/onClient';
+
+interface UserTrackingData {
+  isSignedIn: boolean;
+  hashedId: string | null;
+}
+
+/**
+ * Hook to get user tracking data (signed-in state and hashed ID)
+ * for use in analytics events.
+ *
+ * Returns:
+ * - isSignedIn: boolean (from cookie or AccountContext)
+ * - hashedId: hashed user ID from ckns_sylphid cookie, or null if not present
+ */
+const useUserTrackingData = (): UserTrackingData => {
+  const { isSignedIn: isSignedInFromContext } = use(AccountContext);
+
+  const trackingData = useMemo(() => {
+    let isSignedIn = !!isSignedInFromContext;
+    let hashedId: string | null = null;
+
+    if (onClient()) {
+      const userCookie = Cookie.get('ckns_id');
+      const userIdCookie = Cookie.get('ckns_sylphid');
+
+      if (userCookie) {
+        isSignedIn = true;
+        hashedId = userIdCookie || null;
+      }
+    }
+
+    return {
+      isSignedIn,
+      hashedId,
+    };
+  }, [isSignedInFromContext]);
+
+  return trackingData;
+};
+
+export default useUserTrackingData;
+export type { UserTrackingData };

--- a/src/app/lib/analyticsUtils/extractATITrackingProps/index.ts
+++ b/src/app/lib/analyticsUtils/extractATITrackingProps/index.ts
@@ -32,6 +32,8 @@ export default ({
     producerId,
     statsDestination,
     producerName,
+    isSignedIn,
+    hashedId,
   } = eventTrackingContext;
 
   const campaignID =
@@ -58,5 +60,7 @@ export default ({
     groupTracker,
     viewThreshold,
     alwaysInView,
+    isSignedIn,
+    hashedId,
   };
 };

--- a/src/app/lib/analyticsUtils/sendBeacon/index.ts
+++ b/src/app/lib/analyticsUtils/sendBeacon/index.ts
@@ -59,7 +59,7 @@ const setReverbPageValues = async ({
   });
 
   window.bbcuser = {
-    getHashedId: () => null,
+    getHashedId: () => Promise.resolve(userVars.hashedId ?? null),
     isSignedIn: () => Promise.resolve(userVars.isSignedIn),
   };
 };

--- a/src/app/models/types/eventTracking.ts
+++ b/src/app/models/types/eventTracking.ts
@@ -32,5 +32,7 @@ export type EventTrackingContextProps =
       producerId: string;
       statsDestination: string;
       producerName: string;
+      isSignedIn?: boolean;
+      hashedId?: string | null;
     }
   | Record<string, never>;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -31,7 +31,7 @@ declare global {
         }
       | object;
     bbcuser: {
-      getHashedId: () => null;
+      getHashedId: () => Promise<string | null>;
       isSignedIn: () => Promise<boolean>;
     };
     __reverb: {

--- a/ws-nextjs-app/pages/[service]/my-news/MyNewsPage.tsx
+++ b/ws-nextjs-app/pages/[service]/my-news/MyNewsPage.tsx
@@ -5,12 +5,14 @@ import { ServiceContext } from '#app/contexts/ServiceContext';
 import { useContext } from 'react';
 import { useRouter } from 'next/router';
 import MetadataContainer from '#app/components/Metadata';
+import ATIAnalytics from '#app/components/ATIAnalytics';
 import useUASRecentActivity from '#app/hooks/useUASRecentActivity';
+import { PageData } from '#app/lib/config/fixtures/types';
 import styles from './styles';
 
 const ITEMS_PER_PAGE = 10;
 
-const MyNewsPage = () => {
+const MyNewsPage = ({ pageData }: { pageData?: PageData }) => {
   const router = useRouter();
   const { translations, lang } = useContext(ServiceContext);
 
@@ -27,6 +29,8 @@ const MyNewsPage = () => {
 
   const pageCount = Math.max(1, Math.ceil(total / ITEMS_PER_PAGE));
   const safeActivePage = Math.min(requestedPage, pageCount);
+
+  const atiAnalytics = pageData?.metadata?.atiAnalytics;
 
   const {
     pageXOfY = 'Page {x} of {y}',
@@ -97,6 +101,7 @@ const MyNewsPage = () => {
 
   return (
     <main css={styles.main}>
+      <ATIAnalytics atiData={atiAnalytics} />
       <MetadataContainer
         title={metadataTitle}
         openGraphType="website"

--- a/ws-nextjs-app/pages/[service]/my-news/index.page.tsx
+++ b/ws-nextjs-app/pages/[service]/my-news/index.page.tsx
@@ -47,6 +47,9 @@ export const getServerSideProps: GetServerSideProps = async context => {
       pageData: {
         metadata: {
           type: MY_NEWS_PAGE,
+          atiAnalytics: {
+            pageIdentifier: 'my-news.page',
+          },
         },
       },
     },


### PR DESCRIPTION

Resolves JIRA: https://bbc.atlassian.net/browse/WS-2215

Summary
======
Track UAS SaveForLater and IDCTA account‑related view and click events

Code changes
======
**User Authentication Data Propagation:**

- Added `isSignedIn` and `hashedId` to analytics model and event tracking types, ensuring these user properties are passed through all relevant functions and components, including `buildReverbAnalyticsModel`, `buildReverbEventModel`, and their respective parameter builders.

- Updated the `EventTrackingContextProvider` and the main analytics entry point to use the `useUserTrackingData` hook, making `isSignedIn` and `hashedId` available in analytics contexts and ensuring they're included in all analytics payloads.

**Component-Level Event Tracking Enhancements:**

- Integrated `useViewTracker` and `useClickTrackerHandler` hooks into `AccountHeader`, `AccountPromotionalBanner`, and `SaveArticleButton` components, enabling detailed view and click analytics for these UI elements. This includes dynamic component naming for click events and passing relevant tracking data (such as resource IDs). 

**Analytics Hook Improvements:**

- Updated the click tracker handler to accept and forward `isSignedIn` and `hashedId` as part of event tracking data, ensuring user authentication state is included with each event. 
These changes collectively improve the granularity and accuracy of analytics, especially regarding user authentication state, and ensure that key user interactions are tracked in detail.

Testing
======
Event names :

SaveArticleButton :
save-article-button-click-save and save-article-button-click-remove for button clicks
save-article-button-view - for view
Piano dashboard - https://analytics.piano.io/dataquery/#/designer?reportid=69fc727210a9df2f7a011419

AccountPromotionalBanner:
account-promotional-banner - for view
account-promotional-banner-close - for closing
account-promotional-banner-sign-in - for signin click
account-promotional-banner-register - for register click

Account header:
account-header - for view
account-header-settings - for settings click
account-header-sign-in - for signin click
Piano Dashboard - https://analytics.piano.io/dataquery/#/designer?reportid=6a033bbb5e9acc6f81847ccb

MyNews page:
my_news.page - for the view of page
Piano dashboard -https://analytics.piano.io/dataquery/#/designer?reportid=69fde2d421b0d1e734c23d33