### PR TITLE
WS-2692: Adds white-space nowrap to visuallyhiddentext component

### DIFF
--- a/src/app/components/Caption/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Caption/__snapshots__/index.test.tsx.snap
@@ -64,6 +64,7 @@ exports[`Captions should render caption text with example Farsi offscreen text 1
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -152,6 +153,7 @@ exports[`Captions should render caption text with example News offscreen text 1`
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -240,6 +242,7 @@ exports[`Captions should render caption with multiple paragraphs 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -338,6 +341,7 @@ exports[`Captions should render correctly with inline block 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-2 {

--- a/src/app/components/Copyright/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Copyright/__snapshots__/index.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`should render Copyright with news service context 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -111,6 +112,7 @@ exports[`should render Copyright with persian service context 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>

--- a/src/app/components/ImageWithCaption/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/ImageWithCaption/__snapshots__/index.test.tsx.snap
@@ -102,6 +102,7 @@ exports[`Image with data should render an image with alt text and caption 1`] = 
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -232,6 +233,7 @@ exports[`Image with data should render an image with alt text and offscreen copy
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -354,6 +356,7 @@ exports[`Image with data should render an image with other originCode - this wou
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>

--- a/src/app/components/LiveLabel/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/LiveLabel/__snapshots__/index.test.tsx.snap
@@ -142,6 +142,7 @@ exports[`LiveLabel should render correctly with English live text 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -243,6 +244,7 @@ exports[`LiveLabel should render correctly with English live text and children 1
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -345,6 +347,7 @@ exports[`LiveLabel should render correctly with custom offscreen text 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>

--- a/src/app/components/MediaLoader/Placeholder/PlayButton/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/MediaLoader/Placeholder/PlayButton/__snapshots__/index.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`PlayButton should render audio correctly without duration details 1`] =
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-2>svg {
@@ -196,6 +197,7 @@ exports[`PlayButton should render audio indicator correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-2 {
@@ -346,6 +348,7 @@ exports[`PlayButton should render video by default 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-2>svg {
@@ -480,6 +483,7 @@ exports[`PlayButton should render video correctly with duration and guidance mes
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-2 {
@@ -637,6 +641,7 @@ exports[`PlayButton should render video correctly without duration details 1`] =
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-2>svg {
@@ -771,6 +776,7 @@ exports[`PlayButton should render video indicator correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-2 {

--- a/src/app/components/MediaLoader/Placeholder/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/MediaLoader/Placeholder/__snapshots__/index.test.tsx.snap
@@ -184,6 +184,7 @@ exports[`Media Player: Placeholder should render a video placeholder 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-5 {
@@ -539,6 +540,7 @@ exports[`Media Player: Placeholder should render a video placeholder with guidan
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-6 {
@@ -874,6 +876,7 @@ exports[`Media Player: Placeholder should render a video placeholder without dur
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-5>svg {
@@ -1180,6 +1183,7 @@ exports[`Media Player: Placeholder should render an audio placeholder 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-5 {
@@ -1502,6 +1506,7 @@ exports[`Media Player: Placeholder should render an audio placeholder without du
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-5>svg {
@@ -1827,6 +1832,7 @@ exports[`Media Player: Placeholder should render no-js styles when noJsClassName
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-6 {

--- a/src/app/components/Navigation/__snapshots__/index.amp.test.tsx.snap
+++ b/src/app/components/Navigation/__snapshots__/index.amp.test.tsx.snap
@@ -303,6 +303,7 @@ exports[`AMP Navigation Snapshots should correctly render AMP navigation 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-16 {

--- a/src/app/components/Navigation/__snapshots__/index.canonical.test.tsx.snap
+++ b/src/app/components/Navigation/__snapshots__/index.canonical.test.tsx.snap
@@ -290,6 +290,7 @@ exports[`Navigation - Canonical snapshots should correctly render Canonical navi
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-14 {

--- a/src/app/components/Navigation/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Navigation/__snapshots__/index.test.tsx.snap
@@ -352,6 +352,7 @@ exports[`Navigation should correctly render amp navigation 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-21 {
@@ -1302,6 +1303,7 @@ exports[`Navigation should correctly render amp navigation on a URL not associat
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-27 {
@@ -2103,6 +2105,7 @@ exports[`Navigation should correctly render amp navigation on non-home navigatio
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-23 {
@@ -2911,6 +2914,7 @@ exports[`Navigation should correctly render canonical navigation 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-21 {
@@ -3847,6 +3851,7 @@ exports[`Navigation should correctly render canonical navigation on a URL not as
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-25 {
@@ -4634,6 +4639,7 @@ exports[`Navigation should correctly render canonical navigation on non-home nav
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-23 {

--- a/src/app/components/PageLayoutWrapper/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/PageLayoutWrapper/__snapshots__/index.test.tsx.snap
@@ -439,6 +439,7 @@ exports[`PageLayoutWrapper should render default page wrapper with children 1`] 
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-27 {

--- a/src/app/components/VisuallyHiddenText/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/VisuallyHiddenText/__snapshots__/index.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`VisuallyHiddenText should render off screen text for screen readers 1`]
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <span
@@ -29,6 +30,7 @@ exports[`VisuallyHiddenText should render off screen text for screen readers as 
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <h1
@@ -48,6 +50,7 @@ exports[`VisuallyHiddenText should render off screen text for screen readers as 
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <h1

--- a/src/app/components/VisuallyHiddenText/index.styles.tsx
+++ b/src/app/components/VisuallyHiddenText/index.styles.tsx
@@ -10,6 +10,7 @@ const styles = {
       position: 'absolute',
       width: '1px',
       margin: '0',
+      whiteSpace: 'nowrap',
     }),
 };
 

--- a/src/app/legacy/components/RadioSchedule/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/components/RadioSchedule/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -146,6 +146,7 @@ exports[`ProgramCard should render correctly for live 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-13 {
@@ -434,6 +435,7 @@ exports[`ProgramCard should render correctly for next 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-7 {
@@ -758,6 +760,7 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-10 {
@@ -1056,6 +1059,7 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-10 {
@@ -1403,6 +1407,7 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-13 {

--- a/src/app/legacy/components/RadioSchedule/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/components/RadioSchedule/__snapshots__/index.test.jsx.snap
@@ -473,6 +473,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-31 {
@@ -1777,6 +1778,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-31 {

--- a/src/app/legacy/containers/ArticleTimestamp/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/ArticleTimestamp/__snapshots__/index.test.jsx.snap
@@ -120,6 +120,7 @@ exports[`ArticleTimestamp should render a 'created' Timestamp correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-4 {
@@ -291,6 +292,7 @@ exports[`ArticleTimestamp should render both a 'created' and an 'updated' Timest
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-4 {
@@ -470,6 +472,7 @@ exports[`ArticleTimestamp should render with a prefix 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-4 {
@@ -649,6 +652,7 @@ exports[`ArticleTimestamp should render with a suffix 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-4 {
@@ -828,6 +832,7 @@ exports[`ArticleTimestamp should render with no suffix or prefix 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-4 {

--- a/src/app/legacy/containers/Brand/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/Brand/__snapshots__/index.test.jsx.snap
@@ -141,6 +141,7 @@ exports[`BrandContainer should render correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div

--- a/src/app/legacy/containers/EpisodeList/RecentAudioEpisodes/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/EpisodeList/RecentAudioEpisodes/__snapshots__/index.test.jsx.snap
@@ -228,6 +228,7 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-26 {

--- a/src/app/legacy/containers/EpisodeList/RecentVideoEpisodes/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/EpisodeList/RecentVideoEpisodes/__snapshots__/index.test.jsx.snap
@@ -346,6 +346,7 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-34 {

--- a/src/app/legacy/containers/Footer/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/Footer/__snapshots__/index.test.jsx.snap
@@ -170,6 +170,7 @@ exports[`FooterContainer snapshots should render correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-12 {

--- a/src/app/legacy/containers/Header/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/Header/__snapshots__/index.test.jsx.snap
@@ -424,6 +424,7 @@ exports[`Header Snapshots should render correctly for WS TV page 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-26 {
@@ -1760,6 +1761,7 @@ exports[`Header Snapshots should render correctly for WS on demand audio page 1`
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-26 {
@@ -3096,6 +3098,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-26 {
@@ -4432,6 +4435,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-26 {

--- a/src/app/legacy/containers/Navigation/__snapshots__/index.amp.test.jsx.snap
+++ b/src/app/legacy/containers/Navigation/__snapshots__/index.amp.test.jsx.snap
@@ -112,6 +112,7 @@ exports[`AMP Navigation Snapshots should correctly render AMP navigation 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-11 {

--- a/src/app/legacy/containers/Navigation/__snapshots__/index.canonical.test.jsx.snap
+++ b/src/app/legacy/containers/Navigation/__snapshots__/index.canonical.test.jsx.snap
@@ -110,6 +110,7 @@ exports[`Canonical Navigation snapshots should correctly render Canonical naviga
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 @media (max-width: 37.4375rem) {

--- a/src/app/legacy/containers/Navigation/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/Navigation/__snapshots__/index.test.jsx.snap
@@ -112,6 +112,7 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-11 {
@@ -956,6 +957,7 @@ exports[`Navigation Container should correctly render amp navigation on non-home
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-11 {
@@ -1697,6 +1699,7 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-11 {
@@ -2436,6 +2439,7 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 @media (max-width: 37.4375rem) {
@@ -3285,6 +3289,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 @media (max-width: 37.4375rem) {
@@ -4031,6 +4036,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 @media (max-width: 37.4375rem) {

--- a/src/app/legacy/containers/OnDemandHeading/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/OnDemandHeading/__snapshots__/index.test.jsx.snap
@@ -58,6 +58,7 @@ exports[`AudioPlayer blocks OnDemandHeading should render correctly - dark mode 
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-5 {
@@ -208,6 +209,7 @@ exports[`AudioPlayer blocks OnDemandHeading should render correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-5 {

--- a/src/app/legacy/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
@@ -122,6 +122,7 @@ exports[`PodcastExternalLinks Should render external links 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>

--- a/src/app/legacy/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
@@ -564,6 +564,7 @@ exports[`RadioSchedule With initial data renders correctly for a service 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-40 {

--- a/src/app/legacy/containers/StoryPromo/IndexAlsos/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/StoryPromo/IndexAlsos/__snapshots__/index.test.jsx.snap
@@ -16,6 +16,7 @@ exports[`Index Alsos Snapshots should render multiple correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-3 {
@@ -235,6 +236,7 @@ exports[`Index Alsos Snapshots should render one correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-3 {

--- a/src/app/legacy/containers/StoryPromo/LinkContents/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/StoryPromo/LinkContents/__snapshots__/index.test.jsx.snap
@@ -10,6 +10,7 @@ exports[`Story Promo Link Contents should render with visually hidden text for m
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -43,6 +44,7 @@ exports[`Story Promo Link Contents should render with visually hidden text for m
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -76,6 +78,7 @@ exports[`Story Promo Link Contents should render with visually hidden text for p
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>

--- a/src/app/legacy/containers/StoryPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/StoryPromo/__snapshots__/index.test.jsx.snap
@@ -247,6 +247,7 @@ exports[`StoryPromo Container should render audio correctly for amp 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-25 {
@@ -680,6 +681,7 @@ exports[`StoryPromo Container should render audio correctly for canonical 1`] = 
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-26 {
@@ -995,6 +997,7 @@ exports[`StoryPromo Container should render audio promoType leading on amp 1`] =
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-10 {
@@ -1562,6 +1565,7 @@ exports[`StoryPromo Container should render audio promoType top on amp 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-25 {
@@ -1978,6 +1982,7 @@ exports[`StoryPromo Container should render audio with no duration correctly for
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-22 {
@@ -2396,6 +2401,7 @@ exports[`StoryPromo Container should render audio with no duration correctly for
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-23 {
@@ -2700,6 +2706,7 @@ exports[`StoryPromo Container should render audio with no duration promoType lea
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-9 {
@@ -3248,6 +3255,7 @@ exports[`StoryPromo Container should render audio with no duration promoType top
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-22 {
@@ -6882,6 +6890,7 @@ exports[`StoryPromo Container should render live correctly for amp 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-19 {
@@ -7272,6 +7281,7 @@ exports[`StoryPromo Container should render live correctly for canonical 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-20 {
@@ -7610,6 +7620,7 @@ exports[`StoryPromo Container should render live promoType leading on amp 1`] = 
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-12 {
@@ -8100,6 +8111,7 @@ exports[`StoryPromo Container should render live promoType top on amp 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-19 {
@@ -8503,6 +8515,7 @@ exports[`StoryPromo Container should render multiple Index Alsos correctly for c
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-23 {
@@ -14080,6 +14093,7 @@ exports[`StoryPromo Container should render video correctly for amp 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-25 {
@@ -14520,6 +14534,7 @@ exports[`StoryPromo Container should render video correctly for canonical 1`] = 
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-26 {
@@ -14842,6 +14857,7 @@ exports[`StoryPromo Container should render video promoType leading on amp 1`] =
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-10 {
@@ -15416,6 +15432,7 @@ exports[`StoryPromo Container should render video promoType top on amp 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-25 {

--- a/src/app/legacy/containers/VisuallyHiddenHeadline/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/VisuallyHiddenHeadline/__snapshots__/index.test.jsx.snap
@@ -10,6 +10,7 @@ exports[`VisuallyHiddenHeadline with headline data should render correctly 1`] =
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -33,6 +34,7 @@ exports[`VisuallyHiddenHeadline with plain text headline should render h1 contai
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>

--- a/src/app/legacy/psammead/psammead-brand/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-brand/src/__snapshots__/index.test.jsx.snap
@@ -97,6 +97,7 @@ exports[`Brand should render correctly with link not provided 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -271,6 +272,7 @@ exports[`Brand should render correctly with link provided 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -419,6 +421,7 @@ exports[`Brand should render correctly with no service Localised Name 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>

--- a/src/app/legacy/psammead/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-bulletin/src/__snapshots__/index.test.jsx.snap
@@ -127,6 +127,7 @@ exports[`Bulletin should render audio correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-13 {
@@ -445,6 +446,7 @@ exports[`Bulletin should render audio correctly with lang prop passed in 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-13 {
@@ -813,6 +815,7 @@ exports[`Bulletin should render live audio correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-16 {
@@ -1208,6 +1211,7 @@ exports[`Bulletin should render live video correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-16 {
@@ -1558,6 +1562,7 @@ exports[`Bulletin should render radio bulletin without ariaId 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-13 {
@@ -1876,6 +1881,7 @@ exports[`Bulletin should render radio bulletin without summary correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-13 {
@@ -2160,6 +2166,7 @@ exports[`Bulletin should render video correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-13 {

--- a/src/app/legacy/psammead/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
@@ -67,6 +67,7 @@ exports[`Canonical Closed menu button should render correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -165,6 +166,7 @@ exports[`Canonical Closed menu button should render rtl correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -263,6 +265,7 @@ exports[`Canonical Open menu button should render correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -362,6 +365,7 @@ exports[`Canonical Open menu button should render rtl correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -461,6 +465,7 @@ exports[`Dropdown navigation AMP Menu Button should render correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -586,6 +591,7 @@ exports[`Dropdown navigation AMP Menu Button should render rtl correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -735,6 +741,7 @@ exports[`Dropdown navigation should render correctly when closer 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>
@@ -996,6 +1003,7 @@ exports[`Dropdown navigation should render correctly when open 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 <div>

--- a/src/app/legacy/psammead/psammead-navigation/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-navigation/src/__snapshots__/index.test.jsx.snap
@@ -163,6 +163,7 @@ exports[`Navigation should render correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-15 {
@@ -485,6 +486,7 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-15 {
@@ -801,6 +803,7 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-15 {
@@ -1167,6 +1170,7 @@ exports[`Scrollable Navigation should render correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-17 {

--- a/src/app/legacy/psammead/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-story-promo/src/IndexAlsos/__snapshots__/index.test.jsx.snap
@@ -16,6 +16,7 @@ exports[`Index Alsos should render multiple correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-3 {
@@ -222,6 +223,7 @@ exports[`Index Alsos should render one correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-3 {

--- a/src/app/legacy/psammead/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-story-promo/src/__snapshots__/index.test.jsx.snap
@@ -1389,6 +1389,7 @@ exports[`StoryPromo - Top Story should render with multiple Index Alsos correctl
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-17 {
@@ -1824,6 +1825,7 @@ exports[`StoryPromo - Top Story should render with one Index Also correctly 1`] 
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-17 {
@@ -2229,6 +2231,7 @@ exports[`StoryPromo should render Live promo correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-16 {
@@ -2550,6 +2553,7 @@ exports[`StoryPromo should render a RTL Live promo correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-16 {

--- a/src/app/pages/ArticlePage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/ArticlePage/__snapshots__/index.test.tsx.snap
@@ -2765,6 +2765,7 @@ exports[`Article Page should render a news article with headline in the middle c
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 @media (max-width: 14.9375rem) {
@@ -3172,6 +3173,7 @@ exports[`Article Page should render a news article without headline correctly 1`
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 @media (max-width: 14.9375rem) {

--- a/src/app/pages/LiveRadioPage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/LiveRadioPage/__snapshots__/index.test.tsx.snap
@@ -806,6 +806,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-51 {

--- a/src/app/pages/MediaArticlePage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/MediaArticlePage/__snapshots__/index.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-5 {

--- a/src/app/pages/OnDemandAudioPage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OnDemandAudioPage/__snapshots__/index.test.tsx.snap
@@ -177,6 +177,7 @@ exports[`OnDemand Radio Page  should match snapshot 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-10 {
@@ -2119,6 +2120,7 @@ exports[`OnDemand Radio Page  should show the 'content not yet available' messag
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-10 {
@@ -4018,6 +4020,7 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-10 {

--- a/src/app/pages/OnDemandTvPage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OnDemandTvPage/__snapshots__/index.test.tsx.snap
@@ -220,6 +220,7 @@ exports[`OnDemand TV Page  Dark Mode Design - should match snapshot 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-7 {
@@ -1101,6 +1102,7 @@ exports[`OnDemand TV Page  should show the expired content message if episode is
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-7 {
@@ -1751,6 +1753,7 @@ exports[`OnDemand TV Page  should show the future content message if episode is 
   position: absolute;
   width: 1px;
   margin: 0;
+  white-space: nowrap;
 }
 
 .emotion-7 {

--- a/ws-nextjs-app/integration/pages/articles/afrique/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/afrique/__snapshots__/canonical.test.ts.snap
@@ -28,7 +28,7 @@ exports[`Canonical Articles Media Loader renders a figure caption 1`] = `
     type="button"
   >
     <span
-      class="css-2ozlq5"
+      class="css-5ku87v"
     >
       Play video, ""มหาวิหารน้ำแข็ง" สถาปัตยกรรมงดงามที่ธรรมชาติรังสรรค์ในสวิตเซอร์แลนด์", Durée 0,30
     </span>
@@ -105,7 +105,7 @@ exports[`Canonical Articles Media Loader renders a placeholder 1`] = `
     type="button"
   >
     <span
-      class="css-2ozlq5"
+      class="css-5ku87v"
     >
       Play video, ""มหาวิหารน้ำแข็ง" สถาปัตยกรรมงดงามที่ธรรมชาติรังสรรค์ในสวิตเซอร์แลนด์", Durée 0,30
     </span>
@@ -186,7 +186,7 @@ exports[`Canonical Articles Media Loader renders a valid container 1`] = `
       type="button"
     >
       <span
-        class="css-2ozlq5"
+        class="css-5ku87v"
       >
         Play video, ""มหาวิหารน้ำแข็ง" สถาปัตยกรรมงดงามที่ธรรมชาติรังสรรค์ในสวิตเซอร์แลนด์", Durée 0,30
       </span>
@@ -247,7 +247,7 @@ exports[`Canonical Articles Media Loader renders a valid container 1`] = `
       role="text"
     >
       <span
-        class="css-2ozlq5"
+        class="css-5ku87v"
       >
         Légende vidéo, 
       </span>

--- a/ws-nextjs-app/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.ts.snap
@@ -171,7 +171,7 @@ exports[`Canonical Articles Media Loader renders a figure caption 1`] = `
     type="button"
   >
     <span
-      class="css-2ozlq5"
+      class="css-5ku87v"
     >
       Play video, "Â«Ù‚Ø´Ø²Ù‡Ø° Ø´Ø³Ø³Ø«Ù Ù‡Ø± ÙØ«Ø³Ù", مدت 0,16
     </span>
@@ -248,7 +248,7 @@ exports[`Canonical Articles Media Loader renders a placeholder 1`] = `
     type="button"
   >
     <span
-      class="css-2ozlq5"
+      class="css-5ku87v"
     >
       Play video, "Â«Ù‚Ø´Ø²Ù‡Ø° Ø´Ø³Ø³Ø«Ù Ù‡Ø± ÙØ«Ø³Ù", مدت 0,16
     </span>
@@ -329,7 +329,7 @@ exports[`Canonical Articles Media Loader renders a valid container 1`] = `
       type="button"
     >
       <span
-        class="css-2ozlq5"
+        class="css-5ku87v"
       >
         Play video, "Â«Ù‚Ø´Ø²Ù‡Ø° Ø´Ø³Ø³Ø«Ù Ù‡Ø± ÙØ«Ø³Ù", مدت 0,16
       </span>
@@ -390,7 +390,7 @@ exports[`Canonical Articles Media Loader renders a valid container 1`] = `
       role="text"
     >
       <span
-        class="css-2ozlq5"
+        class="css-5ku87v"
       >
         توضیح ویدئو، 
       </span>

--- a/ws-nextjs-app/integration/pages/av-embeds/russian/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/av-embeds/russian/__snapshots__/canonical.test.ts.snap
@@ -24,7 +24,7 @@ exports[`Canonical Av-embeds Media Loader renders a figure caption 1`] = `
     type="button"
   >
     <span
-      class="css-2ozlq5"
+      class="css-5ku87v"
     >
       Play video, ""Здесь же кругом люди": жизнь в 100 метрах от взлетной полосы", Продолжительность 2,53
     </span>
@@ -101,7 +101,7 @@ exports[`Canonical Av-embeds Media Loader renders a placeholder 1`] = `
     type="button"
   >
     <span
-      class="css-2ozlq5"
+      class="css-5ku87v"
     >
       Play video, ""Здесь же кругом люди": жизнь в 100 метрах от взлетной полосы", Продолжительность 2,53
     </span>
@@ -182,7 +182,7 @@ exports[`Canonical Av-embeds Media Loader renders a valid container 1`] = `
       type="button"
     >
       <span
-        class="css-2ozlq5"
+        class="css-5ku87v"
       >
         Play video, ""Здесь же кругом люди": жизнь в 100 метрах от взлетной полосы", Продолжительность 2,53
       </span>

--- a/ws-nextjs-app/integration/pages/live/pidgin/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/live/pidgin/__snapshots__/canonical.test.ts.snap
@@ -47,7 +47,7 @@ exports[`Canonical Live Media Loader renders a valid container 1`] = `
       role="text"
     >
       <span
-        class="css-2ozlq5"
+        class="css-5ku87v"
       >
         Wetin we call dis Video, 
       </span>

--- a/ws-nextjs-app/integration/pages/onDemandTVPage/hausa/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/onDemandTVPage/hausa/__snapshots__/canonical.test.ts.snap
@@ -156,7 +156,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a figure caption 1`] 
     type="button"
   >
     <span
-      class="css-2ozlq5"
+      class="css-5ku87v"
     >
       Play video, "Labaran Talabijin", Tsawon lokaci 10,00
     </span>
@@ -233,7 +233,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a placeholder 1`] = `
     type="button"
   >
     <span
-      class="css-2ozlq5"
+      class="css-5ku87v"
     >
       Play video, "Labaran Talabijin", Tsawon lokaci 10,00
     </span>
@@ -314,7 +314,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a valid container 1`]
       type="button"
     >
       <span
-        class="css-2ozlq5"
+        class="css-5ku87v"
       >
         Play video, "Labaran Talabijin", Tsawon lokaci 10,00
       </span>

--- a/ws-nextjs-app/integration/pages/onDemandTVPage/pashtoBrand/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/onDemandTVPage/pashtoBrand/__snapshots__/canonical.test.ts.snap
@@ -159,7 +159,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a figure caption 1`] 
     type="button"
   >
     <span
-      class="css-2ozlq5"
+      class="css-5ku87v"
     >
       Play video, " د بي بي سي خبرونه ", موده 28,00
     </span>
@@ -236,7 +236,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a placeholder 1`] = `
     type="button"
   >
     <span
-      class="css-2ozlq5"
+      class="css-5ku87v"
     >
       Play video, " د بي بي سي خبرونه ", موده 28,00
     </span>
@@ -317,7 +317,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a valid container 1`]
       type="button"
     >
       <span
-        class="css-2ozlq5"
+        class="css-5ku87v"
       >
         Play video, " د بي بي سي خبرونه ", موده 28,00
       </span>


### PR DESCRIPTION
Resolves JIRA: [WS-2692](https://bbc.atlassian.net/browse/WS-2692)

Summary
======
Adds white-space nowrap to visuallyhiddentext component, to fix a bug where some visually hidden items weren't read out loud in whole using mouse hover mode in ZoomText

Code changes
======
- Adds white-space nowrap to visuallyhiddentext component
- Updates loads of unit and integration snapshots

Testing
======
Unsure wether this needs any regression, as it's visually hidden

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._


[WS-2692]: https://bbc.atlassian.net/browse/WS-2692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ