### PR TITLE
WS-2215 - Analytics tracking on UAS and IDCTA events

### DIFF
--- a/scripts/bundleSize/bundleSizeConfig.js
+++ b/scripts/bundleSize/bundleSizeConfig.js
@@ -9,5 +9,5 @@
 
 export const VARIANCE = 5;
 
-export const MIN_SIZE = 935;
-export const MAX_SIZE = 1437;
+export const MIN_SIZE = 929;
+export const MAX_SIZE = 1449;

--- a/src/app/components/ATIAnalytics/atiUrl/index.client.test.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.client.test.ts
@@ -85,7 +85,7 @@ describe('atiUrl', () => {
             x18: 'isLocServeCookieSet',
           },
         };
-        const userParams = { isSignedIn: false };
+        const userParams = { isSignedIn: false, hashedId: null };
 
         expect(reverbAnalyticsModel.params.page).toEqual(pageParams);
         expect(reverbAnalyticsModel.params.user).toEqual(userParams);
@@ -126,7 +126,7 @@ describe('atiUrl', () => {
             x18: 'isLocServeCookieSet',
           },
         };
-        const userParams = { isSignedIn: false };
+        const userParams = { isSignedIn: false, hashedId: null };
 
         expect(reverbAnalyticsModel.params.page).toEqual(pageParams);
         expect(reverbAnalyticsModel.params.user).toEqual(userParams);
@@ -230,6 +230,7 @@ describe('atiUrl', () => {
 
         expect(reverbPageSectionViewEventModel.params.user).toEqual({
           isSignedIn: false,
+          hashedId: null,
         });
       });
 

--- a/src/app/components/ATIAnalytics/atiUrl/index.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.ts
@@ -55,6 +55,8 @@ export const buildReverbAnalyticsModel = ({
   timeUpdated,
   experimentName,
   experimentVariant,
+  isSignedIn = false,
+  hashedId = null,
 }: ATIPageTrackingProps): ReverbBeaconConfig => {
   const href = getHref(platform);
   const referrer = getReferrer(platform);
@@ -104,7 +106,8 @@ export const buildReverbAnalyticsModel = ({
         },
       },
       user: {
-        isSignedIn: false,
+        isSignedIn,
+        hashedId,
       },
     },
     eventDetails,
@@ -127,6 +130,8 @@ export const buildReverbEventModel = ({
   itemTracker = {},
   groupTracker = {},
   eventGroupingName,
+  isSignedIn = false,
+  hashedId = null,
 }: ATIEventTrackingProps): ReverbBeaconConfig => {
   const {
     type: itemType,
@@ -160,7 +165,8 @@ export const buildReverbEventModel = ({
         },
       },
       user: {
-        isSignedIn: false,
+        isSignedIn,
+        hashedId,
       },
     },
     eventDetails: {

--- a/src/app/components/ATIAnalytics/beacon/index.ts
+++ b/src/app/components/ATIAnalytics/beacon/index.ts
@@ -17,6 +17,8 @@ export const sendEventBeacon = async ({
   itemTracker,
   groupTracker,
   eventGroupingName,
+  isSignedIn,
+  hashedId,
 }: ATIEventTrackingProps) => {
   const reverbParams = buildReverbEventModel({
     pageIdentifier,
@@ -33,6 +35,8 @@ export const sendEventBeacon = async ({
     itemTracker,
     groupTracker,
     eventGroupingName,
+    isSignedIn,
+    hashedId,
   });
 
   await sendBeacon(reverbParams);

--- a/src/app/components/ATIAnalytics/canonical/getNoScriptTrackingPixelUrl/index.test.ts
+++ b/src/app/components/ATIAnalytics/canonical/getNoScriptTrackingPixelUrl/index.test.ts
@@ -29,7 +29,7 @@ const mockReverbParams = {
         x18: null,
       },
     },
-    user: { isSignedIn: false },
+    user: { isSignedIn: false, hashedId: null },
   },
   eventDetails: { eventName: 'pageView' },
 } as unknown as ReverbBeaconConfig;

--- a/src/app/components/ATIAnalytics/index.client.test.tsx
+++ b/src/app/components/ATIAnalytics/index.client.test.tsx
@@ -95,6 +95,7 @@ describe('ATI Analytics Container', () => {
           },
           user: {
             isSignedIn: false,
+            hashedId: null,
           },
         },
         eventDetails: {
@@ -212,7 +213,7 @@ describe('ATI Analytics Container', () => {
               x18: false,
             },
           },
-          user: { isSignedIn: false },
+          user: { isSignedIn: false, hashedId: null },
         },
         eventDetails: { eventName: 'pageView' },
       });
@@ -387,7 +388,7 @@ describe('ATI Analytics Container', () => {
               x18: false,
             },
           },
-          user: { isSignedIn: false },
+          user: { isSignedIn: false, hashedId: null },
         },
         eventDetails: { eventName: 'pageView' },
       });
@@ -501,7 +502,7 @@ describe('ATI Analytics Container', () => {
               x18: false,
             },
           },
-          user: { isSignedIn: false },
+          user: { isSignedIn: false, hashedId: null },
         },
         eventDetails: { eventName: 'pageView' },
       });
@@ -667,6 +668,7 @@ describe('ATI Analytics Container', () => {
           },
           user: {
             isSignedIn: false,
+            hashedId: null,
           },
         },
         eventDetails: {
@@ -782,6 +784,7 @@ describe('ATI Analytics Container', () => {
           },
           user: {
             isSignedIn: false,
+            hashedId: null,
           },
         },
         eventDetails: {

--- a/src/app/components/ATIAnalytics/index.tsx
+++ b/src/app/components/ATIAnalytics/index.tsx
@@ -1,5 +1,6 @@
 import { use } from 'react';
 import { RequestContext } from '#contexts/RequestContext';
+import { AccountContext } from '#contexts/AccountContext';
 import { ServiceContext } from '../../contexts/ServiceContext';
 import CanonicalATIAnalytics from './canonical';
 import AmpATIAnalytics from './amp';
@@ -11,11 +12,14 @@ const ATIAnalytics = ({ atiData = {} }: ATIProps) => {
   const requestContext = use(RequestContext);
   const serviceContext = use(ServiceContext);
   const { isAmp } = requestContext;
+  const { isSignedIn, hashedUserId: hashedId } = use(AccountContext);
 
   const reverbParams = buildReverbParams({
     requestContext,
     serviceContext,
     atiData,
+    isSignedIn,
+    hashedId,
   });
 
   return isAmp ? (

--- a/src/app/components/ATIAnalytics/params/buildParams/index.test.ts
+++ b/src/app/components/ATIAnalytics/params/buildParams/index.test.ts
@@ -42,6 +42,8 @@ describe('implementation of buildPageATIParams', () => {
       categoryName: undefined,
       contentId: 'urn:bbc:tipo:topic:cm7682qz7v1t',
       contentType: 'index-home',
+      hashedId: null,
+      isSignedIn: false,
       isUk: undefined,
       language: 'pcm',
       ldpThingIds: undefined,
@@ -100,9 +102,12 @@ describe('implementation of buildPageATIParams', () => {
 
     const validPageURLParams = {
       appName: 'atiAnalyticsAppName',
+      campaigns: undefined,
       categoryName: 'Refugees%20and%20asylum%20seekers~Myanmar~Military',
       contentId: 'urn:bbc:optimo:asset:c9wxnzvwp3mo',
       contentType: 'article',
+      hashedId: null,
+      isSignedIn: false,
       isUK: false,
       language: 'my',
       ldpThingIds:
@@ -190,6 +195,8 @@ describe('implementation of buildPageATIParams', () => {
       categoryName: 'Environment~Narendra+Modi~Nature~India~Severe+weather',
       contentId: 'urn:bbc:optimo:asset:c4nrpd0d4nro',
       contentType: 'article-sfv',
+      hashedId: null,
+      isSignedIn: false,
       isUK: false,
       language: 'ha',
       ldpThingIds:
@@ -233,10 +240,13 @@ describe('implementation of buildPageATIParams', () => {
     // timePublished and timeUpdated are not returned via BFF implementation so set to undefined in test
     const validPageURLParams = {
       appName: 'atiAnalyticsAppName',
+      campaigns: undefined,
       categoryName: undefined,
       contentId: 'urn:bbc:tipo:topic:c95y35941vrt',
       contentType: 'index-category',
-      isUk: undefined,
+      hashedId: null,
+      isSignedIn: false,
+      isUK: undefined,
       language: 'pcm',
       ldpThingIds: undefined,
       ldpThingLabels: undefined,
@@ -286,10 +296,13 @@ describe('implementation of buildPageATIParams', () => {
 
     const validPageURLParams = {
       appName: 'atiAnalyticsAppName',
+      campaigns: undefined,
       categoryName: undefined,
       contentId: undefined,
       contentType: 'list-datadriven',
-      isUk: undefined,
+      hashedId: null,
+      isSignedIn: false,
+      isUK: undefined,
       language: 'pcm',
       ldpThingIds: undefined,
       ldpThingLabels: undefined,
@@ -367,6 +380,8 @@ describe('implementation of buildPageATIParams', () => {
         contentId:
           'urn:bbc:cps:curie:asset:3137d6de-62c2-4637-a002-29d2ab075990',
         contentType: 'article',
+        hashedId: null,
+        isSignedIn: false,
         isUK: undefined,
         language: 'es',
         ldpThingIds:
@@ -443,6 +458,8 @@ describe('implementation of buildPageATIParams', () => {
         contentId:
           'urn:bbc:cps:curie:asset:6d745333-c79d-e245-a5b2-f4acb7de35e1',
         contentType: 'article-media-asset',
+        hashedId: null,
+        isSignedIn: false,
         isUK: undefined,
         language: 'es',
         ldpThingIds:
@@ -517,6 +534,8 @@ describe('implementation of buildPageATIParams', () => {
         contentId:
           'urn:bbc:cps:curie:asset:08e22e90-7361-cd47-b586-7cb53fc5a012',
         contentType: 'article-photo-gallery',
+        hashedId: null,
+        isSignedIn: false,
         isUK: undefined,
         language: 'es',
         ldpThingIds: '25844b6e-80b0-4de9-8ea0-7a35e7d4086f',
@@ -583,6 +602,8 @@ describe('implementation of buildPageATIParams', () => {
         contentId:
           'urn:bbc:cps:curie:asset:c1c8b1bf-4c9c-44e8-be0d-c81a2aa59e46',
         contentType: 'article-correspondent',
+        hashedId: null,
+        isSignedIn: false,
         isUK: undefined,
         language: 'en-gb',
         ldpThingIds:

--- a/src/app/components/ATIAnalytics/params/buildParams/index.ts
+++ b/src/app/components/ATIAnalytics/params/buildParams/index.ts
@@ -6,7 +6,12 @@ export const buildPageATIParams = ({
   atiData,
   requestContext,
   serviceContext,
-}: ATIDataWithContexts) => {
+  isSignedIn = false,
+  hashedId = null,
+}: ATIDataWithContexts & {
+  isSignedIn?: boolean;
+  hashedId?: string | null;
+}) => {
   const { isUK, platform, statsDestination } = requestContext;
   const {
     atiAnalyticsAppName,
@@ -55,6 +60,8 @@ export const buildPageATIParams = ({
     statsDestination,
     timePublished,
     timeUpdated,
+    isSignedIn,
+    hashedId,
     ...(ampExperimentName && { ampExperimentName }),
     ...(experimentName && { experimentName }),
     ...(experimentVariant && { experimentVariant }),
@@ -65,7 +72,18 @@ export const buildPageReverbParams = ({
   atiData,
   requestContext,
   serviceContext,
-}: ATIDataWithContexts) =>
+  isSignedIn,
+  hashedId,
+}: ATIDataWithContexts & {
+  isSignedIn?: boolean;
+  hashedId?: string | null;
+}) =>
   buildReverbAnalyticsModel(
-    buildPageATIParams({ atiData, requestContext, serviceContext }),
+    buildPageATIParams({
+      atiData,
+      requestContext,
+      serviceContext,
+      isSignedIn,
+      hashedId,
+    }),
   );

--- a/src/app/components/ATIAnalytics/params/index.test.ts
+++ b/src/app/components/ATIAnalytics/params/index.test.ts
@@ -152,6 +152,7 @@ describe('ATIAnalytics params', () => {
           },
           user: {
             isSignedIn: false,
+            hashedId: null,
           },
         },
         eventDetails: {
@@ -189,6 +190,7 @@ describe('ATIAnalytics params', () => {
           },
           user: {
             isSignedIn: false,
+            hashedId: null,
           },
         },
         eventDetails: {
@@ -232,6 +234,7 @@ describe('ATIAnalytics params', () => {
           },
           user: {
             isSignedIn: false,
+            hashedId: null,
           },
         },
         eventDetails: {
@@ -274,6 +277,7 @@ describe('ATIAnalytics params', () => {
           },
           user: {
             isSignedIn: false,
+            hashedId: null,
           },
         },
         eventDetails: {
@@ -317,6 +321,7 @@ describe('ATIAnalytics params', () => {
           },
           user: {
             isSignedIn: false,
+            hashedId: null,
           },
         },
         eventDetails: {

--- a/src/app/components/ATIAnalytics/params/index.ts
+++ b/src/app/components/ATIAnalytics/params/index.ts
@@ -5,6 +5,17 @@ export default ({
   requestContext,
   serviceContext,
   atiData,
-}: ReverbDetailsProviders) => {
-  return buildPageReverbParams({ atiData, requestContext, serviceContext });
+  isSignedIn,
+  hashedId,
+}: ReverbDetailsProviders & {
+  isSignedIn?: boolean;
+  hashedId?: string | null;
+}) => {
+  return buildPageReverbParams({
+    atiData,
+    requestContext,
+    serviceContext,
+    isSignedIn,
+    hashedId,
+  });
 };

--- a/src/app/components/ATIAnalytics/types.ts
+++ b/src/app/components/ATIAnalytics/types.ts
@@ -115,6 +115,7 @@ export type ReverbPageVars = {
 
 export type ReverbUserVars = {
   isSignedIn: boolean;
+  hashedId?: string | null;
 };
 
 export type ReverbEventDetails = {
@@ -167,6 +168,8 @@ export interface ATIEventTrackingProps {
   groupTracker?: GroupTracker;
   viewThreshold?: number;
   eventGroupingName?: string;
+  isSignedIn?: boolean;
+  hashedId?: string | null;
 }
 
 export interface ItemTracker {
@@ -210,6 +213,8 @@ export interface ATIPageTrackingProps {
   ampExperimentName?: string;
   experimentName?: string | null;
   experimentVariant?: string | null;
+  isSignedIn?: boolean;
+  hashedId?: string | null;
 }
 
 export interface ATIProps {

--- a/src/app/components/Account/AccountHeader/index.tsx
+++ b/src/app/components/Account/AccountHeader/index.tsx
@@ -4,6 +4,8 @@ import { ServiceContext } from '#contexts/ServiceContext';
 import useHydrationDetection from '#hooks/useHydrationDetection';
 import Text from '#app/components/Text';
 import { AccountIcon } from '#app/components/icons';
+import useViewTracker from '#app/hooks/useViewTracker';
+import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import styles from './index.styles';
 
 const AccountHeader = () => {
@@ -11,6 +13,18 @@ const AccountHeader = () => {
   const { isSignedIn, signInUrl, settingsUrl, isIdctaAvailable } =
     use(AccountContext);
   const { translations } = use(ServiceContext);
+
+  const clickComponentName = isSignedIn
+    ? 'account-header-settings'
+    : 'account-header-sign-in';
+
+  const viewTracker = useViewTracker({
+    componentName: 'account-header',
+  });
+
+  const { onClick: onClickTrack } = useClickTrackerHandler({
+    componentName: clickComponentName,
+  });
 
   if (!isHydrated || !isIdctaAvailable) return null;
 
@@ -22,8 +36,14 @@ const AccountHeader = () => {
   if (!href || !label) return null;
 
   return (
-    <div css={styles.wrapper}>
-      <Text as="a" css={styles.link} href={href} fontVariant="sansBold">
+    <div css={styles.wrapper} {...viewTracker}>
+      <Text
+        as="a"
+        css={styles.link}
+        href={href}
+        fontVariant="sansBold"
+        onClick={onClickTrack}
+      >
         <AccountIcon css={styles.icon} />
         {label}
       </Text>

--- a/src/app/components/Account/AccountPromotionalBanner/index.tsx
+++ b/src/app/components/Account/AccountPromotionalBanner/index.tsx
@@ -1,4 +1,4 @@
-import { use, useState } from 'react';
+import { use, useState, useCallback } from 'react';
 import { Helmet } from 'react-helmet';
 import Paragraph from '#app/components/Paragraph';
 import PromotionalBanner from '#app/components/PromotionalBanner';
@@ -8,6 +8,8 @@ import { AccountContext } from '#contexts/AccountContext';
 import { ServiceContext } from '#app/contexts/ServiceContext';
 import { RequestContext } from '#app/contexts/RequestContext';
 import useToggle from '#app/hooks/useToggle';
+import useViewTracker from '#app/hooks/useViewTracker';
+import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import addInlineScript from '#app/lib/utilities/addInlineScript';
 import onClient from '#app/lib/utilities/onClient';
 import {
@@ -28,6 +30,28 @@ const AccountPromotionalBanner = () => {
   const registerText = translations?.account?.register;
   const [isDismissed, setIsDismissed] = useState(false);
 
+  const viewTracker = useViewTracker({
+    componentName: 'account-promotional-banner',
+  });
+
+  const { onClick: onCloseClickTrack } = useClickTrackerHandler({
+    componentName: 'account-promotional-banner-close',
+  });
+
+  const handleCloseClick = useCallback(
+    async (event?: React.MouseEvent) => {
+      if (onCloseClickTrack) {
+        await onCloseClickTrack(event);
+      }
+      setAccountPromoBannerDismissed();
+      setIsDismissed(true);
+      document
+        .querySelector('html')
+        ?.classList.remove(DISPLAY_ACCOUNT_PROMOTIONAL_BANNER_CSS_CLASS);
+    },
+    [onCloseClickTrack],
+  );
+
   if (
     isDismissed ||
     isSignedIn ||
@@ -47,10 +71,13 @@ const AccountPromotionalBanner = () => {
     <>
       {!onClient() && (
         <Helmet>
-          {addInlineScript({ script: buildAccountBannerClientScript(), nonce })}
+          {addInlineScript({
+            script: buildAccountBannerClientScript(),
+            nonce,
+          })}
         </Helmet>
       )}
-      <div css={styles.bannerWrapper}>
+      <div css={styles.bannerWrapper} {...viewTracker}>
         <PromotionalBanner
           id="account-promotional-banner"
           title={title}
@@ -59,18 +86,15 @@ const AccountPromotionalBanner = () => {
           closeLabel={closeLabel}
           buttonSeparatorText={buttonSeparatorText}
           isDismissible
-          onClose={() => {
-            setAccountPromoBannerDismissed();
-            setIsDismissed(true);
-            document
-              .querySelector('html')
-              ?.classList.remove(DISPLAY_ACCOUNT_PROMOTIONAL_BANNER_CSS_CLASS);
-          }}
+          onClose={handleCloseClick}
         >
           <CallToActionLink
             url={signInUrl}
             className="focusIndicatorInvert"
             css={[styles.callToActionLink, styles.signInLink]}
+            eventTrackingData={{
+              componentName: 'account-promotional-banner-sign-in',
+            }}
           >
             <CallToActionLink.ButtonLikeWrapper>
               <AccountIcon css={styles.accountIcon} />
@@ -88,6 +112,9 @@ const AccountPromotionalBanner = () => {
             url={registerUrl}
             className="focusIndicatorInvert"
             css={[styles.callToActionLink, styles.registerLink]}
+            eventTrackingData={{
+              componentName: 'account-promotional-banner-register',
+            }}
           >
             <CallToActionLink.ButtonLikeWrapper>
               <CallToActionLink.Text shouldUnderlineOnHoverFocus>

--- a/src/app/components/SaveArticleButton/SaveArticleButtonAuthenticated/index.tsx
+++ b/src/app/components/SaveArticleButton/SaveArticleButtonAuthenticated/index.tsx
@@ -3,6 +3,8 @@ import { ServiceContext } from '#contexts/ServiceContext';
 import { RequestContext } from '#app/contexts/RequestContext';
 import parseRoute from '#app/routes/utils/parseRoute';
 import useUASButton, { UASAction } from '#app/hooks/useUASButton';
+import useClickTracker from '#app/hooks/useClickTrackerHandler';
+import useViewTracker from '#app/hooks/useViewTracker';
 import SaveButton from '#app/components/SaveButton';
 
 import type { SaveArticleButtonProps } from '../index';
@@ -22,6 +24,21 @@ const SaveArticleButtonAuthenticated = ({
     articlePageData,
   });
 
+  const clickComponentName = `save-article-button-click-${
+    isSaved ? UASAction.REMOVE : UASAction.SAVE
+  }`;
+
+  const viewTracker = useViewTracker({
+    componentName: 'save-article-button-view',
+  });
+
+  const { onClick: onClickTrack } = useClickTracker({
+    componentName: clickComponentName,
+    itemTracker: {
+      resourceId: articleId,
+    },
+  });
+
   if (!saveArticleButton) return null;
 
   if (error) {
@@ -37,20 +54,23 @@ const SaveArticleButtonAuthenticated = ({
     : saveArticleButton.save;
   const buttonText = isLoading ? saveArticleButton.saving : buttonLabel;
 
-  const handleClick = () => {
+  const handleClick = (event?: React.MouseEvent) => {
+    onClickTrack?.(event);
     handleSaveAction(isSaved ? UASAction.REMOVE : UASAction.SAVE);
   };
 
   return (
-    <SaveButton
-      onClick={handleClick}
-      isLoading={isLoading}
-      isSaved={isSaved}
-      disabled={isLoading}
-      buttonText={buttonText}
-      removeText={saveArticleButton.remove}
-      testId="save-article-btn-authorized"
-    />
+    <div {...viewTracker}>
+      <SaveButton
+        onClick={handleClick}
+        isLoading={isLoading}
+        isSaved={isSaved}
+        disabled={isLoading}
+        buttonText={buttonText}
+        removeText={saveArticleButton.remove}
+        testId="save-article-btn-authorized"
+      />
+    </div>
   );
 };
 

--- a/src/app/contexts/EventTrackingContext/index.test.tsx
+++ b/src/app/contexts/EventTrackingContext/index.test.tsx
@@ -55,6 +55,8 @@ describe('Expected use', () => {
 
     expect(trackingData).toEqual({
       campaignID: 'article-sty',
+      hashedId: null,
+      isSignedIn: false,
       pageIdentifier: 'news::pidgin.news.story.51745682.page',
       platform: 'canonical',
       producerId: '70',
@@ -77,6 +79,8 @@ describe('Expected use', () => {
 
     expect(trackingData).toEqual({
       campaignID: 'index-home',
+      hashedId: null,
+      isSignedIn: false,
       pageIdentifier: 'kyrgyz.page',
       platform: 'canonical',
       producerId: '58',

--- a/src/app/contexts/EventTrackingContext/index.tsx
+++ b/src/app/contexts/EventTrackingContext/index.tsx
@@ -1,5 +1,6 @@
 import { createContext, PropsWithChildren, use, useMemo } from 'react';
 
+import { AccountContext } from '#contexts/AccountContext';
 import { RequestContext } from '../RequestContext';
 import useToggle from '../../hooks/useToggle';
 import {
@@ -23,6 +24,7 @@ import {
   AUDIO_PAGE,
   OFFLINE_PAGE,
   LIVE_TV_PAGE,
+  MY_NEWS_PAGE,
 } from '../../routes/utils/pageTypes';
 import { PageTypes } from '../../models/types/global';
 import { EventTrackingContextProps } from '../../models/types/eventTracking';
@@ -57,6 +59,7 @@ const getCampaignID = (pageType: CampaignPageTypes) => {
     [AUDIO_PAGE]: 'player-episode',
     [TV_PAGE]: 'player-episode',
     [LIVE_TV_PAGE]: 'live-tv',
+    [MY_NEWS_PAGE]: 'my-news',
   }[pageType];
 
   if (!campaignID) {
@@ -85,6 +88,7 @@ export const EventTrackingContextProvider = ({
   const serviceContext = use(ServiceContext);
   const { atiAnalyticsProducerId, atiAnalyticsProducerName } = serviceContext;
 
+  const { isSignedIn, hashedUserId } = use(AccountContext);
   const { enabled: eventTrackingIsEnabled } = useToggle('eventTracking');
 
   const trackingProps = useMemo(() => {
@@ -99,6 +103,8 @@ export const EventTrackingContextProvider = ({
         producerId: atiAnalyticsProducerId,
         producerName: atiAnalyticsProducerName,
         statsDestination,
+        isSignedIn,
+        hashedId: hashedUserId || null,
       };
     }
     return null;
@@ -110,6 +116,8 @@ export const EventTrackingContextProvider = ({
     pageType,
     platform,
     statsDestination,
+    isSignedIn,
+    hashedUserId,
   ]);
 
   if (!eventTrackingIsEnabled || !atiData) {
@@ -120,9 +128,16 @@ export const EventTrackingContextProvider = ({
     );
   }
 
-  const hasRequiredProps = Object.values(
-    trackingProps as EventTrackingContextProps,
-  ).every(Boolean);
+  const hasRequiredProps =
+    trackingProps &&
+    [
+      trackingProps.campaignID,
+      trackingProps.pageIdentifier,
+      trackingProps.platform,
+      trackingProps.producerId,
+      trackingProps.producerName,
+      trackingProps.statsDestination,
+    ].every(Boolean);
 
   return (
     <EventTrackingContext.Provider

--- a/src/app/hooks/useClickTrackerHandler/index.jsx
+++ b/src/app/hooks/useClickTrackerHandler/index.jsx
@@ -54,6 +54,8 @@ const useClickTrackerHandler = (eventTrackingData = {}) => {
     experimentVariant,
     groupTracker,
     itemTracker,
+    isSignedIn,
+    hashedId,
   } = extractATITrackingProps({ eventTrackingData, eventType: CLICK_EVENT });
 
   const { trackingIsEnabled } = useTrackingToggle(componentName);
@@ -87,6 +89,7 @@ const useClickTrackerHandler = (eventTrackingData = {}) => {
           service,
           statsDestination,
         ].every(Boolean);
+
         if (shouldSendEvent) {
           event.stopPropagation();
           event.preventDefault();
@@ -132,6 +135,8 @@ const useClickTrackerHandler = (eventTrackingData = {}) => {
               detailedPlacement,
               ...(groupTracker && { groupTracker }),
               ...(itemTracker && { itemTracker }),
+              isSignedIn,
+              hashedId,
               ...(experimentVariant &&
                 experimentVariant !== 'off' && {
                   experimentName,
@@ -171,6 +176,8 @@ const useClickTrackerHandler = (eventTrackingData = {}) => {
       itemTracker,
       experimentName,
       preventNavigation,
+      isSignedIn,
+      hashedId,
     ],
   );
 };

--- a/src/app/hooks/useCustomEventTracker/index.test.tsx
+++ b/src/app/hooks/useCustomEventTracker/index.test.tsx
@@ -102,18 +102,21 @@ describe('useCustomEventTracker', () => {
     });
 
     expect(mockSendEventBeacon).toHaveBeenCalledTimes(1);
-    expect(mockSendEventBeacon).toHaveBeenCalledWith({
-      type: VIEW_EVENT,
-      eventGroupingName: eventName,
-      componentName: '',
-      campaignID: 'article-sty',
-      pageIdentifier: 'news::pidgin.news.story.51745682.page',
-      platform: 'canonical',
-      producerId: '70',
-      producerName: 'PIDGIN',
-      service: 'pidgin',
-      statsDestination: 'WS_NEWS_LANGUAGES_TEST',
-    });
+    expect(mockSendEventBeacon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: VIEW_EVENT,
+        eventGroupingName: eventName,
+        componentName: '',
+        campaignID: 'article-sty',
+        pageIdentifier: 'news::pidgin.news.story.51745682.page',
+        platform: 'canonical',
+        producerId: '70',
+        producerName: 'PIDGIN',
+        service: 'pidgin',
+        statsDestination: 'WS_NEWS_LANGUAGES_TEST',
+        hashedId: null,
+      }),
+    );
   });
 
   it('should use stringifiedData as componentName when provided', async () => {

--- a/src/app/hooks/useCustomEventTracker/index.tsx
+++ b/src/app/hooks/useCustomEventTracker/index.tsx
@@ -34,6 +34,8 @@ const useCustomEventTracker = ({
     statsDestination,
     campaignID,
     producerName,
+    isSignedIn,
+    hashedId,
   } = extractATITrackingProps({
     eventType: VIEW_EVENT,
   });
@@ -71,6 +73,8 @@ const useCustomEventTracker = ({
             statsDestination,
             experimentName,
             experimentVariant,
+            isSignedIn,
+            hashedId,
           });
         } catch (error) {
           // eslint-disable-next-line no-console
@@ -90,6 +94,8 @@ const useCustomEventTracker = ({
       statsDestination,
       experimentName,
       experimentVariant,
+      isSignedIn,
+      hashedId,
     ],
   );
 

--- a/src/app/hooks/useViewTracker/index.tsx
+++ b/src/app/hooks/useViewTracker/index.tsx
@@ -38,6 +38,8 @@ const getComponentViewTracker = (eventTrackingData?: EventTrackingData) => {
     itemTracker,
     viewThreshold,
     alwaysInView = false,
+    isSignedIn,
+    hashedId,
   } = extractATITrackingProps({
     eventTrackingData,
     eventType: VIEW_EVENT,
@@ -79,6 +81,8 @@ const getComponentViewTracker = (eventTrackingData?: EventTrackingData) => {
             advertiserID,
             url,
             detailedPlacement,
+            isSignedIn,
+            hashedId,
             ...(groupTracker && { groupTracker }),
             ...(itemTracker && { itemTracker }),
             ...(experimentVariant &&
@@ -136,6 +140,8 @@ const getComponentViewTracker = (eventTrackingData?: EventTrackingData) => {
     itemTracker,
     groupTracker,
     alwaysInView,
+    isSignedIn,
+    hashedId,
   ]);
 
   const viewTracker = useCallback(

--- a/src/app/lib/analyticsUtils/extractATITrackingProps/index.ts
+++ b/src/app/lib/analyticsUtils/extractATITrackingProps/index.ts
@@ -32,6 +32,8 @@ export default ({
     producerId,
     statsDestination,
     producerName,
+    isSignedIn,
+    hashedId,
   } = eventTrackingContext;
 
   const campaignID =
@@ -58,5 +60,7 @@ export default ({
     groupTracker,
     viewThreshold,
     alwaysInView,
+    isSignedIn,
+    hashedId,
   };
 };

--- a/src/app/lib/analyticsUtils/sendBeacon/index.ts
+++ b/src/app/lib/analyticsUtils/sendBeacon/index.ts
@@ -59,7 +59,7 @@ const setReverbPageValues = async ({
   });
 
   window.bbcuser = {
-    getHashedId: () => null,
+    getHashedId: () => Promise.resolve(userVars.hashedId ?? null),
     isSignedIn: () => Promise.resolve(userVars.isSignedIn),
   };
 };

--- a/src/app/models/types/eventTracking.ts
+++ b/src/app/models/types/eventTracking.ts
@@ -32,5 +32,7 @@ export type EventTrackingContextProps =
       producerId: string;
       statsDestination: string;
       producerName: string;
+      isSignedIn?: boolean;
+      hashedId?: string | null;
     }
   | Record<string, never>;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -31,7 +31,7 @@ declare global {
         }
       | object;
     bbcuser: {
-      getHashedId: () => null;
+      getHashedId: () => Promise<string | null>;
       isSignedIn: () => Promise<boolean>;
     };
     __reverb: {

--- a/ws-nextjs-app/pages/[service]/my-news/MyNewsPage.tsx
+++ b/ws-nextjs-app/pages/[service]/my-news/MyNewsPage.tsx
@@ -5,12 +5,14 @@ import { ServiceContext } from '#app/contexts/ServiceContext';
 import { useContext } from 'react';
 import { useRouter } from 'next/router';
 import MetadataContainer from '#app/components/Metadata';
+import ATIAnalytics from '#app/components/ATIAnalytics';
 import useUASRecentActivity from '#app/hooks/useUASRecentActivity';
+import { PageData } from '#app/lib/config/fixtures/types';
 import styles from './styles';
 
 const ITEMS_PER_PAGE = 10;
 
-const MyNewsPage = () => {
+const MyNewsPage = ({ pageData }: { pageData?: PageData }) => {
   const router = useRouter();
   const { translations, lang } = useContext(ServiceContext);
 
@@ -27,6 +29,8 @@ const MyNewsPage = () => {
 
   const pageCount = Math.max(1, Math.ceil(total / ITEMS_PER_PAGE));
   const safeActivePage = Math.min(requestedPage, pageCount);
+
+  const atiAnalytics = pageData?.metadata?.atiAnalytics;
 
   const {
     pageXOfY = 'Page {x} of {y}',
@@ -97,6 +101,7 @@ const MyNewsPage = () => {
 
   return (
     <main css={styles.main}>
+      <ATIAnalytics atiData={atiAnalytics} />
       <MetadataContainer
         title={metadataTitle}
         openGraphType="website"

--- a/ws-nextjs-app/pages/[service]/my-news/index.page.tsx
+++ b/ws-nextjs-app/pages/[service]/my-news/index.page.tsx
@@ -47,6 +47,9 @@ export const getServerSideProps: GetServerSideProps = async context => {
       pageData: {
         metadata: {
           type: MY_NEWS_PAGE,
+          atiAnalytics: {
+            pageIdentifier: 'my-news.page',
+          },
         },
       },
     },


### PR DESCRIPTION
**This is copy of PR https://github.com/bbc/simorgh/pull/14013 .
As that PR has some issue with "unverified unsigned commit history" , created this PR**

Resolves JIRA: https://bbc.atlassian.net/browse/WS-2215

Summary
======
Track UAS SaveForLater and IDCTA account‑related view and click events

Code changes
======
**User Authentication Data Propagation:**

- Added `isSignedIn` and `hashedId` to analytics model and event tracking types, ensuring these user properties are passed through all relevant functions and components, including `buildReverbAnalyticsModel`, `buildReverbEventModel`, and their respective parameter builders.

- Updated the `EventTrackingContextProvider` and the main analytics entry point to use `isSignedIn` and `hashedId` available in analytics contexts and ensuring they're included in all analytics payloads.

**Component-Level Event Tracking Enhancements:**

- Integrated `useViewTracker` and `useClickTrackerHandler` hooks into `AccountHeader`, `AccountPromotionalBanner`, and `SaveArticleButton` components, enabling detailed view and click analytics for these UI elements. This includes dynamic component naming for click events and passing relevant tracking data (such as resource IDs). 

**Analytics Hook Improvements:**

- Updated the click tracker handler to accept and forward `isSignedIn` and `hashedId` as part of event tracking data, ensuring user authentication state is included with each event. 
These changes collectively improve the granularity and accuracy of analytics, especially regarding user authentication state, and ensure that key user interactions are tracked in detail.

`UserID , Users, Visitors` - these data in Piano is seen tracked because of this new addition of `isSignedin` and `hashedID` 
<img width="2186" height="380" alt="image" src="https://github.com/user-attachments/assets/3741aedb-83b2-47c2-bcd9-d293181494ad" />




Testing
======
Event names :

SaveArticleButton :
save-article-button-click-save and save-article-button-click-remove for button clicks
save-article-button-view - for view
Piano dashboard - https://analytics.piano.io/dataquery/#/designer?reportid=69fc727210a9df2f7a011419


AccountPromotionalBanner:
account-promotional-banner - for view
account-promotional-banner-close - for closing
account-promotional-banner-sign-in - for signin click
account-promotional-banner-register - for register click
Piano dashboard : https://analytics.piano.io/workspaces/#/report/6a171e37ba4080ea6a3c590c


Account header:
account-header - for view
account-header-settings - for settings click
account-header-sign-in - for signin click
Piano Dashboard - https://analytics.piano.io/dataquery/#/designer?reportid=6a033bbb5e9acc6f81847ccb

MyNews page:
my_news.page - for the view of page
Piano dashboard -https://analytics.piano.io/dataquery/#/designer?reportid=69fde2d421b0d1e734c23d33

User authenticated or non-authenticated state:
Select properties UserID , Users, Visitors to see the count of authenticated and non-authenticated users
Piano dashboard : [Workspaces | Piano Analytics](https://analytics.piano.io/workspaces/#/report/6a170f2ec9c58bfff8ec645e)