### PR TITLE
WS 2576 - Sport Data Header Visually hidden H2 translations

### DIFF
--- a/src/app/lib/config/services/afaanoromoo.ts
+++ b/src/app/lib/config/services/afaanoromoo.ts
@@ -62,6 +62,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'Cuunfaa Taphaa',
       and: 'fi',
       readTime: {
         readTimePrefix: 'Yeroo dubbisuu',

--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -65,6 +65,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'Résumé du match',
       and: 'et',
       readTime: {
         readTimePrefix: 'Temps de lecture',

--- a/src/app/lib/config/services/amharic.ts
+++ b/src/app/lib/config/services/amharic.ts
@@ -60,6 +60,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'የጨዋታ ማጠቃለያ',
       and: 'እና',
       readTime: {
         readTimePrefix: 'የንባብ ጊዜ',

--- a/src/app/lib/config/services/arabic.ts
+++ b/src/app/lib/config/services/arabic.ts
@@ -66,6 +66,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'ملخص المباراة',
       and: 'و',
       readTime: {
         readTimePrefix: 'مدة القراءة',

--- a/src/app/lib/config/services/azeri.ts
+++ b/src/app/lib/config/services/azeri.ts
@@ -65,6 +65,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'Matçın xülasəsi',
       and: 'və',
       readTime: {
         readTimePrefix: 'Oxuma vaxtı',

--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -67,6 +67,7 @@ export const service: DefaultServiceConfig = {
     },
     googleSiteVerification: 'D-aEHUiyVaMoUJXjVRbDVkxS0dLTMUZLD3dLPTnWO4Q',
     translations: {
+      matchSummary: 'ম্যাচের সারসংক্ষেপ',
       and: 'এবং',
       readTime: {
         readTimePrefix: 'পড়ার সময়',

--- a/src/app/lib/config/services/burmese.ts
+++ b/src/app/lib/config/services/burmese.ts
@@ -61,6 +61,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'ပွဲအကျဉ်းချုပ်',
       and: 'နှင့်',
       readTime: {
         readTimePrefix: 'ဖတ်ရန်အချိန်',

--- a/src/app/lib/config/services/dari.ts
+++ b/src/app/lib/config/services/dari.ts
@@ -46,6 +46,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: true,
     showRelatedTopics: true,
     translations: {
+      matchSummary: 'خلاصه مسابقه',
       and: 'و',
       readTime: {
         readTimePrefix: 'زمان مطالعه',

--- a/src/app/lib/config/services/gahuza.ts
+++ b/src/app/lib/config/services/gahuza.ts
@@ -60,6 +60,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'Incamake y’umukino',
       and: 'na',
       readTime: {
         readTimePrefix: 'Igihe co gusoma',

--- a/src/app/lib/config/services/gujarati.ts
+++ b/src/app/lib/config/services/gujarati.ts
@@ -65,6 +65,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'મેચનો સારાંશ',
       and: 'અને',
       readTime: {
         readTimePrefix: 'વાંચવાનો સમય',

--- a/src/app/lib/config/services/hausa.ts
+++ b/src/app/lib/config/services/hausa.ts
@@ -65,6 +65,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'Takaitaccen Bayanin Wasa',
       and: 'da',
       readTime: {
         readTimePrefix: 'Lokacin karatu',

--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -67,6 +67,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'मैच का सारांश',
       and: 'और',
       readTime: {
         readTimePrefix: 'पढ़ने का समय',

--- a/src/app/lib/config/services/igbo.ts
+++ b/src/app/lib/config/services/igbo.ts
@@ -64,6 +64,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'Nchịkọta Asọmpi',
       and: 'na',
       readTime: {
         readTimePrefix: 'Oge e ji agụ akụkọ',

--- a/src/app/lib/config/services/indonesia.ts
+++ b/src/app/lib/config/services/indonesia.ts
@@ -67,6 +67,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'Ringkasan Pertandingan',
       and: 'dan',
       readTime: {
         readTimePrefix: 'Waktu membaca',

--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -47,6 +47,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: false,
     showRelatedTopics: true,
     translations: {
+      matchSummary: '경기 요약',
       and: '',
       readTime: {
         readTimePrefix: '읽는 시간',

--- a/src/app/lib/config/services/kyrgyz.ts
+++ b/src/app/lib/config/services/kyrgyz.ts
@@ -65,6 +65,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'Оюндун жыйынтыгы',
       and: 'жана',
       readTime: {
         readTimePrefix: 'Окуу убактысы',

--- a/src/app/lib/config/services/magyarul.ts
+++ b/src/app/lib/config/services/magyarul.ts
@@ -45,6 +45,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: false,
     showRelatedTopics: true,
     translations: {
+      matchSummary: 'Mérkőzés összefoglaló',
       and: 'és',
       pagination: {
         page: 'Lap',

--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -61,6 +61,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'सामन्याचा सारांश',
       and: 'आणि',
       readTime: {
         readTimePrefix: 'वाचन वेळ',

--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -88,6 +88,7 @@ export const service: DefaultServiceConfig = {
       closeLabel: 'Salir',
     },
     translations: {
+      matchSummary: 'Resumen del partido',
       and: 'y',
       readTime: {
         readTimePrefix: 'Tiempo de lectura',

--- a/src/app/lib/config/services/nepali.ts
+++ b/src/app/lib/config/services/nepali.ts
@@ -47,6 +47,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: true,
     showRelatedTopics: true,
     translations: {
+      matchSummary: 'खेलको सारांश',
       and: 'र',
       readTime: {
         readTimePrefix: 'पढ्ने समय',

--- a/src/app/lib/config/services/pashto.ts
+++ b/src/app/lib/config/services/pashto.ts
@@ -49,6 +49,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: true,
     showRelatedTopics: true,
     translations: {
+      matchSummary: 'د لوبې لنډیز',
       and: 'او',
       pagination: {
         page: 'پاڼه',

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -67,6 +67,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'خلاصه مسابقه',
       and: 'و',
       pagination: {
         page: 'صفحه',

--- a/src/app/lib/config/services/pidgin.ts
+++ b/src/app/lib/config/services/pidgin.ts
@@ -47,6 +47,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: false,
     showRelatedTopics: true,
     translations: {
+      matchSummary: 'Match Summary',
       and: 'and',
       readTime: {
         readTimePrefix: 'Read am in',

--- a/src/app/lib/config/services/polska.ts
+++ b/src/app/lib/config/services/polska.ts
@@ -44,6 +44,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: false,
     showRelatedTopics: true,
     translations: {
+      matchSummary: 'Podsumowanie meczu',
       and: 'i',
       pagination: {
         page: 'Strona',

--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -66,6 +66,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'Resumo da partida',
       and: 'e',
       readTime: {
         readTimePrefix: 'Tempo de leitura',

--- a/src/app/lib/config/services/punjabi.ts
+++ b/src/app/lib/config/services/punjabi.ts
@@ -47,6 +47,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: false,
     showRelatedTopics: true,
     translations: {
+      matchSummary: 'ਮੈਚ ਦਾ ਸਾਰ',
       and: 'ਅਤੇ',
       readTime: {
         readTimePrefix: 'ਪੜ੍ਹਨ ਦਾ ਸਮਾਂ',

--- a/src/app/lib/config/services/romania.ts
+++ b/src/app/lib/config/services/romania.ts
@@ -44,6 +44,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: false,
     showRelatedTopics: true,
     translations: {
+      matchSummary: 'Rezumatul meciului',
       and: 'și',
       readTime: {
         readTimePrefix: 'Timp de lectură',

--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -109,6 +109,7 @@ const headerFooterTranslations = {
 export const service: DefaultServiceConfig = {
   default: {
     translations: {
+      matchSummary: 'Обзор матча',
       and: 'и',
       readTime: {
         readTimePrefix: 'Время чтения',

--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -126,6 +126,7 @@ export const service: SerbianConfig = {
       variant: 'cyr',
     },
     translations: {
+      matchSummary: 'Rezime utakmice',
       and: 'i',
       readTime: {
         readTimePrefix: 'Vreme čitanja',
@@ -523,6 +524,7 @@ export const service: SerbianConfig = {
       variant: 'lat',
     },
     translations: {
+      matchSummary: 'Резиме утакмице',
       and: 'и',
       readTime: {
         readTimePrefix: 'Време читања',

--- a/src/app/lib/config/services/sinhala.ts
+++ b/src/app/lib/config/services/sinhala.ts
@@ -61,6 +61,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'තරඟ සාරාංශය',
       and: 'සහ',
       readTime: {
         readTimePrefix: 'කියවීමේ කාලය',

--- a/src/app/lib/config/services/somali.ts
+++ b/src/app/lib/config/services/somali.ts
@@ -65,6 +65,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'Soo koobidda ciyaarta',
       and: 'iyo',
       readTime: {
         readTimePrefix: 'Waqtiga akhriska',

--- a/src/app/lib/config/services/swahili.ts
+++ b/src/app/lib/config/services/swahili.ts
@@ -65,6 +65,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'Muhtasari wa mechi',
       and: 'na',
       readTime: {
         readTimePrefix: 'Muda wa kusoma',

--- a/src/app/lib/config/services/tamil.ts
+++ b/src/app/lib/config/services/tamil.ts
@@ -65,6 +65,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'போட்டி சுருக்கம்',
       and: 'மற்றும்',
       readTime: {
         readTimePrefix: 'வாசிக்கும் நேரம்',

--- a/src/app/lib/config/services/telugu.ts
+++ b/src/app/lib/config/services/telugu.ts
@@ -47,6 +47,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: false,
     showRelatedTopics: true,
     translations: {
+      matchSummary: 'మ్యాచ్ సారాంశం',
       and: 'మరియు',
       readTime: {
         readTimePrefix: 'చదివే సమయం',

--- a/src/app/lib/config/services/thai.ts
+++ b/src/app/lib/config/services/thai.ts
@@ -47,6 +47,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: false,
     showRelatedTopics: true,
     translations: {
+      matchSummary: 'สรุปการแข่งขัน',
       and: 'และ',
       readTime: {
         readTimePrefix: 'เวลาอ่าน',

--- a/src/app/lib/config/services/tigrinya.ts
+++ b/src/app/lib/config/services/tigrinya.ts
@@ -64,6 +64,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'ሓፈሻዊ ጸብጻብ ግጥሚ',
       and: 'እና',
       readTime: {
         readTimePrefix: 'ንባብ',

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -47,6 +47,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: true,
     showRelatedTopics: true,
     translations: {
+      matchSummary: 'Maç Özeti',
       and: 've',
       readTime: {
         readTimePrefix: 'Okuma süresi',

--- a/src/app/lib/config/services/ukrainian.ts
+++ b/src/app/lib/config/services/ukrainian.ts
@@ -63,6 +63,7 @@ const baseServiceConfig = {
     },
   },
   translations: {
+    matchSummary: 'Огляд матчу',
     and: 'i',
     readTime: {
       readTimePrefix: 'Час прочитання',

--- a/src/app/lib/config/services/urdu.ts
+++ b/src/app/lib/config/services/urdu.ts
@@ -66,6 +66,7 @@ export const service: DefaultServiceConfig = {
       },
     },
     translations: {
+      matchSummary: 'میچ کا خلاصہ',
       and: 'اور',
       readTime: {
         readTimePrefix: 'مطالعے کا وقت',

--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -58,6 +58,7 @@ const defaultCyrillicConfig = {
   imageCaptionOffscreenText: 'Сурат тагсўзи, ',
   imageCopyrightOffscreenText: 'Сурат манбаси, ',
   translations: {
+    matchSummary: 'Ўйин хулосаси',
     and: 'ва',
     readTime: {
       readTimePrefix: 'Ўқилиш вақти',
@@ -387,6 +388,7 @@ export const service: UzbekConfig = {
     imageCaptionOffscreenText: 'Surat tagso‘zi, ',
     imageCopyrightOffscreenText: 'Surat manbasi, ',
     translations: {
+      matchSummary: 'O‘yin xulosasi',
       and: 'va',
       readTime: {
         readTimePrefix: "O'qilish vaqti",

--- a/src/app/lib/config/services/vietnamese.ts
+++ b/src/app/lib/config/services/vietnamese.ts
@@ -48,6 +48,7 @@ export const service: DefaultServiceConfig = {
     showAdPlaceholder: true,
     showRelatedTopics: true,
     translations: {
+      matchSummary: 'Tóm tắt trận đấu',
       and: 'và',
       readTime: {
         readTimePrefix: 'Thời gian đọc',

--- a/src/app/lib/config/services/yoruba.ts
+++ b/src/app/lib/config/services/yoruba.ts
@@ -60,6 +60,7 @@ export const service: DefaultServiceConfig = {
     swPath: '/sw.js',
     homePageTitle: 'Àbáwọlé',
     translations: {
+      matchSummary: 'Akopọ Ere',
       and: 'ati',
       pagination: {
         previousPage: 'Ìṣájú',

--- a/src/app/lib/config/services/zhongwen.ts
+++ b/src/app/lib/config/services/zhongwen.ts
@@ -134,6 +134,7 @@ export const service: ZhongwenConfig = {
       variant: 'trad',
     },
     translations: {
+      matchSummary: '比赛总结',
       and: '和',
       readTime: {
         readTimePrefix: '阅读时间',
@@ -430,6 +431,7 @@ export const service: ZhongwenConfig = {
       variant: 'simp',
     },
     translations: {
+      matchSummary: '比賽總結',
       and: '和',
       readTime: {
         readTimePrefix: '閱讀時間',

--- a/src/app/models/types/translations.ts
+++ b/src/app/models/types/translations.ts
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 export interface Translations {
+  matchSummary?: string;
   and?: string;
   pagination?: {
     page?: string;

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/index.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/index.test.tsx
@@ -109,5 +109,19 @@ describe('Live Page Header', () => {
 
       expect(tabIndex).toEqual('-1');
     });
+    it('should render a translated match summary H2 for sport data headers', async () => {
+      await act(async () => {
+        render(<Header title="I am a title" showLiveLabel showSportData />, {
+          service: 'afaanoromoo',
+        });
+      });
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: 'Cuunfaa Taphaa',
+        }),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { use, useState } from 'react';
 import Heading from '#app/components/Heading';
 import Text from '#app/components/Text';
 import LiveHeaderMedia from '#app/components/LiveHeaderMedia';
 import { MediaCollection } from '#app/components/MediaLoader/types';
 import VisuallyHiddenText from '#app/components/VisuallyHiddenText';
+import { ServiceContext } from '#app/contexts/ServiceContext';
 import MaskedImage from '#app/components/MaskedImage';
 import LiveLabelHeader from './LiveLabelHeader';
 import styles from './styles';
@@ -30,6 +31,9 @@ const Header = ({
   const [isMediaOpen, setLiveMediaOpen] = useState(false);
   const isHeaderImage = !!imageUrl && !!imageUrlTemplate && !!imageWidth;
   const isWithImageLayout = isHeaderImage || !!mediaCollections;
+  const {
+    translations: { matchSummary = 'Match Summary' },
+  } = use(ServiceContext);
 
   const watchVideoClickHandler = () => {
     setLiveMediaOpen(!isMediaOpen);
@@ -70,8 +74,7 @@ const Header = ({
               <VisuallyHiddenText>{title}</VisuallyHiddenText>
             )}
           </Heading>
-          {/* TODO - translations needed. Added H2 for accessibility reasons, matches PS */}
-          <VisuallyHiddenText as="h2">Match Summary</VisuallyHiddenText>
+          <VisuallyHiddenText as="h2">{matchSummary}</VisuallyHiddenText>
         </div>
       </div>
     );


### PR DESCRIPTION
Resolves JIRA:[WS-2576](https://bbc.atlassian.net/browse/WS-2576)

Summary
======
adds `‘Match Summary’` translations for livepage pages with sport data

Code changes
======
| File | Description |
| ---- | ----------- |
| ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx | Reads `matchSummary` from ServiceContext and uses it for the visually-hidden H2 |
| ws-nextjs-app/pages/[service]/live/[id]/Header/index.test.tsx | Adds test asserting the translated H2 renders for sport data headers |
| src/app/models/types/translations.ts | Adds optional `matchSummary` field to the `Translations` interface |
| src/app/lib/config/services/*.ts (40+ files) | Adds the `matchSummary` translation per service/variant |



## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._


[WS-2576]: https://bbc.atlassian.net/browse/WS-2576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ