### PR TITLE
WS-2635 [SPIKE] Understand technical approach for switching onward journey layouts by referrer on article pages

### DIFF
--- a/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.tsx
+++ b/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.tsx
@@ -4,7 +4,7 @@ import {
   OptimizelyProvider,
   setLogger,
 } from '@optimizely/react-sdk';
-import { NOTIFICATION_TYPES, ListenerPayload } from '@optimizely/optimizely-sdk';
+import { enums, ListenerPayload } from '@optimizely/optimizely-sdk';
 import Cookie from 'js-cookie';
 import isLive from '#lib/utilities/isLive';
 import onClient from '#lib/utilities/onClient';
@@ -37,7 +37,7 @@ const optimizely = createInstance({
 });
 
 optimizely?.notificationCenter?.addNotificationListener(
-  NOTIFICATION_TYPES.DECISION,
+  enums.NOTIFICATION_TYPES.DECISION,
   (
     notification: ListenerPayload & {
       decisionInfo?: {

--- a/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.tsx
+++ b/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.tsx
@@ -4,7 +4,7 @@ import {
   OptimizelyProvider,
   setLogger,
 } from '@optimizely/react-sdk';
-import { enums, ListenerPayload } from '@optimizely/optimizely-sdk';
+import { NOTIFICATION_TYPES, ListenerPayload } from '@optimizely/optimizely-sdk';
 import Cookie from 'js-cookie';
 import isLive from '#lib/utilities/isLive';
 import onClient from '#lib/utilities/onClient';
@@ -37,7 +37,7 @@ const optimizely = createInstance({
 });
 
 optimizely?.notificationCenter?.addNotificationListener(
-  enums.NOTIFICATION_TYPES.DECISION,
+  NOTIFICATION_TYPES.DECISION,
   (
     notification: ListenerPayload & {
       decisionInfo?: {

--- a/src/app/pages/ArticlePage/ArticlePage.styles.ts
+++ b/src/app/pages/ArticlePage/ArticlePage.styles.ts
@@ -215,4 +215,10 @@ export default {
         padding: 0,
       },
     }),
+  mobileOJContainer: ({ mq }: Theme) =>
+    css({
+      [mq.GROUP_4_MIN_WIDTH]: {
+        display: 'none',
+      },
+    }),
 };

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -662,7 +662,10 @@ const ArticlePage = ({
       </div>
 
       {mobileOJOrder && (
-        <div css={styles.mobileOJContainer}>
+        <div
+          css={styles.mobileOJContainer}
+          style={{ display: mobileOJOrder ? 'block' : 'none' }}
+        >
           {mobileOJOrder.map(key => (
             <Fragment key={key}>{mobileOJComponents[key]}</Fragment>
           ))}

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -1,4 +1,4 @@
-import { use, useState } from 'react';
+import { Fragment, ReactNode, use, useState } from 'react';
 import { useTheme } from '@emotion/react';
 import useToggle from '#hooks/useToggle';
 import useOptimizelyVariation, {
@@ -82,7 +82,11 @@ import { ServiceContext } from '../../contexts/ServiceContext';
 import RelatedContentSection from '../../components/RelatedContentSection';
 import TopicDiscovery from '../../components/TopicDiscovery';
 import Disclaimer from '../../components/Disclaimer';
+import FeaturesAnalysis from '#containers/CpsFeaturesAnalysis';
 import SecondaryColumn from './SecondaryColumn';
+import TopStoriesSection from './PagePromoSections/TopStoriesSection';
+import useMobileReferrerOrder from './useMobileReferrerOrder';
+import { OJComponentKey } from './mobileReferrerComponentOrder';
 import styles from './ArticlePage.styles';
 import { ComponentToRenderProps, TimeStampProps } from './types';
 import ArticleHeadline from './ArticleHeadline';
@@ -447,6 +451,90 @@ const ArticlePage = ({
   const shouldRenderPWAPromotionalBanner =
     !isTopBarOJsEnabled || !pageData?.secondaryColumn?.topStories?.length;
 
+  const mobileOJOrder = useMobileReferrerOrder();
+
+  const topStoriesContent = pageData?.secondaryColumn?.topStories;
+  const featuresContent = pageData?.secondaryColumn?.features;
+
+  const topicDiscoverySlot = showTopicDiscovery ? (
+    <TopicDiscovery
+      css={[
+        ...(showContinueReadingButton
+          ? [!showAllContent && styles.hideTopicDiscovery]
+          : []),
+      ]}
+      topics={topics}
+      experimentProps={topicDiscoveryExperimentProps || undefined}
+    />
+  ) : showRelatedTopicsComponent ? (
+    <RelatedTopics
+      css={[
+        styles.relatedTopics,
+        ...(showContinueReadingButton
+          ? [!showAllContent && styles.hideRelatedTopics]
+          : []),
+      ]}
+      topics={topics}
+      mobileDivider={false}
+      experimentProps={topicDiscoveryExperimentProps || undefined}
+    />
+  ) : null;
+
+  const mobileOJComponents: Record<OJComponentKey, ReactNode> = {
+    mostRead:
+      !isApp && !isPGL ? (
+        <MostRead
+          css={styles.mostReadSection}
+          data={mostReadInitialData}
+          columnLayout="twoColumn"
+          size="default"
+          headingBackgroundColour={GREY_2}
+          mobileDivider={showRelatedTopicsComponent}
+          experimentProps={topicDiscoveryExperimentProps || undefined}
+        />
+      ) : null,
+    topicDiscovery: topicDiscoverySlot,
+    relatedContent: (
+      <RelatedContentSection
+        content={blocks}
+        experimentProps={topicDiscoveryExperimentProps || undefined}
+      />
+    ),
+    pvCarousel: showPortraitVideoCarousel ? (
+      <PortraitVideoCarousel
+        {...portraitVideoCarouselProps}
+        css={styles.portraitVideoCarousel}
+      />
+    ) : null,
+    topStories:
+      !isApp && !isPGL && topStoriesContent ? (
+        <div
+          css={styles.topStoriesSection}
+          data-testid="top-stories"
+          data-experiment-position="secondaryColumn"
+        >
+          <TopStoriesSection
+            content={topStoriesContent}
+            experimentProps={topicDiscoveryExperimentProps || undefined}
+          />
+        </div>
+      ) : null,
+    featuredArticles:
+      !isApp && !isPGL && featuresContent ? (
+        <div css={styles.featuresSection} data-testid="features">
+          <FeaturesAnalysis
+            content={featuresContent}
+            parentColumns={{}}
+            sectionLabelBackground={GREY_2}
+            experimentProps={topicDiscoveryExperimentProps || undefined}
+          />
+        </div>
+      ) : null,
+    locationBasedOJ: showCountryCuration ? (
+      <LocationBasedTopicOJ pageData={pageData} />
+    ) : null,
+  };
+
   return (
     <div css={styles.pageWrapper}>
       {/* EXPERIMENT: PWA Promotional Banner */}
@@ -506,7 +594,7 @@ const ArticlePage = ({
           </main>
           <OptimizelyPageMetrics trackPageView trackPageDepth trackVisit />
           {/* EXPERIMENT: Topic Discovery */}
-          {showTopicDiscovery && (
+          {!mobileOJOrder && showTopicDiscovery && (
             <TopicDiscovery
               css={[
                 ...(showContinueReadingButton
@@ -517,7 +605,7 @@ const ArticlePage = ({
               experimentProps={topicDiscoveryExperimentProps || undefined}
             />
           )}
-          {showRelatedTopicsComponent && (
+          {!mobileOJOrder && showRelatedTopicsComponent && (
             <RelatedTopics
               css={[
                 styles.relatedTopics,
@@ -530,17 +618,21 @@ const ArticlePage = ({
               experimentProps={topicDiscoveryExperimentProps || undefined}
             />
           )}
-          {showPortraitVideoCarousel && (
+          {!mobileOJOrder && showPortraitVideoCarousel && (
             <PortraitVideoCarousel
               {...portraitVideoCarouselProps}
               css={styles.portraitVideoCarousel}
             />
           )}
-          {showCountryCuration && <LocationBasedTopicOJ pageData={pageData} />}
-          <RelatedContentSection
-            content={blocks}
-            experimentProps={topicDiscoveryExperimentProps || undefined}
-          />
+          {!mobileOJOrder && showCountryCuration && (
+            <LocationBasedTopicOJ pageData={pageData} />
+          )}
+          {!mobileOJOrder && (
+            <RelatedContentSection
+              content={blocks}
+              experimentProps={topicDiscoveryExperimentProps || undefined}
+            />
+          )}
           {showMediaCuration && (
             <div css={styles.mediaCurationRow}>
               <div data-testid="media-curation">
@@ -561,7 +653,7 @@ const ArticlePage = ({
           )}
         </div>
 
-        {!isApp && !isPGL && (
+        {!isApp && !isPGL && !mobileOJOrder && (
           <SecondaryColumn
             pageData={pageData}
             experimentProps={topicDiscoveryExperimentProps || undefined}
@@ -569,7 +661,15 @@ const ArticlePage = ({
         )}
       </div>
 
-      {!isApp && !isPGL && (
+      {mobileOJOrder && (
+        <div css={styles.mobileOJContainer}>
+          {mobileOJOrder.map(key => (
+            <Fragment key={key}>{mobileOJComponents[key]}</Fragment>
+          ))}
+        </div>
+      )}
+
+      {!isApp && !isPGL && !mobileOJOrder && (
         <MostRead
           css={styles.mostReadSection}
           data={mostReadInitialData}

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -60,6 +60,7 @@ import ContinueReadingButton, {
 } from '#app/components/ContinueReadingButton';
 import SaveArticleButton from '#app/components/SaveArticleButton';
 import isLive from '#lib/utilities/isLive';
+import FeaturesAnalysis from '#containers/CpsFeaturesAnalysis';
 import ElectionBanner from './ElectionBanner';
 import ImageWithCaption from '../../components/ImageWithCaption';
 import AdContainer from '../../components/Ad';
@@ -82,7 +83,6 @@ import { ServiceContext } from '../../contexts/ServiceContext';
 import RelatedContentSection from '../../components/RelatedContentSection';
 import TopicDiscovery from '../../components/TopicDiscovery';
 import Disclaimer from '../../components/Disclaimer';
-import FeaturesAnalysis from '#containers/CpsFeaturesAnalysis';
 import SecondaryColumn from './SecondaryColumn';
 import TopStoriesSection from './PagePromoSections/TopStoriesSection';
 import useMobileReferrerOrder from './useMobileReferrerOrder';
@@ -456,29 +456,39 @@ const ArticlePage = ({
   const topStoriesContent = pageData?.secondaryColumn?.topStories;
   const featuresContent = pageData?.secondaryColumn?.features;
 
-  const topicDiscoverySlot = showTopicDiscovery ? (
-    <TopicDiscovery
-      css={[
-        ...(showContinueReadingButton
-          ? [!showAllContent && styles.hideTopicDiscovery]
-          : []),
-      ]}
-      topics={topics}
-      experimentProps={topicDiscoveryExperimentProps || undefined}
-    />
-  ) : showRelatedTopicsComponent ? (
-    <RelatedTopics
-      css={[
-        styles.relatedTopics,
-        ...(showContinueReadingButton
-          ? [!showAllContent && styles.hideRelatedTopics]
-          : []),
-      ]}
-      topics={topics}
-      mobileDivider={false}
-      experimentProps={topicDiscoveryExperimentProps || undefined}
-    />
-  ) : null;
+  const getTopicDiscoverySlot = () => {
+    if (showTopicDiscovery) {
+      return (
+        <TopicDiscovery
+          css={[
+            ...(showContinueReadingButton
+              ? [!showAllContent && styles.hideTopicDiscovery]
+              : []),
+          ]}
+          topics={topics}
+          experimentProps={topicDiscoveryExperimentProps || undefined}
+        />
+      );
+    }
+    if (showRelatedTopicsComponent) {
+      return (
+        <RelatedTopics
+          css={[
+            styles.relatedTopics,
+            ...(showContinueReadingButton
+              ? [!showAllContent && styles.hideRelatedTopics]
+              : []),
+          ]}
+          topics={topics}
+          mobileDivider={false}
+          experimentProps={topicDiscoveryExperimentProps || undefined}
+        />
+      );
+    }
+    return null;
+  };
+
+  const topicDiscoverySlot = getTopicDiscoverySlot();
 
   const mobileOJComponents: Record<OJComponentKey, ReactNode> = {
     mostRead:

--- a/src/app/pages/ArticlePage/mobileReferrerComponentOrder.ts
+++ b/src/app/pages/ArticlePage/mobileReferrerComponentOrder.ts
@@ -1,0 +1,40 @@
+export type OJComponentKey =
+  | 'mostRead'
+  | 'topicDiscovery'
+  | 'relatedContent'
+  | 'pvCarousel'
+  | 'topStories'
+  | 'featuredArticles'
+  | 'locationBasedOJ';
+
+export type ReferrerType = 'direct' | 'search' | 'social';
+
+export const MOBILE_COMPONENT_ORDER: Record<ReferrerType, OJComponentKey[]> = {
+  direct: [
+    'mostRead',
+    'topicDiscovery',
+    'relatedContent',
+    'pvCarousel',
+    'featuredArticles',
+    'topStories',
+    'locationBasedOJ',
+  ],
+  search: [
+    'relatedContent',
+    'topicDiscovery',
+    'mostRead',
+    'pvCarousel',
+    'topStories',
+    'featuredArticles',
+    'locationBasedOJ',
+  ],
+  social: [
+    'mostRead',
+    'topicDiscovery',
+    'topStories',
+    'featuredArticles',
+    'relatedContent',
+    'locationBasedOJ',
+    'pvCarousel',
+  ],
+};

--- a/src/app/pages/ArticlePage/useMobileReferrerOrder.test.ts
+++ b/src/app/pages/ArticlePage/useMobileReferrerOrder.test.ts
@@ -1,0 +1,258 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import useMobileReferrerOrder from './useMobileReferrerOrder';
+import { getReferrer } from '#app/legacy/containers/PageHandlers/withOptimizelyProvider/userAttributes';
+import onClient from '#app/lib/utilities/onClient';
+
+jest.mock(
+  '#app/legacy/containers/PageHandlers/withOptimizelyProvider/userAttributes',
+);
+jest.mock('#app/lib/utilities/onClient');
+
+const mockGetReferrer = getReferrer as jest.MockedFunction<typeof getReferrer>;
+const mockOnClient = onClient as jest.MockedFunction<typeof onClient>;
+
+describe('useMobileReferrerOrder', () => {
+  let matchMediaMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockOnClient.mockReturnValue(true);
+    mockGetReferrer.mockReturnValue('direct');
+
+    // Mock window.matchMedia
+    matchMediaMock = jest.fn().mockReturnValue({
+      matches: false,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    });
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: matchMediaMock,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('Desktop behavior', () => {
+    it('should return null when on desktop', () => {
+      matchMediaMock.mockReturnValue({
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      });
+
+      const { result } = renderHook(() => useMobileReferrerOrder());
+
+      expect(result.current).toBeNull();
+    });
+
+    it('should return null regardless of referrer when on desktop', () => {
+      matchMediaMock.mockReturnValue({
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      });
+
+      const { result: directResult } = renderHook(() =>
+        useMobileReferrerOrder(),
+      );
+      expect(directResult.current).toBeNull();
+
+      mockGetReferrer.mockReturnValue('search');
+      const { result: searchResult } = renderHook(() =>
+        useMobileReferrerOrder(),
+      );
+      expect(searchResult.current).toBeNull();
+    });
+  });
+
+  describe('Mobile behavior with different referrers', () => {
+    beforeEach(() => {
+      matchMediaMock.mockReturnValue({
+        matches: true,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      });
+    });
+
+    it('should return direct order when referrer is direct', () => {
+      mockGetReferrer.mockReturnValue('direct');
+
+      const { result } = renderHook(() => useMobileReferrerOrder());
+
+      expect(result.current).toEqual([
+        'mostRead',
+        'topicDiscovery',
+        'relatedContent',
+        'pvCarousel',
+        'featuredArticles',
+        'topStories',
+        'locationBasedOJ',
+      ]);
+    });
+
+    it('should return search order when referrer is search', () => {
+      mockGetReferrer.mockReturnValue('search');
+
+      const { result } = renderHook(() => useMobileReferrerOrder());
+
+      expect(result.current).toEqual([
+        'relatedContent',
+        'topicDiscovery',
+        'mostRead',
+        'pvCarousel',
+        'topStories',
+        'featuredArticles',
+        'locationBasedOJ',
+      ]);
+    });
+
+    it('should return social order when referrer is social', () => {
+      mockGetReferrer.mockReturnValue('social');
+
+      const { result } = renderHook(() => useMobileReferrerOrder());
+
+      expect(result.current).toEqual([
+        'mostRead',
+        'topicDiscovery',
+        'topStories',
+        'featuredArticles',
+        'relatedContent',
+        'locationBasedOJ',
+        'pvCarousel',
+      ]);
+    });
+
+    it('should default to direct order when referrer is null', () => {
+      mockGetReferrer.mockReturnValue(null);
+
+      const { result } = renderHook(() => useMobileReferrerOrder());
+
+      expect(result.current).toEqual([
+        'mostRead',
+        'topicDiscovery',
+        'relatedContent',
+        'pvCarousel',
+        'featuredArticles',
+        'topStories',
+        'locationBasedOJ',
+      ]);
+    });
+  });
+
+  describe('Media query listener', () => {
+    it('should add a change listener to media query on client', () => {
+      const addEventListenerMock = jest.fn();
+      matchMediaMock.mockReturnValue({
+        matches: false,
+        addEventListener: addEventListenerMock,
+        removeEventListener: jest.fn(),
+      });
+
+      renderHook(() => useMobileReferrerOrder());
+
+      expect(addEventListenerMock).toHaveBeenCalledWith(
+        'change',
+        expect.any(Function),
+      );
+    });
+
+    it('should remove listener on unmount', () => {
+      const removeEventListenerMock = jest.fn();
+      matchMediaMock.mockReturnValue({
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: removeEventListenerMock,
+      });
+
+      const { unmount } = renderHook(() => useMobileReferrerOrder());
+
+      unmount();
+
+      expect(removeEventListenerMock).toHaveBeenCalledWith(
+        'change',
+        expect.any(Function),
+      );
+    });
+
+    it('should update order when viewport changes from desktop to mobile', async () => {
+      let listenerCallback: ((e: MediaQueryListEvent) => void) | null = null;
+      matchMediaMock.mockImplementation(() => ({
+        matches: false,
+        addEventListener: jest.fn((event, callback) => {
+          if (event === 'change') {
+            listenerCallback = callback;
+          }
+        }),
+        removeEventListener: jest.fn(),
+      }));
+
+      mockGetReferrer.mockReturnValue('direct');
+
+      const { result } = renderHook(() => useMobileReferrerOrder());
+
+      expect(result.current).toBeNull();
+
+      if (listenerCallback) {
+        await act(async () => {
+          listenerCallback?.({
+            matches: true,
+          } as MediaQueryListEvent);
+        });
+      }
+
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
+
+      expect(result.current?.[0]).toBe('mostRead');
+    });
+
+    it('should update order when viewport changes from mobile to desktop', async () => {
+      let listenerCallback: ((e: MediaQueryListEvent) => void) | null = null;
+      matchMediaMock.mockImplementation(() => ({
+        matches: true,
+        addEventListener: jest.fn((event, callback) => {
+          if (event === 'change') {
+            listenerCallback = callback;
+          }
+        }),
+        removeEventListener: jest.fn(),
+      }));
+
+      mockGetReferrer.mockReturnValue('direct');
+
+      const { result } = renderHook(() => useMobileReferrerOrder());
+
+      expect(result.current).not.toBeNull();
+
+      if (listenerCallback) {
+        await act(async () => {
+          listenerCallback?.({
+            matches: false,
+          } as MediaQueryListEvent);
+        });
+      }
+
+      await waitFor(() => {
+        expect(result.current).toBeNull();
+      });
+    });
+  });
+
+  describe('Correct media query breakpoint', () => {
+    it('should use GROUP_3_MAX_WIDTH_BP for the breakpoint', () => {
+      mockOnClient.mockReturnValue(true);
+
+      renderHook(() => useMobileReferrerOrder());
+
+      const callArgs = matchMediaMock.mock.calls[0][0];
+      // GROUP_3_MAX_WIDTH_BP = pixelsToRem(1007) = 62.9375rem
+      expect(callArgs).toContain('62.9375rem');
+      expect(callArgs).toContain('max-width');
+    });
+  });
+});

--- a/src/app/pages/ArticlePage/useMobileReferrerOrder.test.ts
+++ b/src/app/pages/ArticlePage/useMobileReferrerOrder.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, waitFor, act } from '@testing-library/react';
-import useMobileReferrerOrder from './useMobileReferrerOrder';
 import { getReferrer } from '#app/legacy/containers/PageHandlers/withOptimizelyProvider/userAttributes';
 import onClient from '#app/lib/utilities/onClient';
+import useMobileReferrerOrder from './useMobileReferrerOrder';
 
 jest.mock(
   '#app/legacy/containers/PageHandlers/withOptimizelyProvider/userAttributes',

--- a/src/app/pages/ArticlePage/useMobileReferrerOrder.ts
+++ b/src/app/pages/ArticlePage/useMobileReferrerOrder.ts
@@ -8,6 +8,19 @@ import {
   ReferrerType,
 } from './mobileReferrerComponentOrder';
 
+const getDebugReferrer = (): ReferrerType | null => {
+  const params = new URLSearchParams(window.location.search);
+  const debugParam = params.get('debugReferrer');
+  if (
+    debugParam === 'direct'
+    || debugParam === 'search'
+    || debugParam === 'social'
+  ) {
+    return debugParam;
+  }
+  return null;
+};
+
 const useMobileReferrerOrder = (): OJComponentKey[] | null => {
   const [order, setOrder] = useState<OJComponentKey[] | null>(null);
 
@@ -17,7 +30,8 @@ const useMobileReferrerOrder = (): OJComponentKey[] | null => {
     const mediaQuery = window.matchMedia(
       `(max-width: ${GROUP_3_MAX_WIDTH_BP}rem)`,
     );
-    const referrer = (getReferrer() ?? 'direct') as ReferrerType;
+    const debugReferrer = getDebugReferrer();
+    const referrer = (debugReferrer ?? getReferrer() ?? 'direct') as ReferrerType;
     const mobileOrder =
       MOBILE_COMPONENT_ORDER[referrer] ?? MOBILE_COMPONENT_ORDER.direct;
 

--- a/src/app/pages/ArticlePage/useMobileReferrerOrder.ts
+++ b/src/app/pages/ArticlePage/useMobileReferrerOrder.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react';
+import { GROUP_3_MAX_WIDTH_BP } from '#app/components/ThemeProvider/mediaQueries';
+import onClient from '#app/lib/utilities/onClient';
+import { getReferrer } from '#app/legacy/containers/PageHandlers/withOptimizelyProvider/userAttributes';
+import {
+  MOBILE_COMPONENT_ORDER,
+  OJComponentKey,
+  ReferrerType,
+} from './mobileReferrerComponentOrder';
+
+const useMobileReferrerOrder = (): OJComponentKey[] | null => {
+  const [order, setOrder] = useState<OJComponentKey[] | null>(null);
+
+  useEffect(() => {
+    if (!onClient()) return undefined;
+
+    const mediaQuery = window.matchMedia(
+      `(max-width: ${GROUP_3_MAX_WIDTH_BP}rem)`,
+    );
+    const referrer = (getReferrer() ?? 'direct') as ReferrerType;
+    const mobileOrder =
+      MOBILE_COMPONENT_ORDER[referrer] ?? MOBILE_COMPONENT_ORDER.direct;
+
+    const updateOrder = () => {
+      setOrder(mediaQuery.matches ? mobileOrder : null);
+    };
+
+    updateOrder();
+    mediaQuery.addEventListener('change', updateOrder);
+
+    return () => mediaQuery.removeEventListener('change', updateOrder);
+  }, []);
+
+  return order;
+};
+
+export default useMobileReferrerOrder;

--- a/src/app/pages/ArticlePage/useMobileReferrerOrder.ts
+++ b/src/app/pages/ArticlePage/useMobileReferrerOrder.ts
@@ -21,14 +21,21 @@ const useMobileReferrerOrder = (): OJComponentKey[] | null => {
     const mobileOrder =
       MOBILE_COMPONENT_ORDER[referrer] ?? MOBILE_COMPONENT_ORDER.direct;
 
-    const updateOrder = () => {
-      setOrder(mediaQuery.matches ? mobileOrder : null);
+    const updateOrder = (matches: boolean) => {
+      setOrder(matches ? mobileOrder : null);
     };
 
-    updateOrder();
-    mediaQuery.addEventListener('change', updateOrder);
+    // Initial check
+    updateOrder(mediaQuery.matches);
 
-    return () => mediaQuery.removeEventListener('change', updateOrder);
+    // Listen for changes and use the event's matches value
+    const handleChange = (event: MediaQueryListEvent) => {
+      updateOrder(event.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => mediaQuery.removeEventListener('change', handleChange);
   }, []);
 
   return order;

--- a/src/app/pages/ArticlePage/useMobileReferrerOrder.ts
+++ b/src/app/pages/ArticlePage/useMobileReferrerOrder.ts
@@ -12,9 +12,9 @@ const getDebugReferrer = (): ReferrerType | null => {
   const params = new URLSearchParams(window.location.search);
   const debugParam = params.get('debugReferrer');
   if (
-    debugParam === 'direct'
-    || debugParam === 'search'
-    || debugParam === 'social'
+    debugParam === 'direct' ||
+    debugParam === 'search' ||
+    debugParam === 'social'
   ) {
     return debugParam;
   }
@@ -31,7 +31,9 @@ const useMobileReferrerOrder = (): OJComponentKey[] | null => {
       `(max-width: ${GROUP_3_MAX_WIDTH_BP}rem)`,
     );
     const debugReferrer = getDebugReferrer();
-    const referrer = (debugReferrer ?? getReferrer() ?? 'direct') as ReferrerType;
+    const referrer = (debugReferrer ??
+      getReferrer() ??
+      'direct') as ReferrerType;
     const mobileOrder =
       MOBILE_COMPONENT_ORDER[referrer] ?? MOBILE_COMPONENT_ORDER.direct;
 


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2635


Implements reordering of OJ components based on user referrer type, only on mobile (as this will be difficult on desktop with the secondary column). Desktop layout stays how it was before. There is a centralised config which is used to store the order we want for each referrer. This can easily be changed when we want so is good for flexibility.

**Config-Driven Architecture:**
- Centralized component ordering per referrer type in mobileReferrerComponentOrder.ts
- React hook ([useMobileReferrerOrder](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) that detects mobile via media query and reads referrer
- ArticlePage integration with conditional rendering and responsive styling

**mobileReferrerComponentOrder.ts — Centralised config**

Defines three referrer types: ['direct'](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), ['search'](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), ['social'](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Maps each to a component order (7 reorderable components)

**[useMobileReferrerOrder.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — React hook**

SSR-safe (checks [onClient()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) before accessing [window](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Detects mobile via [window.matchMedia((max-width: 62.9375rem))](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Reads referrer with fallback to ['direct'](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
**Supports debug mode via [?debugReferrer=search](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) URL param for manual testing**
Returns [OJComponentKey[]](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) on mobile, null on desktop

**[ArticlePage.tsx]**

Imports hook and component order type
Calls [useMobileReferrerOrder()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to get mobile order (or null on desktop)
Creates component map: [mobileOJComponents](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with all 7 reorderable OJ components
Desktop rendering: [{!mobileOJOrder && ...}](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) gates show original components in original positions
Mobile rendering: [{mobileOJOrder && ...}](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) renders reordered components in referrer-specific order
Uses Fragment in map loop to avoid wrapper divs (mobile performance)

[ArticlePage.styles.ts]

Adds [mobileOJContainer](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) style with [display: 'none'](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) on desktop (GROUP_4_MIN_WIDTH)


**Direct** | mostRead → topicDiscovery → relatedContent → pvCarousel → featuredArticles → topStories → locationBasedOJ

**Search** | relatedContent → topicDiscovery → mostRead → pvCarousel → topStories → featuredArticles → locationBasedOJ

**Social** | mostRead → topicDiscovery → topStories → featuredArticles → relatedContent → locationBasedOJ → pvCarousel


This order can be changed. It was based off the document https://www.dropbox.com/scl/fi/w9oy1xb27cmlv437910ki/Experiment-Brief-v2-reorder-OJs-based-on-referrer.paper?rlkey=rf0brkjaa846lwal7d79stetr&dl=0 with a few assumptions, but the specifics don't matter for the spike.

**No-CSS Fallback:**
Inline style [display: mobileOJOrder ? 'block' : 'none'](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) ensures correct visibility even if CSS fails to load, while Emotion CSS handles media query logic in normal operation.

**No-JavaScript Fallback:**
Hook's [onClient()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) check prevents errors on server. Returns null, triggering desktop layout rendering.


Manual Testing
Use the debug URL parameter to test different referrer orders without visiting from actual search/social:

e.g http://localhost:7081/mundo/articles/c0myz4m74lwo?renderer_env=live&debugReferrer=social

Omit the param or visit normally to use actual referrer.

Summary
======
_A very high-level summary of easily-reproducible changes that can be understood by non-devs, and why these changes where made._

Code changes
======
- _List key code changes that have been made._

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
