### PR TITLE
WS-2575: Add styling changes

### DIFF
--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/components/head-to-head-banner.tsx
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/components/head-to-head-banner.tsx
@@ -37,6 +37,7 @@ const ItemWrapper = ({
             shortName={data.home.shortName}
             isConciseView={isConciseView}
             imageUrl={data.home.imageSrc}
+            hideBadges={shouldHideBadges}
           />
         </div>
         <div css={styles.scores}>
@@ -53,6 +54,7 @@ const ItemWrapper = ({
             shortName={data.away.shortName}
             isConciseView={isConciseView}
             imageUrl={data.away.imageSrc}
+            hideBadges={shouldHideBadges}
           />
         </div>
         <div css={styles.matchProgressContainer}>

--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/components/team.tsx
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/components/team.tsx
@@ -10,6 +10,7 @@ interface TeamProps {
   isConciseView: boolean;
   imageUrl: string | null;
   urn: string;
+  hideBadges?: boolean;
 }
 
 const Team = ({
@@ -19,12 +20,13 @@ const Team = ({
   isConciseView,
   imageUrl,
   urn,
+  hideBadges,
 }: TeamProps) => {
   const size: BadgeSize = isConciseView
     ? { small: 20, medium: 24, large: 24 }
     : { small: 40, medium: 44, large: 44 };
 
-  const shouldHideBadges = !imageUrl;
+  const shouldHideBadges = hideBadges || !imageUrl;
 
   if (alignment === 'home') {
     return (

--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/head-to-head-v2.tsx
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/head-to-head-v2.tsx
@@ -34,9 +34,6 @@ export const HeadToHeadV2 = ({
     (currentSportData?.home?.actions?.length ?? 0) > 0 ||
     (currentSportData?.away?.actions?.length ?? 0) > 0;
 
-  // TODO: Re-enable badge visibility logic once we have the necessary badge mappings in place
-  const shouldHideBadges = true;
-
   const translatedSportData = translateSportData(
     currentSportData,
     translations,
@@ -50,7 +47,7 @@ export const HeadToHeadV2 = ({
             data={translatedSportData}
             isConciseView={isConciseView ?? false}
             eventSummary={translatedSportData.accessibleEventSummary}
-            shouldHideBadges={shouldHideBadges}
+            shouldHideBadges={isConciseView ?? false}
             maxScoreLength={maximumContainerScoreDigits}
           />
           {hasActions && shouldShowActions && (

--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
@@ -49,12 +49,15 @@ export default {
         fontFeatureSettings: "'ss01' off",
         color: palette.LUNAR_LIGHT,
         padding: isConciseView ? '8px' : '0',
+        paddingBlockStart: `${pixelsToRem(24)}rem`,
         ...(!isConciseView && { paddingBottom: `${pixelsToRem(24)}rem` }),
         [mq.GROUP_2_MAX_WIDTH]: {
-          paddingTop: '8px',
-          ...(!isConciseView && { paddingBottom: `${pixelsToRem(8)}rem` }),
+          paddingTop: isConciseView ? '8px' : '0',
+          ...(!isConciseView && {
+            paddingBottom: `${pixelsToRem(8)}rem`,
+            paddingTop: `${pixelsToRem(24)}rem`,
+          }),
         },
-        paddingBlockStart: `${pixelsToRem(24)}rem`,
       }),
 
   // ==================== Action Grid ====================

--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
@@ -42,20 +42,20 @@ export default {
       }),
   container:
     ({ isConciseView }: { isConciseView?: boolean }) =>
-    ({ mq, palette }: Theme) =>
+    ({ mq, palette, spacings }: Theme) =>
       css({
         fontFamily: 'ReithSans, Helvetica, Arial, freesans, sans-serif',
         fontWeight: 400,
         fontFeatureSettings: "'ss01' off",
         color: palette.LUNAR_LIGHT,
-        padding: isConciseView ? '8px' : '0',
-        paddingBlockStart: `${pixelsToRem(24)}rem`,
-        ...(!isConciseView && { paddingBottom: `${pixelsToRem(24)}rem` }),
+        padding: isConciseView ? `${spacings.FULL}rem` : 0,
+        paddingBlockStart: `${spacings.TRIPLE}rem`,
+        ...(!isConciseView && { paddingBottom: `${spacings.TRIPLE}rem` }),
         [mq.GROUP_2_MAX_WIDTH]: {
-          paddingTop: isConciseView ? '8px' : '0',
+          paddingTop: isConciseView ? `${spacings.FULL}rem` : 0,
           ...(!isConciseView && {
-            paddingBottom: `${pixelsToRem(8)}rem`,
-            paddingTop: `${pixelsToRem(24)}rem`,
+            paddingBottom: `${spacings.FULL}rem`,
+            paddingTop: `${spacings.TRIPLE}rem`,
           }),
         },
       }),

--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
@@ -51,7 +51,7 @@ export default {
         padding: isConciseView ? '8px' : '0',
         ...(!isConciseView && { paddingBottom: `${pixelsToRem(24)}rem` }),
         [mq.GROUP_2_MAX_WIDTH]: {
-          paddingTop: isConciseView ? '8px' : '0',
+          paddingTop: '8px',
           ...(!isConciseView && { paddingBottom: `${pixelsToRem(8)}rem` }),
         },
         paddingBlockStart: `${pixelsToRem(24)}rem`,


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2575

Summary
======
Adds margin at the top for smaller devices:
Before:
<img width="420" height="379" alt="Screenshot 2026-06-03 at 15 37 30" src="https://github.com/user-attachments/assets/eb102db7-ae49-42da-88d8-78a17e93d4ff" />

After:
<img width="377" height="523" alt="Screenshot 2026-06-03 at 15 52 43" src="https://github.com/user-attachments/assets/4561e2cd-3a29-405d-aedd-42a8fed6eef5" />


Code changes
======
- Style changes

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
