### PR TITLE
Buf fix for video curation - GET THE NAME RIGHT EH?

### DIFF
--- a/ws-nextjs-app/pages/[service]/articles/handleArticleRoute.ts
+++ b/ws-nextjs-app/pages/[service]/articles/handleArticleRoute.ts
@@ -109,7 +109,7 @@ export default async (context: GetServerSidePropsContext) => {
     latestMedia = null,
     mostRead = null,
     billboardCuration = null,
-    mediaCuration = null,
+    videoCuration: mediaCuration = null,
     portraitVideoItems = null,
   } = secondaryData || {};
 


### PR DESCRIPTION
Had 'mediaCuration' in the front end as the name of the data for the video curation, but called it 'videoCuration' in the back end. 

Summary
======
_A very high-level summary of easily-reproducible changes that can be understood by non-devs, and why these changes where made._

Code changes
======
- _List key code changes that have been made._

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
