### PR TITLE
WS-NA: Update match header styling to use teal divider and period label mid-event

### DIFF
--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/components/period.tsx
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/components/period.tsx
@@ -36,7 +36,10 @@ const Period = ({
 
   const periodValue = period?.translation || period?.value;
   return (
-    <div css={styles.period({ isLive: isLiveStatus(status) })} aria-hidden="true">
+    <div
+      css={styles.period({ isLive: isLiveStatus(status) })}
+      aria-hidden="true"
+    >
       <div>{periodValue}</div>
     </div>
   );

--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/components/period.tsx
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/components/period.tsx
@@ -1,5 +1,6 @@
 import { use } from 'react';
 import { ServiceContext } from '#app/contexts/ServiceContext';
+import { isLiveStatus } from '../helpers/event-status-groups';
 import { getFallbackFootballPeriodLabel } from '../helpers/event-summary';
 import styles from '../index.styles';
 import type { EventStatusType, RunningScores } from '../types';
@@ -35,7 +36,7 @@ const Period = ({
 
   const periodValue = period?.translation || period?.value;
   return (
-    <div css={styles.period} aria-hidden="true">
+    <div css={styles.period({ isLive: isLiveStatus(status) })} aria-hidden="true">
       <div>{periodValue}</div>
     </div>
   );

--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/components/score.tsx
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/components/score.tsx
@@ -1,3 +1,4 @@
+import { isLiveStatus } from '../helpers/event-status-groups';
 import styles from '../index.styles';
 import type { EventStatusType } from '../types';
 
@@ -28,7 +29,7 @@ const Score = ({
   return (
     <div css={styles.score} data-testid="score" aria-hidden="true">
       <div css={styles.homeScore}>{matchStatusLetter || homeScore}</div>
-      <div css={styles.verticalLine} />
+      <div css={styles.verticalLine({ isLive: isLiveStatus(status) })} />
       <div css={styles.awayScore}>{matchStatusLetter || awayScore}</div>
     </div>
   );

--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
@@ -12,6 +12,8 @@ const HOME_SCORE = 'home_score';
 const VERTICAL_LINE = 'vertical_line';
 const AWAY_SCORE = 'away_score';
 
+const LIVE_ACCENT_COLOUR = '#00ccc7';
+const SCORE_ACCENT_COLOUR = '#FFD230';
 // Helper for centre min-width calculation
 const getCentreMinWidthPx = (maxScoreLength?: number) =>
   maxScoreLength && maxScoreLength > 1
@@ -32,31 +34,31 @@ export default {
   // ==================== Main Wrapper (Theme-based) ====================
   wrapper:
     ({ isConciseView }: { isConciseView?: boolean }) =>
-    ({ palette, mq }: Theme) =>
-      css({
-        background: isConciseView ? palette.GREY_15 : palette.GREY_16,
-        borderLeft: `medium none ${palette.LIVE_CORE}`,
-        [mq.FORCED_COLOURS]: {
-          borderBottom: `solid ${pixelsToRem(1)}rem transparent`,
-        },
-      }),
+      ({ palette, mq }: Theme) =>
+        css({
+          background: isConciseView ? palette.GREY_15 : palette.GREY_16,
+          borderLeft: `medium none ${palette.LIVE_CORE}`,
+          [mq.FORCED_COLOURS]: {
+            borderBottom: `solid ${pixelsToRem(1)}rem transparent`,
+          },
+        }),
   container:
     ({ isConciseView }: { isConciseView?: boolean }) =>
-    ({ mq, palette, spacings }: Theme) =>
-      css({
-        fontFamily: 'ReithSans, Helvetica, Arial, freesans, sans-serif',
-        fontWeight: 400,
-        fontFeatureSettings: "'ss01' off",
-        color: palette.LUNAR_LIGHT,
-        padding: isConciseView ? `${spacings.FULL}rem` : 0,
-        ...(!isConciseView && { paddingBottom: `${spacings.TRIPLE}rem` }),
-        [mq.GROUP_2_MAX_WIDTH]: {
-          paddingTop: isConciseView ? `${spacings.FULL}rem` : 0,
-          ...(!isConciseView && {
-            paddingBottom: `${spacings.FULL}rem`,
-          }),
-        },
-      }),
+      ({ mq, palette, spacings }: Theme) =>
+        css({
+          fontFamily: 'ReithSans, Helvetica, Arial, freesans, sans-serif',
+          fontWeight: 400,
+          fontFeatureSettings: "'ss01' off",
+          color: palette.LUNAR_LIGHT,
+          padding: isConciseView ? `${spacings.FULL}rem` : 0,
+          ...(!isConciseView && { paddingBottom: `${spacings.TRIPLE}rem` }),
+          [mq.GROUP_2_MAX_WIDTH]: {
+            paddingTop: isConciseView ? `${spacings.FULL}rem` : 0,
+            ...(!isConciseView && {
+              paddingBottom: `${spacings.FULL}rem`,
+            }),
+          },
+        }),
 
   // ==================== Action Grid ====================
   actionGrid: css({
@@ -223,14 +225,14 @@ export default {
         'progress          progress          progress'`,
       ...(!isConciseView &&
         !shouldHideBadges && {
-          [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
-            {
-              gridTemplateColumns: '1fr auto auto 1fr',
-              gridTemplateAreas: `
+        [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
+        {
+          gridTemplateColumns: '1fr auto auto 1fr',
+          gridTemplateAreas: `
               'home_team         scores            scores            away_team'
               'home_team         progress          progress          away_team'`,
-            },
-        }),
+        },
+      }),
     }),
 
   teamHome: css({
@@ -394,13 +396,14 @@ export default {
   }),
 
   // ==================== Period ====================
-  period: css({
-    display: 'flex',
-    justifyContent: 'center',
-    color: '#FFD230',
-    fontSize: '1rem',
-    lineHeight: 1.375,
-  }),
+  period: ({ isLive }: { isLive: boolean }) =>
+    css({
+      display: 'flex',
+      justifyContent: 'center',
+      color: isLive ? LIVE_ACCENT_COLOUR : SCORE_ACCENT_COLOUR,
+      fontSize: '1rem',
+      lineHeight: 1.375,
+    }),
 
   // ==================== Score ====================
   score: css({
@@ -430,16 +433,17 @@ export default {
     textAlign: 'start',
   }),
 
-  verticalLine: css({
-    borderInlineStart: `${pixelsToRem(2)}rem solid #FFD230`,
-    display: 'inline-block',
-    marginInline: `${pixelsToRem(16)}rem`,
-    gridArea: VERTICAL_LINE,
-    height: `${pixelsToRem(38)}rem`,
-    [`@media (min-width: ${pixelsToRem(600)}rem)`]: {
-      height: `${pixelsToRem(44)}rem`,
-    },
-  }),
+  verticalLine: ({ isLive }: { isLive: boolean }) =>
+    css({
+      borderInlineStart: `${pixelsToRem(2)}rem solid ${isLive ? LIVE_ACCENT_COLOUR : SCORE_ACCENT_COLOUR}`,
+      display: 'inline-block',
+      marginInline: `${pixelsToRem(16)}rem`,
+      gridArea: VERTICAL_LINE,
+      height: `${pixelsToRem(38)}rem`,
+      [`@media (min-width: ${pixelsToRem(600)}rem)`]: {
+        height: `${pixelsToRem(44)}rem`,
+      },
+    }),
 
   // ==================== Score Details ====================
   scoreDetailsWrapper: css({
@@ -541,24 +545,24 @@ export default {
         textAlign: 'end',
         ...(!isConciseView &&
           !shouldHideBadges && {
-            [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
-              {
-                justifyContent: 'flex-end',
-                flexDirection: 'column-reverse',
-                textAlign: 'center',
-              },
-          }),
+          [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
+          {
+            justifyContent: 'flex-end',
+            flexDirection: 'column-reverse',
+            textAlign: 'center',
+          },
+        }),
       }),
       ...(alignment === 'away' && {
         justifyContent: 'flex-start',
         textAlign: 'start',
         ...(!isConciseView &&
           !shouldHideBadges && {
-            [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
-              {
-                textAlign: 'center',
-              },
-          }),
+          [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
+          {
+            textAlign: 'center',
+          },
+        }),
       }),
     }),
 

--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
@@ -34,31 +34,31 @@ export default {
   // ==================== Main Wrapper (Theme-based) ====================
   wrapper:
     ({ isConciseView }: { isConciseView?: boolean }) =>
-      ({ palette, mq }: Theme) =>
-        css({
-          background: isConciseView ? palette.GREY_15 : palette.GREY_16,
-          borderLeft: `medium none ${palette.LIVE_CORE}`,
-          [mq.FORCED_COLOURS]: {
-            borderBottom: `solid ${pixelsToRem(1)}rem transparent`,
-          },
-        }),
+    ({ palette, mq }: Theme) =>
+      css({
+        background: isConciseView ? palette.GREY_15 : palette.GREY_16,
+        borderLeft: `medium none ${palette.LIVE_CORE}`,
+        [mq.FORCED_COLOURS]: {
+          borderBottom: `solid ${pixelsToRem(1)}rem transparent`,
+        },
+      }),
   container:
     ({ isConciseView }: { isConciseView?: boolean }) =>
-      ({ mq, palette, spacings }: Theme) =>
-        css({
-          fontFamily: 'ReithSans, Helvetica, Arial, freesans, sans-serif',
-          fontWeight: 400,
-          fontFeatureSettings: "'ss01' off",
-          color: palette.LUNAR_LIGHT,
-          padding: isConciseView ? `${spacings.FULL}rem` : 0,
-          ...(!isConciseView && { paddingBottom: `${spacings.TRIPLE}rem` }),
-          [mq.GROUP_2_MAX_WIDTH]: {
-            paddingTop: isConciseView ? `${spacings.FULL}rem` : 0,
-            ...(!isConciseView && {
-              paddingBottom: `${spacings.FULL}rem`,
-            }),
-          },
-        }),
+    ({ mq, palette, spacings }: Theme) =>
+      css({
+        fontFamily: 'ReithSans, Helvetica, Arial, freesans, sans-serif',
+        fontWeight: 400,
+        fontFeatureSettings: "'ss01' off",
+        color: palette.LUNAR_LIGHT,
+        padding: isConciseView ? `${spacings.FULL}rem` : 0,
+        ...(!isConciseView && { paddingBottom: `${spacings.TRIPLE}rem` }),
+        [mq.GROUP_2_MAX_WIDTH]: {
+          paddingTop: isConciseView ? `${spacings.FULL}rem` : 0,
+          ...(!isConciseView && {
+            paddingBottom: `${spacings.FULL}rem`,
+          }),
+        },
+      }),
 
   // ==================== Action Grid ====================
   actionGrid: css({
@@ -225,14 +225,14 @@ export default {
         'progress          progress          progress'`,
       ...(!isConciseView &&
         !shouldHideBadges && {
-        [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
-        {
-          gridTemplateColumns: '1fr auto auto 1fr',
-          gridTemplateAreas: `
+          [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
+            {
+              gridTemplateColumns: '1fr auto auto 1fr',
+              gridTemplateAreas: `
               'home_team         scores            scores            away_team'
               'home_team         progress          progress          away_team'`,
-        },
-      }),
+            },
+        }),
     }),
 
   teamHome: css({
@@ -545,24 +545,24 @@ export default {
         textAlign: 'end',
         ...(!isConciseView &&
           !shouldHideBadges && {
-          [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
-          {
-            justifyContent: 'flex-end',
-            flexDirection: 'column-reverse',
-            textAlign: 'center',
-          },
-        }),
+            [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
+              {
+                justifyContent: 'flex-end',
+                flexDirection: 'column-reverse',
+                textAlign: 'center',
+              },
+          }),
       }),
       ...(alignment === 'away' && {
         justifyContent: 'flex-start',
         textAlign: 'start',
         ...(!isConciseView &&
           !shouldHideBadges && {
-          [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
-          {
-            textAlign: 'center',
-          },
-        }),
+            [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
+              {
+                textAlign: 'center',
+              },
+          }),
       }),
     }),
 

--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
@@ -1,5 +1,6 @@
 import { css, Theme } from '@emotion/react';
 import pixelsToRem from '../../../utilities/pixelsToRem';
+import { LIVE_LIGHT, SPORT_YELLOW } from '#app/components/ThemeProvider/palette';
 
 // Constants for grid areas
 export const GRID_AREAS = {
@@ -12,8 +13,8 @@ const HOME_SCORE = 'home_score';
 const VERTICAL_LINE = 'vertical_line';
 const AWAY_SCORE = 'away_score';
 
-const LIVE_ACCENT_COLOUR = '#00ccc7';
-const SCORE_ACCENT_COLOUR = '#FFD230';
+const LIVE_ACCENT_COLOUR = LIVE_LIGHT;
+const SCORE_ACCENT_COLOUR = SPORT_YELLOW;
 // Helper for centre min-width calculation
 const getCentreMinWidthPx = (maxScoreLength?: number) =>
   maxScoreLength && maxScoreLength > 1
@@ -34,31 +35,31 @@ export default {
   // ==================== Main Wrapper (Theme-based) ====================
   wrapper:
     ({ isConciseView }: { isConciseView?: boolean }) =>
-    ({ palette, mq }: Theme) =>
-      css({
-        background: isConciseView ? palette.GREY_15 : palette.GREY_16,
-        borderLeft: `medium none ${palette.LIVE_CORE}`,
-        [mq.FORCED_COLOURS]: {
-          borderBottom: `solid ${pixelsToRem(1)}rem transparent`,
-        },
-      }),
+      ({ palette, mq }: Theme) =>
+        css({
+          background: isConciseView ? palette.GREY_15 : palette.GREY_16,
+          borderLeft: `medium none ${palette.LIVE_CORE}`,
+          [mq.FORCED_COLOURS]: {
+            borderBottom: `solid ${pixelsToRem(1)}rem transparent`,
+          },
+        }),
   container:
     ({ isConciseView }: { isConciseView?: boolean }) =>
-    ({ mq, palette, spacings }: Theme) =>
-      css({
-        fontFamily: 'ReithSans, Helvetica, Arial, freesans, sans-serif',
-        fontWeight: 400,
-        fontFeatureSettings: "'ss01' off",
-        color: palette.LUNAR_LIGHT,
-        padding: isConciseView ? `${spacings.FULL}rem` : 0,
-        ...(!isConciseView && { paddingBottom: `${spacings.TRIPLE}rem` }),
-        [mq.GROUP_2_MAX_WIDTH]: {
-          paddingTop: isConciseView ? `${spacings.FULL}rem` : 0,
-          ...(!isConciseView && {
-            paddingBottom: `${spacings.FULL}rem`,
-          }),
-        },
-      }),
+      ({ mq, palette, spacings }: Theme) =>
+        css({
+          fontFamily: 'ReithSans, Helvetica, Arial, freesans, sans-serif',
+          fontWeight: 400,
+          fontFeatureSettings: "'ss01' off",
+          color: palette.LUNAR_LIGHT,
+          padding: isConciseView ? `${spacings.FULL}rem` : 0,
+          ...(!isConciseView && { paddingBottom: `${spacings.TRIPLE}rem` }),
+          [mq.GROUP_2_MAX_WIDTH]: {
+            paddingTop: isConciseView ? `${spacings.FULL}rem` : 0,
+            ...(!isConciseView && {
+              paddingBottom: `${spacings.FULL}rem`,
+            }),
+          },
+        }),
 
   // ==================== Action Grid ====================
   actionGrid: css({
@@ -225,14 +226,14 @@ export default {
         'progress          progress          progress'`,
       ...(!isConciseView &&
         !shouldHideBadges && {
-          [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
-            {
-              gridTemplateColumns: '1fr auto auto 1fr',
-              gridTemplateAreas: `
+        [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
+        {
+          gridTemplateColumns: '1fr auto auto 1fr',
+          gridTemplateAreas: `
               'home_team         scores            scores            away_team'
               'home_team         progress          progress          away_team'`,
-            },
-        }),
+        },
+      }),
     }),
 
   teamHome: css({
@@ -545,24 +546,24 @@ export default {
         textAlign: 'end',
         ...(!isConciseView &&
           !shouldHideBadges && {
-            [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
-              {
-                justifyContent: 'flex-end',
-                flexDirection: 'column-reverse',
-                textAlign: 'center',
-              },
-          }),
+          [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
+          {
+            justifyContent: 'flex-end',
+            flexDirection: 'column-reverse',
+            textAlign: 'center',
+          },
+        }),
       }),
       ...(alignment === 'away' && {
         justifyContent: 'flex-start',
         textAlign: 'start',
         ...(!isConciseView &&
           !shouldHideBadges && {
-            [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
-              {
-                textAlign: 'center',
-              },
-          }),
+          [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
+          {
+            textAlign: 'center',
+          },
+        }),
       }),
     }),
 

--- a/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
+++ b/src/app/components-webcore/SportDataHeader/head-to-head-v2/index.styles.ts
@@ -1,6 +1,9 @@
 import { css, Theme } from '@emotion/react';
+import {
+  LIVE_LIGHT,
+  SPORT_YELLOW,
+} from '#app/components/ThemeProvider/palette';
 import pixelsToRem from '../../../utilities/pixelsToRem';
-import { LIVE_LIGHT, SPORT_YELLOW } from '#app/components/ThemeProvider/palette';
 
 // Constants for grid areas
 export const GRID_AREAS = {
@@ -35,31 +38,31 @@ export default {
   // ==================== Main Wrapper (Theme-based) ====================
   wrapper:
     ({ isConciseView }: { isConciseView?: boolean }) =>
-      ({ palette, mq }: Theme) =>
-        css({
-          background: isConciseView ? palette.GREY_15 : palette.GREY_16,
-          borderLeft: `medium none ${palette.LIVE_CORE}`,
-          [mq.FORCED_COLOURS]: {
-            borderBottom: `solid ${pixelsToRem(1)}rem transparent`,
-          },
-        }),
+    ({ palette, mq }: Theme) =>
+      css({
+        background: isConciseView ? palette.GREY_15 : palette.GREY_16,
+        borderLeft: `medium none ${palette.LIVE_CORE}`,
+        [mq.FORCED_COLOURS]: {
+          borderBottom: `solid ${pixelsToRem(1)}rem transparent`,
+        },
+      }),
   container:
     ({ isConciseView }: { isConciseView?: boolean }) =>
-      ({ mq, palette, spacings }: Theme) =>
-        css({
-          fontFamily: 'ReithSans, Helvetica, Arial, freesans, sans-serif',
-          fontWeight: 400,
-          fontFeatureSettings: "'ss01' off",
-          color: palette.LUNAR_LIGHT,
-          padding: isConciseView ? `${spacings.FULL}rem` : 0,
-          ...(!isConciseView && { paddingBottom: `${spacings.TRIPLE}rem` }),
-          [mq.GROUP_2_MAX_WIDTH]: {
-            paddingTop: isConciseView ? `${spacings.FULL}rem` : 0,
-            ...(!isConciseView && {
-              paddingBottom: `${spacings.FULL}rem`,
-            }),
-          },
-        }),
+    ({ mq, palette, spacings }: Theme) =>
+      css({
+        fontFamily: 'ReithSans, Helvetica, Arial, freesans, sans-serif',
+        fontWeight: 400,
+        fontFeatureSettings: "'ss01' off",
+        color: palette.LUNAR_LIGHT,
+        padding: isConciseView ? `${spacings.FULL}rem` : 0,
+        ...(!isConciseView && { paddingBottom: `${spacings.TRIPLE}rem` }),
+        [mq.GROUP_2_MAX_WIDTH]: {
+          paddingTop: isConciseView ? `${spacings.FULL}rem` : 0,
+          ...(!isConciseView && {
+            paddingBottom: `${spacings.FULL}rem`,
+          }),
+        },
+      }),
 
   // ==================== Action Grid ====================
   actionGrid: css({
@@ -226,14 +229,14 @@ export default {
         'progress          progress          progress'`,
       ...(!isConciseView &&
         !shouldHideBadges && {
-        [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
-        {
-          gridTemplateColumns: '1fr auto auto 1fr',
-          gridTemplateAreas: `
+          [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
+            {
+              gridTemplateColumns: '1fr auto auto 1fr',
+              gridTemplateAreas: `
               'home_team         scores            scores            away_team'
               'home_team         progress          progress          away_team'`,
-        },
-      }),
+            },
+        }),
     }),
 
   teamHome: css({
@@ -546,24 +549,24 @@ export default {
         textAlign: 'end',
         ...(!isConciseView &&
           !shouldHideBadges && {
-          [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
-          {
-            justifyContent: 'flex-end',
-            flexDirection: 'column-reverse',
-            textAlign: 'center',
-          },
-        }),
+            [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
+              {
+                justifyContent: 'flex-end',
+                flexDirection: 'column-reverse',
+                textAlign: 'center',
+              },
+          }),
       }),
       ...(alignment === 'away' && {
         justifyContent: 'flex-start',
         textAlign: 'start',
         ...(!isConciseView &&
           !shouldHideBadges && {
-          [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
-          {
-            textAlign: 'center',
-          },
-        }),
+            [`@media (max-width: calc(${pixelsToRem(600)}rem - ${pixelsToRem(1)}rem))`]:
+              {
+                textAlign: 'center',
+              },
+          }),
       }),
     }),
 


### PR DESCRIPTION
Resolves JIRA: NA

Summary
======
The divider and period label in the head-to-head component are rendered yellow (#FFD230) pre, mid and post match. The correct behaviour is to show teal (#00CCC7) during a live match (mid event), and yellow pre and post match.

Current behaviour:
<img width="1380" height="614" alt="En-direct-Portugal-RD-Congo-Coupe-du-monde-2026-score-résultat-et-analyses-BBC-News-Afrique" src="https://github.com/user-attachments/assets/77b11de9-6229-4249-ba6f-a0551cb43676" />

Expected behaviour:
<img width="1100" height="296" alt="Components-Live-Page-Sport-Data-Header-Head-To-Head-V2-Mid-event-First-Half-Of-90-Mins-⋅-Storybook" src="https://github.com/user-attachments/assets/40c5f365-ceb7-4828-910d-df868287ceae" />

Code changes
======
- Updated `verticalLine` and `period` styles to accept an `isLive` boolean, using teal when true and yellow when false
- Updated `score.tsx` and `period.tsx` to pass `isLiveStatus(status)` to the updated styles

Testing
======
1. Open Storybook and navigate to the head-to-head-v2 component stories
2. Check the mid-event match story — verify the vertical divider and period label are teal (#00CCC7)
3. Check the pre-event and post-event stories — verify the vertical divider and period label are yellow (#FFD230)

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
