### PR TITLE
WS-2736 - Piano Tracking for Topic Discovery [EXPERIMENT]

### DIFF
--- a/src/app/components/RelatedTopics/index.test.tsx
+++ b/src/app/components/RelatedTopics/index.test.tsx
@@ -136,6 +136,11 @@ describe('Related Topics', () => {
   describe('Event Tracking', () => {
     const eventTrackingData = {
       componentName: 'topics',
+      groupTracker: {
+        itemCount: 1,
+        name: 'Temas relacionados',
+        type: 'topics',
+      },
     };
 
     it('should call the click tracker with the correct params', () => {
@@ -145,7 +150,15 @@ describe('Related Topics', () => {
         { service: 'mundo' },
       );
 
-      expect(clickTrackerSpy).toHaveBeenCalledWith(eventTrackingData);
+      expect(clickTrackerSpy).toHaveBeenCalledWith({
+        ...eventTrackingData,
+        itemTracker: {
+          position: 1,
+          resourceId: 'id',
+          text: 'topic',
+          type: 'topics-link',
+        },
+      });
     });
 
     it('should call the view tracker with the correct params', () => {

--- a/src/app/components/TopicDiscovery/ScrollableTabs/index.tsx
+++ b/src/app/components/TopicDiscovery/ScrollableTabs/index.tsx
@@ -3,6 +3,7 @@ import { ServiceContext } from '#app/contexts/ServiceContext';
 import { Chevron, ChevronOrientation } from '#app/components/icons';
 import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import { ComponentExperimentProps } from '#app/models/types/global';
+import { EventTrackingData } from '#app/lib/analyticsUtils/types';
 
 import styles from './index.styles';
 
@@ -11,6 +12,7 @@ type ScrollableTabsProps = {
   activeTabId: string;
   onTabChange: (tabId: string) => void;
   labelledBy: string;
+  groupTracker?: EventTrackingData['groupTracker'];
   experimentProps?: ComponentExperimentProps;
 };
 
@@ -19,6 +21,7 @@ const ScrollableTabs = ({
   activeTabId,
   onTabChange,
   labelledBy,
+  groupTracker,
   experimentProps,
 }: ScrollableTabsProps) => {
   const { dir } = use(ServiceContext);
@@ -105,11 +108,18 @@ const ScrollableTabs = ({
         aria-labelledby={labelledBy}
         css={styles.tabList}
       >
-        {tabs.map(tab => {
+        {tabs.map((tab, index) => {
           const isActive = tab.id === activeTabId;
 
           const clickTrackerHandler = getClickTrackerHandler({
-            componentName: `topic-discovery-tab-${tab.id}`,
+            componentName: 'topic-discovery-tab',
+            groupTracker,
+            itemTracker: {
+              type: 'topic-discovery-tab',
+              text: tab.label,
+              position: index + 1,
+              resourceId: tab.id,
+            },
             preventNavigation: true,
             ...(experimentProps && experimentProps),
           });

--- a/src/app/components/TopicDiscovery/index.test.tsx
+++ b/src/app/components/TopicDiscovery/index.test.tsx
@@ -188,6 +188,12 @@ describe('TopicDiscovery', () => {
   });
 
   describe('analytics', () => {
+    const groupTracker = {
+      itemCount: 4,
+      name: 'Descubra mais',
+      type: 'topic-discovery',
+    };
+
     it('should call useViewTracker with topic-discovery component name', () => {
       const viewTrackerSpy = jest.spyOn(viewTracking, 'default');
 
@@ -197,6 +203,7 @@ describe('TopicDiscovery', () => {
 
       expect(viewTrackerSpy).toHaveBeenCalledWith({
         componentName: 'topic-discovery',
+        groupTracker,
       });
 
       viewTrackerSpy.mockRestore();
@@ -232,7 +239,14 @@ describe('TopicDiscovery', () => {
       });
 
       const expectedCalls = topicTagsFixture.map(topic => ({
-        componentName: `topic-discovery-tab-${topic.topicId}`,
+        componentName: 'topic-discovery-tab',
+        groupTracker,
+        itemTracker: {
+          type: 'topic-discovery-tab',
+          text: topic.topicName,
+          position: topicTagsFixture.indexOf(topic) + 1,
+          resourceId: topic.topicId,
+        },
         preventNavigation: true,
       }));
 
@@ -263,6 +277,13 @@ describe('TopicDiscovery', () => {
 
       expect(clickTracking.default).toHaveBeenCalledWith({
         componentName: 'topic-discovery-more-from-link',
+        groupTracker,
+        itemTracker: {
+          type: 'topic-discovery-more-from-link',
+          text: `Mais de ${topicTagsFixture[0].topicName}`,
+          position: 1,
+          resourceId: topicTagsFixture[0].topicId,
+        },
       });
     });
   });

--- a/src/app/components/TopicDiscovery/index.test.tsx
+++ b/src/app/components/TopicDiscovery/index.test.tsx
@@ -281,7 +281,6 @@ describe('TopicDiscovery', () => {
         itemTracker: {
           type: 'topic-discovery-more-from-link',
           text: `Mais de ${topicTagsFixture[0].topicName}`,
-          position: 1,
           resourceId: topicTagsFixture[0].topicId,
         },
       });

--- a/src/app/components/TopicDiscovery/index.tsx
+++ b/src/app/components/TopicDiscovery/index.tsx
@@ -69,7 +69,6 @@ const TopicDiscovery = ({
       text: currentTopic
         ? moreFromTopic.replace('{topic}', currentTopic.topicName)
         : undefined,
-      position: 1,
       resourceId: currentTopic?.topicId,
     },
     ...(experimentProps && experimentProps),

--- a/src/app/components/TopicDiscovery/index.tsx
+++ b/src/app/components/TopicDiscovery/index.tsx
@@ -24,11 +24,6 @@ const TopicDiscovery = ({
   className,
   experimentProps,
 }: TopicDiscoveryProps) => {
-  const eventTrackingData = {
-    componentName: 'topic-discovery',
-    ...(experimentProps && experimentProps),
-  };
-
   const { translations } = use(ServiceContext);
   const {
     heading = 'Discover more',
@@ -37,6 +32,24 @@ const TopicDiscovery = ({
   } = translations.topicDiscovery || {};
 
   const [activeTabId, setActiveTabId] = useState(topics?.[0]?.topicId || '');
+  const activeTopic = topics?.find(topic => topic.topicId === activeTabId);
+  const currentTopic = activeTopic || topics?.[0];
+  const tabs = topics
+    ? topics.map(topic => ({
+        id: topic.topicId,
+        label: topic.topicName,
+      }))
+    : [];
+  const groupTracker = {
+    name: heading,
+    type: 'topic-discovery',
+    ...(topics?.length > 0 && { itemCount: topics.length }),
+  };
+  const eventTrackingData = {
+    componentName: 'topic-discovery',
+    groupTracker,
+    ...(experimentProps && experimentProps),
+  };
 
   const { topicPromos, isLoading, isError } = useFetchTopicPromos({
     activeTabId,
@@ -50,19 +63,20 @@ const TopicDiscovery = ({
 
   const moreFromLinkClickTracker = useClickTrackerHandler({
     componentName: 'topic-discovery-more-from-link',
+    groupTracker,
+    itemTracker: {
+      type: 'topic-discovery-more-from-link',
+      text: currentTopic
+        ? moreFromTopic.replace('{topic}', currentTopic.topicName)
+        : undefined,
+      position: 1,
+      resourceId: currentTopic?.topicId,
+    },
     ...(experimentProps && experimentProps),
   });
 
   if (!topics || topics.length === 0) return null;
-
-  const activeTopic = topics.find(
-    topic => topic.topicId === activeTabId,
-  ) as ExtractedTopic;
-
-  const tabs = topics.map(topic => ({
-    id: topic.topicId,
-    label: topic.topicName,
-  }));
+  const selectedTopic = currentTopic as ExtractedTopic;
 
   const showLoadingState = Boolean(isLoading && !isError);
   const showErrorMessage = Boolean(!isLoading && isError);
@@ -84,6 +98,7 @@ const TopicDiscovery = ({
         activeTabId={activeTabId}
         onTabChange={setActiveTabId}
         labelledBy={HEADING_ID}
+        groupTracker={groupTracker}
         experimentProps={experimentProps}
       />
       <div
@@ -128,16 +143,25 @@ const TopicDiscovery = ({
                     summaries={topicPromos}
                     eventTrackingData={{
                       componentName: 'topic-discovery-curation-grid',
+                      groupTracker: {
+                        name: selectedTopic.topicName,
+                        type: 'topic-discovery-curation-grid',
+                        link: selectedTopic.topicUrl,
+                        resourceId: selectedTopic.topicId,
+                        ...(topicPromos?.length > 0 && {
+                          itemCount: topicPromos.length,
+                        }),
+                      },
                       ...(experimentProps && experimentProps),
                     }}
                   />
                   <a
                     css={styles.moreFromLink}
-                    href={activeTopic?.topicUrl}
+                    href={selectedTopic.topicUrl}
                     data-testid="topic-discovery-more-from"
                     {...moreFromLinkClickTracker}
                   >
-                    {moreFromTopic.replace('{topic}', activeTopic.topicName)}
+                    {moreFromTopic.replace('{topic}', selectedTopic.topicName)}
                   </a>
                 </>
               );

--- a/src/app/components/TopicTags/index.tsx
+++ b/src/app/components/TopicTags/index.tsx
@@ -3,6 +3,7 @@ import { ServiceContext } from '#app/contexts/ServiceContext';
 import { RequestContext } from '#app/contexts/RequestContext';
 import { ComponentExperimentProps } from '#app/models/types/global';
 import { TopicTag } from '#app/models/types/metadata';
+import { EventTrackingData } from '#app/lib/analyticsUtils/types';
 import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import useViewTracker from '#app/hooks/useViewTracker';
 import styles from './index.styles';
@@ -12,21 +13,54 @@ interface TopicTagsProps {
   experimentProps?: ComponentExperimentProps;
 }
 
+type TopicTagLinkProps = {
+  tag: Pick<TopicTag, 'topicName' | 'topicId'>;
+  href: string;
+  position: number;
+  eventTrackingData: EventTrackingData;
+};
+
+const TopicTagLink = ({
+  tag,
+  href,
+  position,
+  eventTrackingData,
+}: TopicTagLinkProps) => {
+  const clickTrackerHandler = useClickTrackerHandler({
+    ...eventTrackingData,
+    itemTracker: {
+      type: 'topics-link',
+      text: tag.topicName,
+      position,
+      resourceId: tag.topicId,
+    },
+  });
+
+  return (
+    <a href={href} {...clickTrackerHandler}>
+      {tag.topicName}
+    </a>
+  );
+};
+
 export const TopicTags = ({ tags, experimentProps }: TopicTagsProps) => {
   const componentName = 'topics';
-
+  const { service, translations } = use(ServiceContext);
+  const { variant } = use(RequestContext);
+  const heading = translations?.relatedTopics ?? 'Related Topics';
   const eventTrackingData = {
     componentName,
+    groupTracker: {
+      name: heading,
+      type: componentName,
+      itemCount: tags.length,
+    },
     ...(experimentProps && experimentProps),
   };
 
   const viewTracker = useViewTracker(eventTrackingData);
-  const clickTrackerHandler = useClickTrackerHandler(eventTrackingData);
 
   if (tags?.length === 0) return null;
-
-  const { service, translations } = use(ServiceContext);
-  const { variant } = use(RequestContext);
 
   const getTopicPageUrl = (id: string) => {
     const isPublicService = ['news', 'cymrufyw', 'naidheachdan'];
@@ -45,11 +79,14 @@ export const TopicTags = ({ tags, experimentProps }: TopicTagsProps) => {
       data-testid="topic-tags-multiple"
       {...viewTracker}
     >
-      {tags.map(tag => (
+      {tags.map((tag, index) => (
         <li key={tag.topicId} css={styles.topicTagItem}>
-          <a href={getTopicPageUrl(tag.topicId)} {...clickTrackerHandler}>
-            {tag.topicName}
-          </a>
+          <TopicTagLink
+            tag={tag}
+            href={getTopicPageUrl(tag.topicId)}
+            position={index + 1}
+            eventTrackingData={eventTrackingData}
+          />
         </li>
       ))}
     </ul>
@@ -60,9 +97,12 @@ export const TopicTags = ({ tags, experimentProps }: TopicTagsProps) => {
       {...viewTracker}
     >
       <div css={styles.topicTagItem}>
-        <a href={getTopicPageUrl(tags[0].topicId)} {...clickTrackerHandler}>
-          {tags[0].topicName}
-        </a>
+        <TopicTagLink
+          tag={tags[0]}
+          href={getTopicPageUrl(tags[0].topicId)}
+          position={1}
+          eventTrackingData={eventTrackingData}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
Resolves JIRA: 
WS-2736

Summary
======
- Adds Piano/ATI tracking metadata for the Topic Discovery experiment so we can compare results with Optimizely

- Adds clearer tracking for topic tag clicks, Topic Discovery tab clicks, “More from” clicks, and Topic Discovery promo clicks by sending details such the topic name, topic id, item position, and section/group context

Code changes
======
- See files changed

Testing
======
1. Check beacons firing/events registering in inspect window of the browser for the experiment when it is enabled

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
