### PR TITLE
WS-2660: Update UAS resourceDomain to world-service-news for WS

### DIFF
--- a/src/app/hooks/useUASButton/index.test.tsx
+++ b/src/app/hooks/useUASButton/index.test.tsx
@@ -163,7 +163,7 @@ describe('useUASButton', () => {
       expect(mockUasApiRequest).toHaveBeenCalledWith('POST', 'favourites', {
         body: {
           activityType: 'favourites',
-          resourceDomain: 'articles',
+          resourceDomain: 'world-service-news',
           resourceType: 'article',
           resourceId: '123',
           action: 'favourited',
@@ -211,7 +211,7 @@ describe('useUASButton', () => {
       });
 
       expect(mockUasApiRequest).toHaveBeenCalledWith('DELETE', 'favourites', {
-        globalId: 'urn:bbc:articles:article:123',
+        globalId: 'urn:bbc:world-service-news:article:123',
       });
     });
 

--- a/src/app/lib/uasApi/getRecentActivity.test.ts
+++ b/src/app/lib/uasApi/getRecentActivity.test.ts
@@ -24,7 +24,7 @@ const mockActivityResponse = {
       activityType: 'favourites',
       resourceId: 'article1',
       resourceType: 'article',
-      resourceDomain: 'articles',
+      resourceDomain: 'world-service-news',
       created: '2026-02-15T18:30:05Z',
       action: 'favourited',
       metaData: {
@@ -33,13 +33,13 @@ const mockActivityResponse = {
         title: 'Article Title 1',
         locatorUrl: '/hindi/articles/article1',
       },
-      '@id': 'urn:bbc:articles:article:article1',
+      '@id': 'urn:bbc:world-service-news:article:article1',
     } as UasActivityItem,
     {
       activityType: 'favourites',
       resourceId: 'article2',
       resourceType: 'article',
-      resourceDomain: 'articles',
+      resourceDomain: 'world-service-news',
       created: '2026-02-12T11:12:52Z',
       action: 'favourited',
       metaData: {
@@ -48,7 +48,7 @@ const mockActivityResponse = {
         title: 'Article Title 2',
         locatorUrl: '/Hindi/articles/article2',
       },
-      '@id': 'urn:bbc:articles:article:article2',
+      '@id': 'urn:bbc:world-service-news:article:article2',
     } as UasActivityItem,
   ],
 };
@@ -97,7 +97,7 @@ describe('getRecentActivity', () => {
       queryParams: {
         startIndex: 10,
         items: 10,
-        resourceDomain: 'articles',
+        resourceDomain: 'world-service-news',
         resourceType: 'article',
         action: 'favourited',
       },
@@ -116,7 +116,7 @@ describe('getRecentActivity', () => {
       queryParams: {
         startIndex: 0,
         items: 10,
-        resourceDomain: 'articles',
+        resourceDomain: 'world-service-news',
         resourceType: 'article',
         action: 'favourited',
       },
@@ -148,11 +148,11 @@ describe('getRecentActivity', () => {
           activityType: 'favourites',
           resourceId: 'article1',
           resourceType: 'article',
-          resourceDomain: 'articles',
+          resourceDomain: 'world-service-news',
           created: '2026-02-15T18:30:05Z',
           action: 'favourited',
           metaData: {},
-          '@id': 'urn:bbc:articles:article:article1',
+          '@id': 'urn:bbc:world-service-news:article:article1',
         } as UasActivityItem,
       ],
     };
@@ -182,7 +182,7 @@ describe('getRecentActivity', () => {
       queryParams: {
         startIndex: 0,
         items: 10,
-        resourceDomain: 'articles',
+        resourceDomain: 'world-service-news',
         resourceType: 'article',
         action: 'favourited',
       },

--- a/src/app/lib/uasApi/uasUtility.ts
+++ b/src/app/lib/uasApi/uasUtility.ts
@@ -17,7 +17,7 @@ export interface SavedArticle {
 
 const FAVOURITES_CONFIG = {
   activityType: 'favourites',
-  resourceDomain: 'articles',
+  resourceDomain: 'world-service-news',
   resourceType: 'article',
   action: 'favourited',
 } as const;


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2660

Summary
======
- Use WS specific resourceDomain - `world-service-news` 
<img width="1888" height="829" alt="Screenshot 2026-05-15 at 12 45 02" src="https://github.com/user-attachments/assets/d15f2cf0-d050-4dbd-8312-328ab4d607b2" />



Testing
======
1. http://localhost.bbc.com:7081/hindi/articles/c4g0zpel0v0o?renderer_env=live - UAS request contains `resourceDomain: "world-service-news"` 
## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
