### PR TITLE
Fix padding for sport header mobile view

### DIFF
--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
@@ -49,12 +49,15 @@ export default {
         fontFeatureSettings: "'ss01' off",
         color: palette.LUNAR_LIGHT,
         padding: isConciseView ? '8px' : '0',
+        paddingBlockStart: `${pixelsToRem(24)}rem`,
         ...(!isConciseView && { paddingBottom: `${pixelsToRem(24)}rem` }),
         [mq.GROUP_2_MAX_WIDTH]: {
           paddingTop: isConciseView ? '8px' : '0',
-          ...(!isConciseView && { paddingBottom: `${pixelsToRem(8)}rem` }),
+          ...(!isConciseView && {
+            paddingBottom: `${pixelsToRem(8)}rem`,
+            paddingTop: `${pixelsToRem(24)}rem`,
+          }),
         },
-        paddingBlockStart: `${pixelsToRem(24)}rem`,
       }),
 
   // ==================== Action Grid ====================


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Adds padding top to the sport header mobile view

Code changes
======
- _List key code changes that have been made._

Testing
======

Compare bbc.com/afrique/live/cz72dnj7plxt?renderer_env=live to localhost version on this branch

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
