### PR TITLE
WS-2846: Adds remaining tournament and Group Stage translations

### DIFF
--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/transformers/translateSportData.test.tsx
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/transformers/translateSportData.test.tsx
@@ -763,7 +763,7 @@ describe('TranslateSportData', () => {
       );
       expect(result.tournament).toStrictEqual({
         id: '70excpe1synn9kadnbppahdn7',
-        name: 'Coupe du Monde de la FIFA',
+        name: 'Coupe du Monde FIFA',
         disambiguatedName: 'FIFA World Cup',
         urn: 'urn:bbc:sportsdata:football:tournament:world-cup',
         thingsGuid: 'de6a07ff-47ff-4551-9b71-7494a71aceac',

--- a/src/app/lib/config/services/afaanoromoo.ts
+++ b/src/app/lib/config/services/afaanoromoo.ts
@@ -365,6 +365,12 @@ export const service: DefaultServiceConfig = {
           usa: 'USA',
           uzbekistan: 'Uzbekistaan',
         },
+        tournaments: {
+          fifaWorldCup: 'Waancaa Addunyaa FIFA',
+        },
+        stages: {
+          groupStage: 'Waltajjii Garee',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -375,7 +375,7 @@ export const service: DefaultServiceConfig = {
           uzbekistan: 'Ouzbékistan',
         },
         tournaments: {
-          fifaWorldCup: 'Coupe du Monde de la FIFA', // temp
+          fifaWorldCup: 'Coupe du Monde FIFA',
         },
         stages: {
           groupStage: 'Phase de poules',

--- a/src/app/lib/config/services/amharic.ts
+++ b/src/app/lib/config/services/amharic.ts
@@ -415,6 +415,12 @@ export const service: DefaultServiceConfig = {
           usa: 'ዩኤስ አሜሪካ',
           uzbekistan: 'ኡዝቤክስታን',
         },
+        tournaments: {
+          fifaWorldCup: 'የፊፋ ዓለም ዋንጫ',
+        },
+        stages: {
+          groupStage: 'የምድብ ጨዋታ',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/arabic.ts
+++ b/src/app/lib/config/services/arabic.ts
@@ -425,6 +425,12 @@ export const service: DefaultServiceConfig = {
           usa: 'الولايات المتحدة الأمريكية',
           uzbekistan: 'أزبكستان',
         },
+        tournaments: {
+          fifaWorldCup: 'كأس العالم لكرة القدم',
+        },
+        stages: {
+          groupStage: 'مرحلة المجموعات',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/azeri.ts
+++ b/src/app/lib/config/services/azeri.ts
@@ -385,6 +385,12 @@ export const service: DefaultServiceConfig = {
           usa: 'ABŞ',
           uzbekistan: 'Özbəkistan',
         },
+        tournaments: {
+          fifaWorldCup: 'FİFA Dünya Kuboku',
+        },
+        stages: {
+          groupStage: 'Qrup mərhələsi',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -365,6 +365,12 @@ export const service: DefaultServiceConfig = {
           usa: 'যুুক্তরাষ্ট্র',
           uzbekistan: '‌উজবেকিস্তান',
         },
+        tournaments: {
+          fifaWorldCup: 'ফিফা বিশ্বকাপ ২০২৬',
+        },
+        stages: {
+          groupStage: 'গ্রুপ পর্ব',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/burmese.ts
+++ b/src/app/lib/config/services/burmese.ts
@@ -378,6 +378,12 @@ export const service: DefaultServiceConfig = {
           usa: 'အမေရိကန်',
           uzbekistan: 'ဥဇဘက်ကစ္စတန်',
         },
+        tournaments: {
+          fifaWorldCup: 'ဖီဖာ ၂၀၂၆ ကမ္ဘာ့ဖလား',
+        },
+        stages: {
+          groupStage: 'အုပ်စုအဆင့်',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/dari.ts
+++ b/src/app/lib/config/services/dari.ts
@@ -425,6 +425,12 @@ export const service: DefaultServiceConfig = {
           usa: 'ایالات متحده',
           uzbekistan: 'ازبکستان',
         },
+        tournaments: {
+          fifaWorldCup: 'جام جهانی ۲۰۲۶',
+        },
+        stages: {
+          groupStage: 'مرحله گروهی',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/gahuza.ts
+++ b/src/app/lib/config/services/gahuza.ts
@@ -367,10 +367,10 @@ export const service: DefaultServiceConfig = {
           uzbekistan: 'Uzbekistan',
         },
         tournaments: {
-          fifaWorldCup: 'Igikombe c\'isi ca FIFA',
+          fifaWorldCup: "Igikombe c'isi ca FIFA",
         },
         stages: {
-          groupStage: 'Urwego rw\'amatsinda',
+          groupStage: "Urwego rw'amatsinda",
         },
       },
     },

--- a/src/app/lib/config/services/gahuza.ts
+++ b/src/app/lib/config/services/gahuza.ts
@@ -366,6 +366,12 @@ export const service: DefaultServiceConfig = {
           usa: 'USA',
           uzbekistan: 'Uzbekistan',
         },
+        tournaments: {
+          fifaWorldCup: 'Igikombe c\'isi ca FIFA',
+        },
+        stages: {
+          groupStage: 'Urwego rw\'amatsinda',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/gujarati.ts
+++ b/src/app/lib/config/services/gujarati.ts
@@ -363,6 +363,12 @@ export const service: DefaultServiceConfig = {
           usa: 'અમેરિકા',
           uzbekistan: 'ઉઝબેકિસ્તાન',
         },
+        tournaments: {
+          fifaWorldCup: 'ફિફા વર્લ્ડ કપ',
+        },
+        stages: {
+          groupStage: 'ગ્રૂપ સ્ટેજ',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/hausa.ts
+++ b/src/app/lib/config/services/hausa.ts
@@ -449,6 +449,12 @@ export const service: DefaultServiceConfig = {
           usa: 'Amurka',
           uzbekistan: 'Uzbekistan',
         },
+        tournaments: {
+          fifaWorldCup: 'Gasar Kofin Duniya',
+        },
+        stages: {
+          groupStage: 'Matakin rukuni',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -471,6 +471,12 @@ export const service: DefaultServiceConfig = {
           usa: 'अमरीका',
           uzbekistan: 'उजबेकिस्तान',
         },
+        tournaments: {
+          fifaWorldCup: 'फीफा वर्ल्ड कप',
+        },
+        stages: {
+          groupStage: 'ग्रुप स्टेज',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/igbo.ts
+++ b/src/app/lib/config/services/igbo.ts
@@ -360,6 +360,12 @@ export const service: DefaultServiceConfig = {
           usa: 'USA',
           uzbekistan: 'Uzbekistan',
         },
+        tournaments: {
+          fifaWorldCup: 'Asọmpi Iko mba ụwa',
+        },
+        stages: {
+          groupStage: 'Agba nke Mbụ',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/indonesia.ts
+++ b/src/app/lib/config/services/indonesia.ts
@@ -368,6 +368,12 @@ export const service: DefaultServiceConfig = {
           usa: 'Amerika Serikat',
           uzbekistan: 'Uzbekistan',
         },
+        tournaments: {
+          fifaWorldCup: 'Piala Dunia FIFA',
+        },
+        stages: {
+          groupStage: 'Babak Grup',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/japanese.ts
+++ b/src/app/lib/config/services/japanese.ts
@@ -323,6 +323,12 @@ export const service: DefaultServiceConfig = {
           usa: 'アメリカ合衆国',
           uzbekistan: 'ウズベキスタン',
         },
+        tournaments: {
+          fifaWorldCup: 'FIFAワールドカップ',
+        },
+        stages: {
+          groupStage: 'グループステージ',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -335,6 +335,12 @@ export const service: DefaultServiceConfig = {
           usa: '미국',
           uzbekistan: '우즈베키스탄',
         },
+        tournaments: {
+          fifaWorldCup: 'FIFA 월드컵',
+        },
+        stages: {
+          groupStage: '조별 리그',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/kyrgyz.ts
+++ b/src/app/lib/config/services/kyrgyz.ts
@@ -361,6 +361,12 @@ export const service: DefaultServiceConfig = {
           usa: 'АКШ',
           uzbekistan: 'Өзбекстан',
         },
+        tournaments: {
+          fifaWorldCup: 'Футбол боюнча дүйнө чемпионаты',
+        },
+        stages: {
+          groupStage: 'Тайпалык беттештер',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/magyarul.ts
+++ b/src/app/lib/config/services/magyarul.ts
@@ -385,6 +385,12 @@ export const service: DefaultServiceConfig = {
           usa: 'Egyesült Államok',
           uzbekistan: 'Üzbegisztán',
         },
+        tournaments: {
+          fifaWorldCup: 'FIFA labdarúgó-világbajnokság',
+        },
+        stages: {
+          groupStage: 'Csoportkör',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -361,6 +361,12 @@ export const service: DefaultServiceConfig = {
           usa: 'अमेेरिका (USA)',
           uzbekistan: 'उझबेकिस्तान',
         },
+        tournaments: {
+          fifaWorldCup: 'फिफा वर्ल्ड कप',
+        },
+        stages: {
+          groupStage: 'साखळी फेरी',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -461,6 +461,12 @@ export const service: DefaultServiceConfig = {
           usa: 'Estados Unidos',
           uzbekistan: 'Uzbekistán',
         },
+        tournaments: {
+          fifaWorldCup: 'Copa Mundial FIFA',
+        },
+        stages: {
+          groupStage: 'Fase de grupos',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/nepali.ts
+++ b/src/app/lib/config/services/nepali.ts
@@ -348,6 +348,12 @@ export const service: DefaultServiceConfig = {
           usa: 'अमेेरिका (यूएसए)',
           uzbekistan: 'उज्बेकिस्तान',
         },
+        tournaments: {
+          fifaWorldCup: 'फिफा विश्वकप २०२६',
+        },
+        stages: {
+          groupStage: 'समूह चरण',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/pashto.ts
+++ b/src/app/lib/config/services/pashto.ts
@@ -360,6 +360,12 @@ export const service: DefaultServiceConfig = {
           usa: 'د امريکا متحد ايالتونه',
           uzbekistan: 'ازبکستان',
         },
+        tournaments: {
+          fifaWorldCup: 'د ۲۰۲۶ نړیوال جام',
+        },
+        stages: {
+          groupStage: 'ګروپي پړاو',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -455,6 +455,12 @@ export const service: DefaultServiceConfig = {
           usa: 'ایالات متحده آمریکا',
           uzbekistan: 'ازبکستان',
         },
+        tournaments: {
+          fifaWorldCup: 'جام جهانی',
+        },
+        stages: {
+          groupStage: 'مرحله گروهی',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/pidgin.ts
+++ b/src/app/lib/config/services/pidgin.ts
@@ -333,6 +333,12 @@ export const service: DefaultServiceConfig = {
           usa: 'United States of America',
           uzbekistan: 'Uzbekistan',
         },
+        tournaments: {
+          fifaWorldCup: 'FIFA World Cup',
+        },
+        stages: {
+          groupStage: 'Group Stage',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/polska.ts
+++ b/src/app/lib/config/services/polska.ts
@@ -395,6 +395,12 @@ export const service: DefaultServiceConfig = {
           usa: 'Stany Zjednoczone',
           uzbekistan: 'Uzbekistan',
         },
+        tournaments: {
+          fifaWorldCup: 'Mistrzostwa świata w piłce nożnej',
+        },
+        stages: {
+          groupStage: 'Faza grupowa',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -441,7 +441,7 @@ export const service: DefaultServiceConfig = {
           uzbekistan: 'Uzbequistão',
         },
         tournaments: {
-          fifaWorldCup: 'Copa do Mundo da FIFA', // temp
+          fifaWorldCup: 'Copa do Mundo da FIFA',
         },
         stages: {
           groupStage: 'Fase de Grupos',

--- a/src/app/lib/config/services/punjabi.ts
+++ b/src/app/lib/config/services/punjabi.ts
@@ -338,6 +338,12 @@ export const service: DefaultServiceConfig = {
           usa: 'ਸੰਯੁਕਤ ਰਾਜ ਅਮਰੀਕਾ',
           uzbekistan: 'ਉਜ਼ਬੇਕਿਸਤਾਨ',
         },
+        tournaments: {
+          fifaWorldCup: 'ਫੀਫਾ ਵਿਸ਼ਵ ਕੱਪ',
+        },
+        stages: {
+          groupStage: 'ਗਰੁੱਪ ਮੁਕਾਬਲੇ',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/romania.ts
+++ b/src/app/lib/config/services/romania.ts
@@ -392,6 +392,12 @@ export const service: DefaultServiceConfig = {
           usa: 'Statele Unite',
           uzbekistan: 'Uzbekistan',
         },
+        tournaments: {
+          fifaWorldCup: 'Cupa Mondială FIFA',
+        },
+        stages: {
+          groupStage: 'Faza grupelor',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -180,6 +180,12 @@ export const service: DefaultServiceConfig = {
           usa: 'США',
           uzbekistan: 'Узбекистан',
         },
+        tournaments: {
+          fifaWorldCup: 'ЧМ по футболу',
+        },
+        stages: {
+          groupStage: 'Групповой этап',
+        },
       },
     },
     lang: `ru`,

--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -422,6 +422,12 @@ export const service: SerbianConfig = {
           usa: 'SAD',
           uzbekistan: 'Uzbekistan',
         },
+        tournaments: {
+          fifaWorldCup: 'Svetsko fudbalsko prvenstvo',
+        },
+        stages: {
+          groupStage: 'Grupna faza',
+        },
       },
       topStoriesTitle: 'Najvažnije',
       featuresAnalysisTitle: 'Reportaže',
@@ -882,6 +888,12 @@ export const service: SerbianConfig = {
           uruguay: 'Уругвај',
           usa: 'САД',
           uzbekistan: 'Узбекистан',
+        },
+        tournaments: {
+          fifaWorldCup: 'Светско првенство у фудбалу',
+        },
+        stages: {
+          groupStage: 'Групна фаза',
         },
       },
       topStoriesTitle: 'Најважније',

--- a/src/app/lib/config/services/sinhala.ts
+++ b/src/app/lib/config/services/sinhala.ts
@@ -365,6 +365,12 @@ export const service: DefaultServiceConfig = {
           usa: 'එක්සත් ජනපදය',
           uzbekistan: 'උස්බෙකිස්තානය',
         },
+        tournaments: {
+          fifaWorldCup: 'FIFA World Cup',
+        },
+        stages: {
+          groupStage: 'කණ්ඩායම් අදියර',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/somali.ts
+++ b/src/app/lib/config/services/somali.ts
@@ -364,6 +364,12 @@ export const service: DefaultServiceConfig = {
           usa: 'Mareykanka',
           uzbekistan: 'Uzbekistan',
         },
+        tournaments: {
+          fifaWorldCup: 'Koobka Adduunka ee FIFA',
+        },
+        stages: {
+          groupStage: 'Heerka kooxaha isku guruubka ah',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/swahili.ts
+++ b/src/app/lib/config/services/swahili.ts
@@ -378,6 +378,12 @@ export const service: DefaultServiceConfig = {
           usa: 'Marekani',
           uzbekistan: 'Uzbekistan',
         },
+        tournaments: {
+          fifaWorldCup: 'Kombe la Dunia la Fifa',
+        },
+        stages: {
+          groupStage: 'Hatua ya Makundi',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/tamil.ts
+++ b/src/app/lib/config/services/tamil.ts
@@ -442,6 +442,12 @@ export const service: DefaultServiceConfig = {
           usa: 'அமெரிக்கா',
           uzbekistan: 'உஸ்பெகிஸ்தான்',
         },
+        tournaments: {
+          fifaWorldCup: 'ஃபிஃபா உலகக் கோப்பை',
+        },
+        stages: {
+          groupStage: 'குரூப் சுற்று',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/telugu.ts
+++ b/src/app/lib/config/services/telugu.ts
@@ -346,6 +346,12 @@ export const service: DefaultServiceConfig = {
           usa: 'అమెరికా సంయుక్త రాష్ట్రాలు',
           uzbekistan: 'ఉజ్బెకిస్తాన్',
         },
+        tournaments: {
+          fifaWorldCup: 'FIFA World Cup',
+        },
+        stages: {
+          groupStage: 'గ్రూప్ స్టేజ్',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/thai.ts
+++ b/src/app/lib/config/services/thai.ts
@@ -326,6 +326,12 @@ export const service: DefaultServiceConfig = {
           usa: 'สหรัฐอเมริกา',
           uzbekistan: 'อุซเบกิสถาน',
         },
+        tournaments: {
+          fifaWorldCup: 'ฟุตบอลโลก',
+        },
+        stages: {
+          groupStage: 'รอบแบ่งกลุ่ม',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/tigrinya.ts
+++ b/src/app/lib/config/services/tigrinya.ts
@@ -345,6 +345,12 @@ export const service: DefaultServiceConfig = {
           usa: 'ሕቡራት መንግስታት ኣሜሪካ',
           uzbekistan: 'ኡዝቤኪስታን',
         },
+        tournaments: {
+          fifaWorldCup: 'ዋንጫ ዓለም',
+        },
+        stages: {
+          groupStage: 'ናይ ምድብ ጸወታ',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -346,6 +346,12 @@ export const service: DefaultServiceConfig = {
           usa: 'ABD',
           uzbekistan: 'Özbekistan',
         },
+        tournaments: {
+          fifaWorldCup: 'FIFA Dünya Kupası',
+        },
+        stages: {
+          groupStage: 'Grup Aşaması',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/ukrainian.ts
+++ b/src/app/lib/config/services/ukrainian.ts
@@ -352,6 +352,12 @@ const baseServiceConfig = {
         usa: 'США',
         uzbekistan: 'Узбекистан',
       },
+      tournaments: {
+        fifaWorldCup: 'Чемпіонат світу з футболу',
+      },
+      stages: {
+        groupStage: 'Груповий етап',
+      },
     },
     ...secondaryColumnTranslations,
   },
@@ -487,6 +493,12 @@ export const service: UkrainianConfig = {
           uruguay: 'Уругвай',
           usa: 'США',
           uzbekistan: 'Узбекистан',
+        },
+        tournaments: {
+          fifaWorldCup: 'ЧМ по футболу',
+        },
+        stages: {
+          groupStage: 'Групповой этап',
         },
       },
     },

--- a/src/app/lib/config/services/urdu.ts
+++ b/src/app/lib/config/services/urdu.ts
@@ -436,6 +436,12 @@ export const service: DefaultServiceConfig = {
           usa: 'امریکہ',
           uzbekistan: 'ازبکستان',
         },
+        tournaments: {
+          fifaWorldCup: 'فیفا ورلڈ کپ',
+        },
+        stages: {
+          groupStage: 'گروپ مرحلہ',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -349,6 +349,12 @@ const defaultCyrillicConfig = {
         usa: 'АҚШ',
         uzbekistan: 'Ўзбекистон',
       },
+      tournaments: {
+        fifaWorldCup: 'Жаҳон чемпионати',
+      },
+      stages: {
+        groupStage: 'Гуруҳ босқичи',
+      },
     },
     topStoriesTitle: 'Бош мақола',
     featuresAnalysisTitle: 'Муҳаррир танлови',
@@ -739,6 +745,12 @@ export const service: UzbekConfig = {
           uruguay: 'Urugvay',
           usa: 'AQSH',
           uzbekistan: 'Oʻzbekiston',
+        },
+        tournaments: {
+          fifaWorldCup: 'FIFA World Cup',
+        },
+        stages: {
+          groupStage: 'Guruh bosqichi',
         },
       },
       topStoriesTitle: 'Bosh maqola',

--- a/src/app/lib/config/services/vietnamese.ts
+++ b/src/app/lib/config/services/vietnamese.ts
@@ -335,6 +335,12 @@ export const service: DefaultServiceConfig = {
           usa: 'Hoa Kỳ',
           uzbekistan: 'Uzbekistan',
         },
+        tournaments: {
+          fifaWorldCup: 'FIFA World Cup',
+        },
+        stages: {
+          groupStage: 'Vòng bảng',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/yoruba.ts
+++ b/src/app/lib/config/services/yoruba.ts
@@ -340,6 +340,12 @@ export const service: DefaultServiceConfig = {
           usa: 'Orilẹede Amẹrika',
           uzbekistan: 'Orilẹede Uzbekistan',
         },
+        tournaments: {
+          fifaWorldCup: 'Ìdíjé Ife Agbaye Ọdun',
+        },
+        stages: {
+          groupStage: 'Ìpele pipin si ìsọ̀rí',
+        },
       },
     },
     mostRead: {

--- a/src/app/lib/config/services/zhongwen.ts
+++ b/src/app/lib/config/services/zhongwen.ts
@@ -411,6 +411,12 @@ export const service: ZhongwenConfig = {
           usa: '美国',
           uzbekistan: '乌兹别克斯坦',
         },
+        tournaments: {
+          fifaWorldCup: 'FIFA 世界杯',
+        },
+        stages: {
+          groupStage: '小组赛',
+        },
       },
     },
   },
@@ -770,6 +776,12 @@ export const service: ZhongwenConfig = {
           uruguay: '烏拉圭',
           usa: '美國',
           uzbekistan: '烏茲別克斯坦',
+        },
+        tournaments: {
+          fifaWorldCup: 'FIFA 世界盃',
+        },
+        stages: {
+          groupStage: '小組賽',
         },
       },
     },


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2846

Summary
======
Adds remaining tournament and Group Stage translations

Code changes
======
- Adds remaining tournament and Group Stage translations

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
