### PR TITLE
Updated translation for Hinid acc promotional banner

### DIFF
--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -115,9 +115,8 @@ export const service: DefaultServiceConfig = {
         register: 'रजिस्टर',
       },
       accountPromoBanner: {
-        title: 'अपना BBC खोजिए',
-        description:
-          'देखने, सुनने और भाग लेने के लिए साइन‑इन करें या खाता बनाएं',
+        title: 'आपका अपना BBC',
+        description: 'लॉग इन करें या निःशुल्क नया खाता बनाएं',
         closeLabel: 'बंद करें',
         buttonSeparatorText: 'या',
       },


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2699

Summary
======
Replace the hindi copy in the account promotional banner

<img width="800" height="458" alt="image" src="https://github.com/user-attachments/assets/31731c02-8730-4c75-b954-0db40b48a80f" />

