### PR TITLE
Fix PV carousel heading with link theme

### DIFF
--- a/src/app/components/Curation/Subhead/index.styles.ts
+++ b/src/app/components/Curation/Subhead/index.styles.ts
@@ -1,13 +1,13 @@
 import { css, Theme } from '@emotion/react';
 
 const styles = {
-  h2: ({ palette, fontVariants, fontSizes }: Theme) =>
+  h2: ({ palette, fontVariants, fontSizes, isDarkUi }: Theme) =>
     css({
       ...fontVariants.sansBold,
       ...fontSizes.doublePica,
-      color: palette.GREY_10,
+      color: isDarkUi ? palette.GREY_2 : palette.GREY_10,
       a: {
-        color: palette.GREY_10,
+        color: isDarkUi ? palette.GREY_2 : palette.GREY_10,
         textDecoration: 'none',
         display: 'inline-block',
       },
@@ -16,7 +16,7 @@ const styles = {
         position: 'relative',
       },
       'a:visited': {
-        color: palette.GREY_10,
+        color: isDarkUi ? palette.GREY_2 : palette.GREY_10,
       },
       'a: hover, a:focus': {
         color: palette.POSTBOX,

--- a/src/app/components/Curation/Subhead/index.styles.ts
+++ b/src/app/components/Curation/Subhead/index.styles.ts
@@ -5,9 +5,9 @@ const styles = {
     css({
       ...fontVariants.sansBold,
       ...fontSizes.doublePica,
-      color: isDarkUi ? palette.GREY_2 : palette.GREY_10,
+      color: isDarkUi ? palette.GHOST : palette.GREY_10,
       a: {
-        color: isDarkUi ? palette.GREY_2 : palette.GREY_10,
+        color: isDarkUi ? palette.GHOST : palette.GREY_10,
         textDecoration: 'none',
         display: 'inline-block',
       },
@@ -16,7 +16,7 @@ const styles = {
         position: 'relative',
       },
       'a:visited': {
-        color: isDarkUi ? palette.GREY_2 : palette.GREY_10,
+        color: isDarkUi ? palette.GHOST : palette.GREY_10,
       },
       'a: hover, a:focus': {
         color: palette.POSTBOX,


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Fixes PV Carousel heading darkmode issues on liveTv pages 

Code changes
======
- Add isDarkUi checks to Subhead component

Testing
======
http://localhost.bbc.com:7081/hindi/watch/bbc_hindi_tv/live?renderer_env=live

Before:
<img width="1202" height="413" alt="image" src="https://github.com/user-attachments/assets/7a79909d-6ea5-4a8e-b229-d789f00cc19d" />

After:
<img width="1202" height="413" alt="image" src="https://github.com/user-attachments/assets/4b56ce60-7e9b-4421-b638-2baf8833e150" />


## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
