### PR TITLE
WS-2689: Fixes High contrast mode with sports data header

### DIFF
--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
@@ -32,10 +32,13 @@ export default {
   // ==================== Main Wrapper (Theme-based) ====================
   wrapper:
     ({ isConciseView }: { isConciseView?: boolean }) =>
-    ({ palette }: Theme) =>
+    ({ palette, mq }: Theme) =>
       css({
         background: isConciseView ? palette.GREY_15 : palette.GREY_16,
         borderLeft: `medium none ${palette.LIVE_CORE}`,
+        [mq.FORCED_COLOURS]: {
+          borderBottom: `solid ${pixelsToRem(1)}rem transparent`,
+        },
       }),
   container:
     ({ isConciseView }: { isConciseView?: boolean }) =>

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx
@@ -81,7 +81,7 @@ const Header = ({
   }
 
   return (
-    <div css={styles.headerContainer}>
+    <div css={[styles.headerContainer, styles.headerContainerForcedColours]}>
       <div css={styles.backgroundContainer}>
         <div css={styles.backgroundColor} />
       </div>

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -2,11 +2,14 @@ import { css, Theme } from '@emotion/react';
 import pixelsToRem from '../../../../../../src/app/utilities/pixelsToRem';
 
 export default {
-  headerContainer: ({ mq }: Theme) =>
+  headerContainer: () =>
     css({
       display: 'flex',
       flexDirection: 'column',
       position: 'relative',
+    }),
+  headerContainerForcedColours: ({ mq }: Theme) =>
+    css({
       [mq.FORCED_COLOURS]: {
         borderBottom: `solid ${pixelsToRem(1)}rem transparent`,
       },


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2689

Summary
======
Fixes bottom borders on High Contrast modes

After (with fix)
<img width="1412" height="635" alt="Screenshot 2026-05-22 at 08 37 56" src="https://github.com/user-attachments/assets/68fc7c44-d165-411f-938a-d6f5b3e04a12" />

Before 
<img width="1411" height="697" alt="Screenshot 2026-05-22 at 08 38 13" src="https://github.com/user-attachments/assets/1088c8cb-723f-4ffe-bdb7-9fb99ab91323" />

Code changes
======
- Amends styles

Testing
======
1. Visit http://localhost:7081/afrique/live/c7gk1vjglxn1t and see fixes. Check no regression on storybook test

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
