### PR TITLE
WS-NA: Shows WS Title as visually hidden H1 for Sport Data Header

### DIFF
--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/metadata.json
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/metadata.json
@@ -1,24 +1,28 @@
 {
+  "lastUpdated": {
+    "day": 12,
+    "month": "June",
+    "year": 2026
+  },
   "uxAccessibilityDoc": {
     "done": true,
     "reference": {
-      "url": "",
-      "label": "Screenreader UX"
+      "url": "https://www.dropbox.com/scl/fi/do6f7e7bw7qmkxlak2lsv/A11y-Criteria-and-Screen-Reader-UX-Sport-Data-Header-component.paper?rlkey=5xv7uflmu92lo65mzycrzpeqs&dl=0",
+      "label": "Screenreader UX (non-translated requirements)"
     }
   },
   "acceptanceCriteria": {
     "done": true,
     "reference": {
-      "url": "https://jira.dev.bbc.co.uk/browse/SWD-2208",
-      "label": "Acceptance criteria"
+      "url": "https://www.dropbox.com/scl/fi/do6f7e7bw7qmkxlak2lsv/A11y-Criteria-and-Screen-Reader-UX-Sport-Data-Header-component.paper?rlkey=5xv7uflmu92lo65mzycrzpeqs&dl=0",
+      "label": "Acceptance criteria (non-translated requirements)"
     }
   },
   "swarm": {
-    "done": false,
+    "done": true,
     "reference": {
-      "url": "https://paper.dropbox.com/folder/show/Head-to-Head-e.1gg8YzoPEhbTkrhvQwJ2zzo3g3aKslj5mXLzEJbxSH2zyS7TwiyR",
-      "label": "Swarm template"
+      "url": "https://www.dropbox.com/scl/fi/78n3tu4trn264iz02dj50/A11Y-Swarm-Sports-Data-Header.paper?rlkey=af023e7wpm0k7f7k0pezd7cv0&dl=0",
+      "label": "A11y Swarm (non-translated requirements)"
     }
-  },
-  "creationDate": "2022-11-24"
+  }
 }

--- a/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
@@ -217,7 +217,7 @@ const LivePage = ({ pageData, assetId }: LivePageProps) => {
       <main>
         <Header
           showLiveLabel={showSportData ? isSportDataLive : isLive}
-          title={showSportData && !!sportDataTitle ? sportDataTitle : title}
+          title={title}
           description={description}
           imageUrl={imageUrl}
           imageUrlTemplate={imageUrlTemplate}

--- a/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
@@ -112,11 +112,8 @@ const LivePage = ({ pageData, assetId }: LivePageProps) => {
   const { currentStreamData, hasPendingUpdate, applyPendingUpdate } =
     useLivePagePolling(pageData, livePagePollingEnabled && isLive);
 
-  const {
-    sportDataEvent: sportData,
-    live: isSportDataLive = false,
-    title: sportDataTitle,
-  } = sportDataEventContent || {};
+  const { sportDataEvent: sportData, live: isSportDataLive = false } =
+    sportDataEventContent || {};
   const showSportData = !!sportData && Boolean(sportHeaderEnabled);
 
   const {

--- a/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
@@ -820,7 +820,7 @@ describe('Live Page', () => {
       });
 
       const visuallyHiddenTitle = screen.getByText(
-        'Villa gain upper hand with gritty Europa League win at Bologna',
+        'Israeli tanks shell Jabalia camp as heavy fighting continues in north Gaza', // mock data, in production this would be a sport title
       );
       expect(visuallyHiddenTitle).toBeInTheDocument();
       expect(visuallyHiddenTitle).toHaveStyle(


### PR DESCRIPTION
Resolves JIRA: WS-NA

Summary
======
Uses Live Page title in the data as visually hidden H1. Does not use Sports Data Header title. (Deviation from PS implementation - but better suited for WS audiences since the page title will be in the right language).

More A11y improvements are documented in this ticket: https://bbc.atlassian.net/browse/WS-2840

Code changes
======
- Gets title from different part of page data
- Updates unit tests
- Also updates A11y metadata because I just realised it's outdated.

Testing
======
1. Go to http://localhost:7081/afrique/live/c7gk1vjglxn1t
2. Use a screen reader or inspect the code. The visually hidden H1 will now match the page title, and not the sports data header title.

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
