### PR TITLE
NOTICKET Fix passing through of data in /head-to-head-v2/storybook/helpers

### DIFF
--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/storybook/helpers/base-component.tsx
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/storybook/helpers/base-component.tsx
@@ -36,15 +36,12 @@ const buildTeamObject = ({
   alignment: 'home' | 'away';
   data: HeadToHeadV2Data;
 }): Team => {
-  const { runningScore } = data[alignment];
-
   return {
-    id: data[alignment].id,
+    ...data[alignment],
     fullName: team,
     shortName: shortNamesMap(team),
     urn: `urn:bbc:sportsdata:football:team:${team.toLowerCase().split(' ').join('-')}`,
     actions,
-    runningScore,
     ...(score && { score, scoreUnconfirmed }),
   };
 };


### PR DESCRIPTION
Resolves comment left by copilot [here](https://github.com/bbc/simorgh/pull/13989#discussion_r3201519385)

Summary
======

We were passing through `runningScore` , where it needs to be `runningScores` to be accessed everywhere else. This skips extracting any specifc data and just passes it straight through as one object keeping it the same.

Code changes
======
- _List key code changes that have been made._

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
