### PR TITLE
WS-2584-improve-save-for-later-button-loading-states

### DIFF
--- a/scripts/bundleSize/bundleSizeConfig.js
+++ b/scripts/bundleSize/bundleSizeConfig.js
@@ -9,5 +9,5 @@
 
 export const VARIANCE = 5;
 
-export const MIN_SIZE = 935;
-export const MAX_SIZE = 1437;
+export const MIN_SIZE = 945;
+export const MAX_SIZE = 1447;

--- a/src/app/components/SaveArticleButton/index.test.tsx
+++ b/src/app/components/SaveArticleButton/index.test.tsx
@@ -23,6 +23,8 @@ describe('SaveArticleButton', () => {
       showButton: false,
       isSaved: false,
       isLoading: false,
+      isSaving: false,
+      isRemoving: false,
       error: null,
       handleSaveAction: mockHandleSaveAction,
     });
@@ -38,6 +40,8 @@ describe('SaveArticleButton', () => {
       showButton: true,
       isSaved: false,
       isLoading: false,
+      isSaving: false,
+      isRemoving: false,
       error: null,
       handleSaveAction: mockHandleSaveAction,
     });
@@ -51,6 +55,8 @@ describe('SaveArticleButton', () => {
       showButton: true,
       isSaved: true,
       isLoading: false,
+      isSaving: false,
+      isRemoving: false,
       error: null,
       handleSaveAction: mockHandleSaveAction,
     });
@@ -64,6 +70,26 @@ describe('SaveArticleButton', () => {
       showButton: true,
       isSaved: false,
       isLoading: true,
+      isSaving: false,
+      isRemoving: false,
+      error: null,
+      handleSaveAction: mockHandleSaveAction,
+    });
+
+    render(<SaveArticleButton {...defaultProps} />, { service: 'hindi' });
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveTextContent('Loading');
+    expect(button).toBeDisabled();
+  });
+
+  it('renders saving state and disables button', () => {
+    mockedUseUASButton.mockReturnValue({
+      showButton: true,
+      isSaved: false,
+      isLoading: false,
+      isSaving: true,
+      isRemoving: false,
       error: null,
       handleSaveAction: mockHandleSaveAction,
     });
@@ -75,11 +101,31 @@ describe('SaveArticleButton', () => {
     expect(button).toBeDisabled();
   });
 
+  it('renders removing state and disables button', () => {
+    mockedUseUASButton.mockReturnValue({
+      showButton: true,
+      isSaved: true,
+      isLoading: false,
+      isSaving: false,
+      isRemoving: true,
+      error: null,
+      handleSaveAction: mockHandleSaveAction,
+    });
+
+    render(<SaveArticleButton {...defaultProps} />, { service: 'hindi' });
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveTextContent('Removing');
+    expect(button).toBeDisabled();
+  });
+
   it('calls handleSaveAction with save when button is clicked and not already saved', async () => {
     mockedUseUASButton.mockReturnValue({
       showButton: true,
       isSaved: false,
       isLoading: false,
+      isSaving: false,
+      isRemoving: false,
       error: null,
       handleSaveAction: mockHandleSaveAction,
     });
@@ -96,6 +142,8 @@ describe('SaveArticleButton', () => {
       showButton: true,
       isSaved: false,
       isLoading: false,
+      isSaving: false,
+      isRemoving: false,
       error: null,
       handleSaveAction: mockHandleSaveAction,
     });

--- a/src/app/components/SaveArticleButton/index.tsx
+++ b/src/app/components/SaveArticleButton/index.tsx
@@ -20,12 +20,19 @@ const SaveArticleButton = ({
   const { translations } = useContext(ServiceContext);
   const { saveArticleButton } = translations || {};
   const { assetId: articleId } = parseRoute(pathname);
-  const { showButton, isSaved, isLoading, error, handleSaveAction } =
-    useUASButton({
-      articleId,
-      articleTitle,
-      articlePageData,
-    });
+  const {
+    showButton,
+    isSaved,
+    isLoading,
+    isSaving,
+    isRemoving,
+    error,
+    handleSaveAction,
+  } = useUASButton({
+    articleId,
+    articleTitle,
+    articlePageData,
+  });
 
   if (!showButton) return null;
 
@@ -43,7 +50,12 @@ const SaveArticleButton = ({
     ? saveArticleButton.saved
     : saveArticleButton.save;
 
-  const buttonText = isLoading ? saveArticleButton.saving : buttonLabel;
+  const getButtonText = () => {
+    if (isLoading) return saveArticleButton.loading;
+    if (isSaving) return saveArticleButton.saving;
+    if (isRemoving) return saveArticleButton.removing;
+    return buttonLabel;
+  };
 
   const handleClick = () => {
     handleSaveAction(isSaved ? UASAction.REMOVE : UASAction.SAVE);
@@ -54,9 +66,11 @@ const SaveArticleButton = ({
       <SaveButton
         onClick={handleClick}
         isLoading={isLoading}
+        isSaving={isSaving}
+        isRemoving={isRemoving}
         isSaved={isSaved}
         disabled={isLoading}
-        buttonText={buttonText}
+        buttonText={getButtonText()}
         removeText={saveArticleButton.remove}
       />
     </div>

--- a/src/app/components/SaveButton/index.stories.tsx
+++ b/src/app/components/SaveButton/index.stories.tsx
@@ -1,53 +1,6 @@
-import ThemeProvider from '#app/components/ThemeProvider';
-import { ServiceContextProvider } from '#app/contexts/ServiceContext';
-import { AccountContext } from '#app/contexts/AccountContext';
 import SaveButton from '.';
 import metadata from './metadata.json';
 import readme from './README.md';
-
-type WithProvidersArgs = {
-  isLoading?: boolean;
-  disabled?: boolean;
-  buttonText?: string;
-  isSaved?: boolean;
-  removeText?: string;
-};
-
-const withProviders =
-  ({
-    isLoading = false,
-    disabled = false,
-    isSaved = false,
-    buttonText = 'Save article',
-    removeText,
-  }: WithProvidersArgs) =>
-  () => (
-    <ThemeProvider service="pidgin">
-      <ServiceContextProvider service="pidgin">
-        <AccountContext.Provider
-          value={{
-            isSignedIn: false,
-            signInUrl: 'https://example.com/signin',
-            registerUrl: 'https://example.com/register',
-            isIdctaAvailable: true,
-            settingsUrl: undefined,
-            signOutUrl: undefined,
-            forYouUrl: undefined,
-            isAccountPromoBannerVisible: true,
-          }}
-        >
-          <SaveButton
-            onClick={() => console.log('Button clicked')}
-            isLoading={isLoading}
-            isSaved={isSaved}
-            disabled={disabled}
-            buttonText={buttonText}
-            removeText={removeText}
-          />
-        </AccountContext.Provider>
-      </ServiceContextProvider>
-    </ThemeProvider>
-  );
 
 export default {
   title: 'Components/SaveButton',
@@ -56,19 +9,47 @@ export default {
     metadata,
     docs: { readme },
   },
+  args: {
+    onClick: () => {},
+    isLoading: false,
+    isSaving: false,
+    isRemoving: false,
+    isSaved: false,
+    disabled: false,
+  },
 };
 
-export const Unsaved = withProviders({
-  buttonText: 'Save for later',
-});
+export const Unsaved = {
+  args: {
+    buttonText: 'Save for later',
+  },
+};
 
-export const Loading = withProviders({
-  isLoading: true,
-  buttonText: 'Saving',
-});
+export const Loading = {
+  args: {
+    isLoading: true,
+    buttonText: 'Loading',
+  },
+};
 
-export const Saved = withProviders({
-  buttonText: 'Saved to My News',
-  isSaved: true,
-  removeText: 'Remove',
-});
+export const Saving = {
+  args: {
+    isSaving: true,
+    buttonText: 'Saving',
+  },
+};
+
+export const Saved = {
+  args: {
+    isSaved: true,
+    buttonText: 'Saved to My News',
+    removeText: 'Remove',
+  },
+};
+
+export const Removing = {
+  args: {
+    isRemoving: true,
+    buttonText: 'Removing',
+  },
+};

--- a/src/app/components/SaveButton/index.styles.ts
+++ b/src/app/components/SaveButton/index.styles.ts
@@ -43,6 +43,19 @@ const styles = {
         },
       },
     }),
+  mutatingState: ({ palette }: Theme) =>
+    css({
+      backgroundColor: palette.BLACK,
+      color: palette.WHITE,
+      border: `${pixelsToRem(1)}rem solid ${palette.BLACK}`,
+      '& svg': {
+        fill: palette.WHITE,
+      },
+      ':disabled': {
+        backgroundColor: palette.BLACK,
+        cursor: 'not-allowed',
+      },
+    }),
   buttonAnimation: ({ palette }: Theme) =>
     css({
       display: 'block',

--- a/src/app/components/SaveButton/index.test.tsx
+++ b/src/app/components/SaveButton/index.test.tsx
@@ -34,9 +34,9 @@ describe('SaveButton', () => {
     expect(screen.getByText('Save for later')).toBeInTheDocument();
   });
 
-  it('shows saving text when isLoading is true', () => {
-    render(<SaveButton onClick={noop} buttonText="Saving" isLoading />);
-    expect(screen.getByText('Saving')).toBeInTheDocument();
+  it('shows loading text when isLoading is true', () => {
+    render(<SaveButton onClick={noop} buttonText="Loading" isLoading />);
+    expect(screen.getByText('Loading')).toBeInTheDocument();
   });
 
   it('shows saved text when isSaved is true', () => {
@@ -55,5 +55,17 @@ describe('SaveButton', () => {
     );
     await userEvent.hover(screen.getByRole('button'));
     expect(screen.getByText('Remove')).toBeInTheDocument();
+  });
+
+  it('is disabled and shows Saving text when isSaving is true', () => {
+    render(<SaveButton onClick={noop} buttonText="Saving" isSaving />);
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByText('Saving')).toBeInTheDocument();
+  });
+
+  it('is disabled and shows Removing text when isRemoving is true', () => {
+    render(<SaveButton onClick={noop} buttonText="Removing" isRemoving />);
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByText('Removing')).toBeInTheDocument();
   });
 });

--- a/src/app/components/SaveButton/index.tsx
+++ b/src/app/components/SaveButton/index.tsx
@@ -10,6 +10,8 @@ import styles from './index.styles';
 export interface SaveButtonProps {
   onClick: () => void;
   isLoading?: boolean;
+  isSaving?: boolean;
+  isRemoving?: boolean;
   isSaved?: boolean;
   disabled?: boolean;
   buttonText: string;
@@ -19,27 +21,31 @@ export interface SaveButtonProps {
 const SaveButton = ({
   onClick,
   isLoading = false,
+  isSaving = false,
+  isRemoving = false,
   isSaved = false,
   disabled = false,
   buttonText,
   removeText = '',
 }: SaveButtonProps) => {
   const [isHovered, setIsHovered] = useState(false);
+  const isMutating = isSaving || isRemoving;
 
   return (
     <button
-      css={styles.buttonWrapper}
+      css={[styles.buttonWrapper, isMutating && styles.mutatingState]}
       type="button"
       onClick={onClick}
-      disabled={disabled || isLoading}
+      disabled={disabled || isLoading || isMutating}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onFocus={() => setIsHovered(true)}
       onBlur={() => setIsHovered(false)}
     >
-      {isLoading && <Spinner css={styles.buttonAnimation} />}
-      {!isLoading && !isSaved && <BookmarkIcon />}
+      {(isLoading || isMutating) && <Spinner css={styles.buttonAnimation} />}
+      {!isLoading && !isMutating && !isSaved && <BookmarkIcon />}
       {!isLoading &&
+        !isMutating &&
         isSaved &&
         (isHovered ? <Close width="20" height="20" /> : <FilledBookmarkIcon />)}
       {isHovered && isSaved ? removeText : buttonText}

--- a/src/app/hooks/useUASButton/index.test.tsx
+++ b/src/app/hooks/useUASButton/index.test.tsx
@@ -4,10 +4,12 @@ import {
   act,
 } from '#app/components/react-testing-library-with-providers';
 import useUASFetchSaveStatus from '#app/hooks/useUASFetchSaveStatus';
+import { AccountContext } from '#app/contexts/AccountContext';
+import { ServiceContext } from '#app/contexts/ServiceContext';
 import isLocal from '#app/lib/utilities/isLocal';
 import uasApiRequest from '#app/lib/uasApi';
+import { Article } from '#app/models/types/optimo';
 import useUASButton, { UASAction } from './index';
-
 import useToggle from '../useToggle';
 
 jest.mock('#app/hooks/useUASFetchSaveStatus');
@@ -19,7 +21,7 @@ jest.mock('react', () => ({
   use: jest.fn(),
 }));
 
-const mockuseUASFetchSaveStatus = useUASFetchSaveStatus as jest.Mock;
+const mockUseUASFetchSaveStatus = useUASFetchSaveStatus as jest.Mock;
 const mockUseToggle = useToggle as jest.Mock;
 const mockIsLocal = isLocal as jest.Mock;
 const mockUasApiRequest = uasApiRequest as jest.Mock;
@@ -30,21 +32,18 @@ describe('useUASButton', () => {
     articleTitle: 'Test Article',
   };
 
-  const mockSetIsSaved = jest.fn();
-
   beforeEach(() => {
-    jest.clearAllMocks();
-
-    mockuseUASFetchSaveStatus.mockReturnValue({
+    mockUseUASFetchSaveStatus.mockReturnValue({
       isSaved: false,
       isLoading: false,
       error: null,
-      setIsSaved: mockSetIsSaved,
+      setIsSaved: jest.fn(),
     });
 
-    (use as jest.Mock).mockReturnValue({
-      isSignedIn: false,
-      service: 'hindi',
+    (use as jest.Mock).mockImplementation((context: unknown) => {
+      if (context === AccountContext) return { hashedUserId: 'user-123' };
+      if (context === ServiceContext) return { service: 'hindi' };
+      return {};
     });
   });
 
@@ -67,7 +66,7 @@ describe('useUASButton', () => {
     mockIsLocal.mockReturnValue(false);
     (use as jest.Mock).mockReturnValue({ isSignedIn: false, service: 'hindi' });
 
-    const { result } = renderHook(() => useUASButton({ ...defaultProps }));
+    const { result } = renderHook(() => useUASButton(defaultProps));
 
     expect(result.current.showButton).toBe(false);
   });
@@ -77,11 +76,11 @@ describe('useUASButton', () => {
     mockIsLocal.mockReturnValue(false);
     (use as jest.Mock).mockReturnValue({ isSignedIn: true, service: 'hindi' });
 
-    mockuseUASFetchSaveStatus.mockReturnValue({
+    mockUseUASFetchSaveStatus.mockReturnValue({
       isSaved: true,
       isLoading: false,
       error: null,
-      setIsSaved: mockSetIsSaved,
+      setIsSaved: jest.fn(),
     });
 
     const { result } = renderHook(() => useUASButton(defaultProps));
@@ -96,7 +95,7 @@ describe('useUASButton', () => {
 
     renderHook(() => useUASButton(defaultProps));
 
-    expect(mockuseUASFetchSaveStatus).toHaveBeenCalledWith('123');
+    expect(mockUseUASFetchSaveStatus).toHaveBeenCalledWith('123');
   });
 
   it('passes empty string when showButton is false', () => {
@@ -106,7 +105,7 @@ describe('useUASButton', () => {
 
     renderHook(() => useUASButton(defaultProps));
 
-    expect(mockuseUASFetchSaveStatus).toHaveBeenCalledWith('');
+    expect(mockUseUASFetchSaveStatus).toHaveBeenCalledWith('');
   });
 
   it('respects local environment service filtering', () => {
@@ -146,41 +145,40 @@ describe('useUASButton', () => {
       mockUasApiRequest.mockResolvedValue({ ok: true, status: 202 });
     });
 
-    it('sends POST request with correct payload when saving', async () => {
-      mockuseUASFetchSaveStatus.mockReturnValue({
-        isSaved: false,
-        isLoading: false,
-        error: null,
-        setIsSaved: mockSetIsSaved,
-      });
-
-      const { result } = renderHook(() => useUASButton(defaultProps));
-
-      await act(async () => {
-        await result.current.handleSaveAction(UASAction.SAVE);
-      });
-
-      expect(mockUasApiRequest).toHaveBeenCalledWith('POST', 'favourites', {
-        body: {
-          activityType: 'favourites',
-          resourceDomain: 'articles',
-          resourceType: 'article',
-          resourceId: '123',
-          action: 'favourited',
-          metaData: {
-            service: 'hindi',
-            articleId: '123',
-            title: 'Test Article',
-            promoImage: '',
-            promoImageAltText: '',
-            locatorUrl: '',
+    it('sends POST request when saving', async () => {
+      const articlePageData = {
+        metadata: {
+          locators: {
+            canonicalUrl: 'https://bbc.com/article',
           },
         },
+      } as unknown as Article;
+
+      const { result } = renderHook(() =>
+        useUASButton({ ...defaultProps, articlePageData }),
+      );
+
+      await act(async () => {
+        await result.current.handleSaveAction(UASAction.SAVE);
       });
+
+      expect(mockUasApiRequest).toHaveBeenCalledWith(
+        'POST',
+        'favourites',
+        expect.objectContaining({
+          body: expect.objectContaining({
+            resourceId: defaultProps.articleId,
+            activityType: 'favourites',
+            action: 'favourited',
+            resourceType: 'article',
+          }),
+        }),
+      );
     });
 
-    it('sets isSaved to true on successful save', async () => {
-      mockuseUASFetchSaveStatus.mockReturnValue({
+    it('sets isSaving to false and calls setIsSaved(true) after successful save', async () => {
+      const mockSetIsSaved = jest.fn();
+      mockUseUASFetchSaveStatus.mockReturnValue({
         isSaved: false,
         isLoading: false,
         error: null,
@@ -193,11 +191,13 @@ describe('useUASButton', () => {
         await result.current.handleSaveAction(UASAction.SAVE);
       });
 
+      expect(result.current.isSaving).toBe(false);
       expect(mockSetIsSaved).toHaveBeenCalledWith(true);
     });
 
-    it('sends DELETE request with correct globalId when removing', async () => {
-      mockuseUASFetchSaveStatus.mockReturnValue({
+    it('sets isRemoving to false and calls setIsSaved(false) after successful remove', async () => {
+      const mockSetIsSaved = jest.fn();
+      mockUseUASFetchSaveStatus.mockReturnValue({
         isSaved: true,
         isLoading: false,
         error: null,
@@ -210,50 +210,41 @@ describe('useUASButton', () => {
         await result.current.handleSaveAction(UASAction.REMOVE);
       });
 
-      expect(mockUasApiRequest).toHaveBeenCalledWith('DELETE', 'favourites', {
-        globalId: 'urn:bbc:articles:article:123',
-      });
-    });
-
-    it('sets isSaved to false on successful remove', async () => {
-      mockuseUASFetchSaveStatus.mockReturnValue({
-        isSaved: true,
-        isLoading: false,
-        error: null,
-        setIsSaved: mockSetIsSaved,
-      });
-
-      const { result } = renderHook(() => useUASButton(defaultProps));
-
-      await act(async () => {
-        await result.current.handleSaveAction(UASAction.REMOVE);
-      });
-
+      expect(result.current.isRemoving).toBe(false);
       expect(mockSetIsSaved).toHaveBeenCalledWith(false);
     });
 
-    it('captures error when DELETE request fails', async () => {
+    it('sends DELETE request when removing', async () => {
+      const { result } = renderHook(() => useUASButton(defaultProps));
+
+      await act(async () => {
+        await result.current.handleSaveAction(UASAction.REMOVE);
+      });
+
+      expect(mockUasApiRequest).toHaveBeenCalledWith(
+        'DELETE',
+        'favourites',
+        expect.objectContaining({
+          globalId: 'urn:bbc:articles:article:123',
+        }),
+      );
+    });
+
+    it('sets error and isRemoving to false when request fails', async () => {
       mockUasApiRequest.mockRejectedValueOnce(
         new Error('UAS request failed with status 500'),
       );
 
-      mockuseUASFetchSaveStatus.mockReturnValue({
-        isSaved: true,
-        isLoading: false,
-        error: null,
-        setIsSaved: mockSetIsSaved,
-      });
-
       const { result } = renderHook(() => useUASButton(defaultProps));
 
       await act(async () => {
         await result.current.handleSaveAction(UASAction.REMOVE);
       });
 
+      expect(result.current.isRemoving).toBe(false);
       expect(result.current.error).toEqual(
         new Error('UAS request failed with status 500'),
       );
-      expect(mockSetIsSaved).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/hooks/useUASButton/index.ts
+++ b/src/app/hooks/useUASButton/index.ts
@@ -27,6 +27,8 @@ interface UseUASButtonReturn {
   showButton: boolean;
   isSaved: boolean;
   isLoading: boolean;
+  isSaving: boolean;
+  isRemoving: boolean;
   error: Error | null;
   handleSaveAction: (action: UASAction) => Promise<void>;
 }
@@ -43,9 +45,10 @@ const useUASButton = ({
 }: UseUASButtonProps): UseUASButtonReturn => {
   const { isSignedIn } = use(AccountContext);
   const { service } = use(ServiceContext);
-  const { enabled: featureToggleOn = false, value: accountService = '' } =
+  const { enabled: featureToggleOn, value: accountService = '' } =
     useToggle('uasPersonalization');
   const [isSaving, setIsSaving] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
   const [saveError, setSaveError] = useState<Error | null>(null);
 
   const isUASEnabled =
@@ -64,13 +67,12 @@ const useUASButton = ({
 
   const handleSaveAction = useCallback(
     async (action: UASAction) => {
-      if (isSaving) return;
+      if (isSaving || isRemoving) return;
 
-      setIsSaving(true);
-      try {
-        setSaveError(null);
-
-        if (action === UASAction.SAVE) {
+      if (action === UASAction.SAVE) {
+        setIsSaving(true);
+        try {
+          setSaveError(null);
           const promoImageBuild = buildPromoImageUrl(promoImageObj);
           const body = createFavouritesPayload({
             articleId,
@@ -82,27 +84,37 @@ const useUASButton = ({
           });
           await uasApiRequest('POST', FAVOURITES_CONFIG.activityType, { body });
           setIsSaved(true);
-        } else {
+        } catch (err) {
+          const saveErr = err instanceof Error ? err : new Error(String(err));
+          setSaveError(saveErr);
+        } finally {
+          setIsSaving(false);
+        }
+      } else {
+        setIsRemoving(true);
+        try {
+          setSaveError(null);
           const globalId = buildGlobalId(articleId);
           await uasApiRequest('DELETE', FAVOURITES_CONFIG.activityType, {
             globalId,
           });
           setIsSaved(false);
+        } catch (err) {
+          const saveErr = err instanceof Error ? err : new Error(String(err));
+          setSaveError(saveErr);
+        } finally {
+          setIsRemoving(false);
         }
-      } catch (err) {
-        const saveErr = err instanceof Error ? err : new Error(String(err));
-        setSaveError(saveErr);
-      } finally {
-        setIsSaving(false);
       }
     },
     [
       articleId,
-      service,
-      articleTitle,
-      promoImageObj,
       articlePageData,
+      articleTitle,
+      isRemoving,
       isSaving,
+      promoImageObj,
+      service,
       setIsSaved,
     ],
   );
@@ -110,7 +122,9 @@ const useUASButton = ({
   return {
     showButton,
     isSaved,
-    isLoading: isLoading || isSaving,
+    isLoading,
+    isSaving,
+    isRemoving,
     error: saveError || error,
     handleSaveAction,
   };

--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -121,10 +121,12 @@ export const service: DefaultServiceConfig = {
         buttonSeparatorText: 'या',
       },
       saveArticleButton: {
+        loading: 'Loading',
         save: 'Save for later',
         saving: 'Saving',
         saved: 'Saved to My News',
         remove: 'Remove',
+        removing: 'Removing',
       },
       gist: 'सारांश',
       error: {

--- a/src/app/models/types/translations.ts
+++ b/src/app/models/types/translations.ts
@@ -55,10 +55,12 @@ export interface Translations {
     buttonSeparatorText: string;
   };
   saveArticleButton?: {
+    loading: string;
     save: string;
     saving: string;
     saved: string;
     remove: string;
+    removing: string;
   };
   error: {
     home?: string;


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2584

Summary
======
Adding loading states to the SaveArticleButton so users see accurate feedback during initial page load, saving, and removing actions. Previously, a single loading state was used for all three scenarios, causing a brief UI flicker on page refresh and no visual distinction between saving and removing.

<img width="400" height="74" alt="Screenshot 2026-05-18 at 12 34 39" src="https://github.com/user-attachments/assets/e5a93776-689c-4cec-9622-7f698eee32cd" />
<img width="399" height="76" alt="Screenshot 2026-05-18 at 12 35 01" src="https://github.com/user-attachments/assets/83d31886-1c7a-4ec5-91a4-cdeb33664126" />
<img width="398" height="74" alt="Screenshot 2026-05-18 at 12 35 18" src="https://github.com/user-attachments/assets/0b729be2-c59a-4601-967f-1741d8f2be1f" />


Code changes
======
* SaveButton — added isSaving and isRemoving props, new mutatingState style (black background) for mutation states, new Storybook stories for Saving and Removing
* useUASButton — split loading into isSaving and isRemoving states, each with their own try/catch/finally blocks
* SaveArticleButton — wired up new props, added getButtonText() to handle all loading states without nested ternaries
* translations.ts — added loading and removing to saveArticleButton type
* hindi.ts — added loading: 'Loading' and removing: 'Removing' translations

Testing
======
1. Sign in to BBC account on local Hindi article page
2. On page load — button should show “Loading” with spinner
3. Click “Save for later” — button should show “Saving” with spinner and be disabled
4. After save — button should show “Saved to My News”
5. Click “Remove” — button should show “Removing” with spinner and be disabled
6. After remove — button should show “Save for later”

## Useful Links
UX design: https://www.figma.com/design/O5es2iJ7Ocjm85He1wc38q/WS-Save-for-later-Component?node-id=256-10975&t=9je9TMxNTeo3nnIy-0
