### PR TITLE
WS-2641: Fallback Image for articles in my-news page

### DIFF
--- a/src/app/components/Curation/CurationPromo/index.test.tsx
+++ b/src/app/components/Curation/CurationPromo/index.test.tsx
@@ -15,6 +15,8 @@ interface FixtureProps {
   position?: number;
   resourceId?: string;
   eventTrackingData?: EventTrackingData;
+  imageUrl?: string;
+  imageAlt?: string;
 }
 
 const Fixture = ({
@@ -26,15 +28,17 @@ const Fixture = ({
   position = 1,
   resourceId = 'e2263a1c-8d5a-4a73-a00c-881acfa34381',
   eventTrackingData,
+  imageUrl = 'https://ichef.bbci.co.uk/ace/ws/240/cpsprodpb/17CDB/production/_123699479_indigena.jpg',
+  imageAlt = 'Campesino indígena peruano.',
 }: FixtureProps) => (
   <CurationPromo
     lazy={lazy}
     title="Promo title"
     description="This is a description"
     firstPublished="2022-03-30T07:37:18.253Z"
-    imageUrl="https://ichef.bbci.co.uk/ace/ws/240/cpsprodpb/17CDB/production/_123699479_indigena.jpg"
+    imageUrl={imageUrl}
     lastPublished="2023-04-17T07:37:18.253Z"
-    imageAlt="Campesino indígena peruano."
+    imageAlt={imageAlt}
     link={link}
     type={type}
     duration={duration}
@@ -136,6 +140,30 @@ describe('Curation Promo', () => {
         { service: 'mundo' },
       );
       expect(container.queryByText('17 abril 2023')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Fallback placeholder image', () => {
+    it('should render a placeholder when imageUrl is missing on My News page', () => {
+      const { container } = render(<Fixture imageUrl="" imageAlt="" />, {
+        pageType: 'myNews',
+      });
+      expect(container.querySelector('.promo-image')).not.toBeEmptyDOMElement();
+      expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    });
+
+    it('should not render a placeholder when imageUrl is missing on non-My News page', () => {
+      const { container } = render(<Fixture imageUrl="" imageAlt="" />, {
+        pageType: 'article',
+      });
+      expect(container.querySelector('.promo-image')).toBeEmptyDOMElement();
+    });
+
+    it('should render the real image when imageUrl is provided on My News page', () => {
+      render(<Fixture />, { pageType: 'myNews' });
+      expect(
+        screen.getByAltText('Campesino indígena peruano.'),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/app/components/Curation/CurationPromo/index.tsx
+++ b/src/app/components/Curation/CurationPromo/index.tsx
@@ -7,6 +7,7 @@ import Promo from '#components/Promo';
 import { Summary } from '#app/models/types/curationData';
 import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import isMediaType from '#app/lib/utilities/isMedia';
+import { MY_NEWS_PAGE } from '#app/routes/utils/pageTypes';
 import VisuallyHiddenText from '../../VisuallyHiddenText';
 import { ServiceContext } from '../../../contexts/ServiceContext';
 import { RequestContext } from '../../../contexts/RequestContext';
@@ -30,8 +31,10 @@ const CurationPromo = ({
   eventTrackingData,
   isPortraitImage,
 }: Summary) => {
-  const { isAmp, isLite } = use(RequestContext);
+  const { isAmp, isLite, pageType } = use(RequestContext);
   const { translations } = use(ServiceContext);
+
+  const shouldShowFallbackPlaceholder = !imageUrl && pageType === MY_NEWS_PAGE;
 
   const audioTranslation = path(['media', 'audio'], translations);
   const videoTranslation = path(['media', 'video'], translations);
@@ -55,7 +58,7 @@ const CurationPromo = ({
 
   return (
     <Promo css={styles.promo} className="">
-      {imageUrl && (
+      {(imageUrl || shouldShowFallbackPlaceholder) && (
         <Promo.Image
           src={imageUrl}
           alt={imageAlt}

--- a/src/app/components/Image/index.tsx
+++ b/src/app/components/Image/index.tsx
@@ -20,7 +20,7 @@ export type ImageProps = {
   mediaType?: string;
   srcSet?: string;
   sizes?: string;
-  src: string;
+  src?: string;
   width?: number;
   fetchPriority?: 'high';
   hasCaption?: boolean;
@@ -59,7 +59,7 @@ const Image = ({
   const [isLoaded, setIsLoaded] = useState(false);
   if (isLite) return null;
 
-  const showPlaceholder = placeholder && !isLoaded;
+  const showPlaceholder = !src || (placeholder && !isLoaded);
   const hasDimensions = width && height;
   const hasFixedAspectRatio = !!aspectRatio || !!hasDimensions;
   const [aspectRatioX, aspectRatioY] = aspectRatio ||
@@ -124,69 +124,70 @@ const Image = ({
           ...(!hasCaption && { overflow: 'hidden' }),
         }}
       >
-        {isAmp ? (
-          <>
-            {!hasDimensions && (
-              // ensures amp-img will render when width and height is not provided
-              // https://amp.dev/documentation/examples/style-layout/how_to_support_images_with_unknown_dimensions/
-              <Global
-                styles={{
-                  '.bbc-image img': {
-                    objectFit: 'cover',
-                  },
-                }}
-              />
-            )}
-            <amp-img
-              class="bbc-image"
-              layout={ampImgLayout}
-              alt={alt}
-              src={src}
-              width={width}
-              height={height}
-              fallback=""
-              attribution={attribution}
-              {...(srcSet && { srcSet: imgSrcSet })}
-              {...(imgSizes && { sizes: imgSizes })}
-              {...(preload && { 'data-hero': 'true' })}
-            />
-          </>
-        ) : (
-          <ImageWrapper>
-            {hasFallback && pageType === HOME_PAGE && (
-              <>
-                <source srcSet={srcSet} type={mediaType} sizes={sizes} />
-                <source
-                  srcSet={fallbackSrcSet}
-                  type={fallbackMediaType}
-                  sizes={sizes}
+        {src &&
+          (isAmp ? (
+            <>
+              {!hasDimensions && (
+                // ensures amp-img will render when width and height is not provided
+                // https://amp.dev/documentation/examples/style-layout/how_to_support_images_with_unknown_dimensions/
+                <Global
+                  styles={{
+                    '.bbc-image img': {
+                      objectFit: 'cover',
+                    },
+                  }}
                 />
-              </>
-            )}
-            <img
-              onLoad={() => setIsLoaded(true)}
-              src={src}
-              {...(srcSet && { srcSet: imgSrcSet })}
-              {...(imgSizes && { sizes: imgSizes })}
-              alt={alt}
-              loading={lazyLoad ? 'lazy' : 'eager'}
-              width={width}
-              height={height}
-              css={[
-                styles.image,
-                hasFixedAspectRatio
-                  ? styles.imageFixedAspectRatio
-                  : styles.imageResponsiveRatio,
-              ]}
-              fetchPriority={fetchPriority}
-              style={{
-                aspectRatio: hasFixedAspectRatio
-                  ? `${aspectRatioX} / ${aspectRatioY}`
-                  : 'auto',
-              }} // aspectRatio used in combination with the objectFit:cover will center the image horizontally and vertically if aspectRatio prop is different from image's intrinsic aspect ratio
-            />
-          </ImageWrapper>
-        )}
+              )}
+              <amp-img
+                class="bbc-image"
+                layout={ampImgLayout}
+                alt={alt}
+                src={src}
+                width={width}
+                height={height}
+                fallback=""
+                attribution={attribution}
+                {...(srcSet && { srcSet: imgSrcSet })}
+                {...(imgSizes && { sizes: imgSizes })}
+                {...(preload && { 'data-hero': 'true' })}
+              />
+            </>
+          ) : (
+            <ImageWrapper>
+              {hasFallback && pageType === HOME_PAGE && (
+                <>
+                  <source srcSet={srcSet} type={mediaType} sizes={sizes} />
+                  <source
+                    srcSet={fallbackSrcSet}
+                    type={fallbackMediaType}
+                    sizes={sizes}
+                  />
+                </>
+              )}
+              <img
+                onLoad={() => setIsLoaded(true)}
+                src={src}
+                {...(srcSet && { srcSet: imgSrcSet })}
+                {...(imgSizes && { sizes: imgSizes })}
+                alt={alt}
+                loading={lazyLoad ? 'lazy' : 'eager'}
+                width={width}
+                height={height}
+                css={[
+                  styles.image,
+                  hasFixedAspectRatio
+                    ? styles.imageFixedAspectRatio
+                    : styles.imageResponsiveRatio,
+                ]}
+                fetchPriority={fetchPriority}
+                style={{
+                  aspectRatio: hasFixedAspectRatio
+                    ? `${aspectRatioX} / ${aspectRatioY}`
+                    : 'auto',
+                }} // aspectRatio used in combination with the objectFit:cover will center the image horizontally and vertically if aspectRatio prop is different from image's intrinsic aspect ratio
+              />
+            </ImageWrapper>
+          ))}
         {children}
       </div>
     </>


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2641 


Summary
======
- Update Image component to support placeholder image rendering. 

<img width="1038" height="1003" alt="Screenshot 2026-06-09 at 14 33 55" src="https://github.com/user-attachments/assets/e2794778-312f-4831-a198-36ebe08a4298" />

Code changes
======
- _List key code changes that have been made._

Testing
======
1. Manually remove the `promoImage` [from the payload](https://github.com/bbc/simorgh/blob/1729e946bd7462b992614aa93117da305e9efe30/src/app/lib/uasApi/uasUtility.ts#L59)
2. Save any article ([example](http://localhost.bbc.com:7081/hindi/articles/cj94erzl8e8o?renderer_env=live))
3. Visit My News page (http://localhost.bbc.com:7081/hindi/my-news) 

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
