### PR TITLE
WS-2218: Sets article og image to 1200px width for image previews

### DIFF
--- a/src/app/components/LinkedData/index.tsx
+++ b/src/app/components/LinkedData/index.tsx
@@ -97,7 +97,7 @@ const LinkedData = ({
   const LANGUAGE_TYPE = 'Language';
   const isNotRadioChannel = type !== 'RadioChannel';
   const brandedIndexImage = imageLocator
-    ? getBrandedImage(imageLocator, service)
+    ? getBrandedImage({ locator: imageLocator, service })
     : null;
 
   const logo = {

--- a/src/app/legacy/containers/ArticleMetadata/index.jsx
+++ b/src/app/legacy/containers/ArticleMetadata/index.jsx
@@ -21,7 +21,7 @@ const ArticleMetadata = ({
 }) => {
   const { service } = use(ServiceContext);
   const brandedImage = imageLocator
-    ? getBrandedImage(imageLocator, service)
+    ? getBrandedImage({ locator: imageLocator, service, width: 1200 })
     : null;
 
   return (

--- a/src/app/legacy/containers/ArticleMetadata/index.test.jsx
+++ b/src/app/legacy/containers/ArticleMetadata/index.test.jsx
@@ -86,7 +86,7 @@ describe('ArticleMetadata get branded image', () => {
           .querySelector('head > meta[property="og:image"]')
           .getAttribute('content'),
       ).toEqual(
-        'https://ichef.test.bbci.co.uk/news/1024/branded_news/c34e/live/fea48140-27e5-11eb-a689-1f68cd2c5502.jpg',
+        'https://ichef.test.bbci.co.uk/news/1200/branded_news/c34e/live/fea48140-27e5-11eb-a689-1f68cd2c5502.jpg',
       );
     });
   });

--- a/src/app/lib/utilities/getBrandedImage/index.js
+++ b/src/app/lib/utilities/getBrandedImage/index.js
@@ -1,8 +1,8 @@
 import { getEnvConfig } from '#app/lib/utilities/getEnvConfig';
 
-const getBrandedImage = (locator, service) =>
+const getBrandedImage = ({ locator, service, width = 1024 }) =>
   `${
     getEnvConfig().SIMORGH_ICHEF_BASE_URL
-  }/news/${service === 'russian' ? '1200' : '1024'}/branded_${service}/${locator}`;
+  }/news/${width}/branded_${service}/${locator}`;
 
 export default getBrandedImage;

--- a/src/app/lib/utilities/getBrandedImage/index.js
+++ b/src/app/lib/utilities/getBrandedImage/index.js
@@ -3,6 +3,6 @@ import { getEnvConfig } from '#app/lib/utilities/getEnvConfig';
 const getBrandedImage = ({ locator, service, width = 1024 }) =>
   `${
     getEnvConfig().SIMORGH_ICHEF_BASE_URL
-  }/news/${width}/branded_${service}/${locator}`;
+  }/news/${service === 'russian' ? 1200 : width}/branded_${service}/${locator}`;
 
 export default getBrandedImage;

--- a/src/app/lib/utilities/getBrandedImage/index.test.js
+++ b/src/app/lib/utilities/getBrandedImage/index.test.js
@@ -10,7 +10,7 @@ describe('CpsMetadata get branded image', () => {
 
     const locator = '729E/test/_63724392_gettyimages-1098075358.jpg';
     const service = 'pidgin';
-    const actual = getBrandedImage(locator, service);
+    const actual = getBrandedImage({ locator, service });
     const expected =
       'https://ichef.test.bbci.co.uk/news/1024/branded_pidgin/729E/test/_63724392_gettyimages-1098075358.jpg';
 
@@ -22,7 +22,7 @@ describe('CpsMetadata get branded image', () => {
 
     const locator = '729E/test/_63724392_gettyimages-1098075358.jpg';
     const service = 'igbo';
-    const actual = getBrandedImage(locator, service);
+    const actual = getBrandedImage({ locator, service });
     const expected =
       'https://ichef.test.bbci.co.uk/news/1024/branded_igbo/729E/test/_63724392_gettyimages-1098075358.jpg';
 
@@ -34,7 +34,7 @@ describe('CpsMetadata get branded image', () => {
 
     const locator = '729E/test/_63724392_gettyimages-1098075358.jpg';
     const service = 'korean';
-    const actual = getBrandedImage(locator, service);
+    const actual = getBrandedImage({ locator, service });
     const expected =
       'https://ichef.bbci.co.uk/news/1024/branded_korean/729E/test/_63724392_gettyimages-1098075358.jpg';
 
@@ -46,7 +46,7 @@ describe('CpsMetadata get branded image', () => {
 
     const locator = '729E/test/_63724392_gettyimages-1098075358.jpg';
     const service = 'russian';
-    const actual = getBrandedImage(locator, service);
+    const actual = getBrandedImage({ locator, service });
     const expected =
       'https://ichef.bbci.co.uk/news/1200/branded_russian/729E/test/_63724392_gettyimages-1098075358.jpg';
 

--- a/src/app/pages/ArticlePage/index.test.tsx
+++ b/src/app/pages/ArticlePage/index.test.tsx
@@ -365,7 +365,7 @@ describe('Article Page', () => {
             .querySelector('meta[property="og:image"]')
             ?.getAttribute('content'),
         ).toEqual(
-          'https://ichef.test.bbci.co.uk/news/1024/branded_news/c34e/live/fea48140-27e5-11eb-a689-1f68cd2c5502.jpg',
+          'https://ichef.test.bbci.co.uk/news/1200/branded_news/c34e/live/fea48140-27e5-11eb-a689-1f68cd2c5502.jpg',
         );
       });
     });

--- a/ws-nextjs-app/integration/pages/articles/gahuza/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/gahuza/__snapshots__/canonical.test.ts.snap
@@ -301,7 +301,7 @@ exports[`Canonical Articles SEO Linked data should match text 1`] = `
 
 exports[`Canonical Articles SEO OG description 1`] = `"Yulia Navalnaya yavuze ibi mu kumurika igitabo umugabo we Alexei Navalny yandikaga ari muri gereza mbere y'uko apfa. "`;
 
-exports[`Canonical Articles SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_gahuza/8654/live/6fd0abe0-8f8a-11ef-8e6d-e3e64e16c628.jpg"`;
+exports[`Canonical Articles SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_gahuza/8654/live/6fd0abe0-8f8a-11ef-8e6d-e3e64e16c628.jpg"`;
 
 exports[`Canonical Articles SEO OG image alt 1`] = `"Alexei Navalny na Yulia Navalnaya bari i Moscow mu 2013 muri metingi yo kwiyamamaza kw'abakuru b'imijyi"`;
 
@@ -327,7 +327,7 @@ exports[`Canonical Articles SEO Twitter description 1`] = `"Yulia Navalnaya yavu
 
 exports[`Canonical Articles SEO Twitter image alt 1`] = `"Alexei Navalny na Yulia Navalnaya bari i Moscow mu 2013 muri metingi yo kwiyamamaza kw'abakuru b'imijyi"`;
 
-exports[`Canonical Articles SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_gahuza/8654/live/6fd0abe0-8f8a-11ef-8e6d-e3e64e16c628.jpg"`;
+exports[`Canonical Articles SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_gahuza/8654/live/6fd0abe0-8f8a-11ef-8e6d-e3e64e16c628.jpg"`;
 
 exports[`Canonical Articles SEO Twitter site 1`] = `"@bbcgahuza"`;
 

--- a/ws-nextjs-app/integration/pages/articles/news/__snapshots__/amp.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/news/__snapshots__/amp.test.ts.snap
@@ -299,7 +299,7 @@ exports[`AMP Articles SEO Linked data should match text 1`] = `
 
 exports[`AMP Articles SEO OG description 1`] = `"Royal wedding flowers given to Hackney hospice"`;
 
-exports[`AMP Articles SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_news/e8d3/test/98b75f50-814d-11e9-b0be-cb6d2b512d8b.jpg"`;
+exports[`AMP Articles SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_news/e8d3/test/98b75f50-814d-11e9-b0be-cb6d2b512d8b.jpg"`;
 
 exports[`AMP Articles SEO OG image alt 1`] = `"Pauline Clayton"`;
 
@@ -325,7 +325,7 @@ exports[`AMP Articles SEO Twitter description 1`] = `"Royal wedding flowers give
 
 exports[`AMP Articles SEO Twitter image alt 1`] = `"Pauline Clayton"`;
 
-exports[`AMP Articles SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_news/e8d3/test/98b75f50-814d-11e9-b0be-cb6d2b512d8b.jpg"`;
+exports[`AMP Articles SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_news/e8d3/test/98b75f50-814d-11e9-b0be-cb6d2b512d8b.jpg"`;
 
 exports[`AMP Articles SEO Twitter site 1`] = `"@BBCNews"`;
 

--- a/ws-nextjs-app/integration/pages/articles/news/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/news/__snapshots__/canonical.test.ts.snap
@@ -367,7 +367,7 @@ exports[`Canonical Articles SEO Linked data should match text 1`] = `
 
 exports[`Canonical Articles SEO OG description 1`] = `"Royal wedding flowers given to Hackney hospice"`;
 
-exports[`Canonical Articles SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_news/e8d3/test/98b75f50-814d-11e9-b0be-cb6d2b512d8b.jpg"`;
+exports[`Canonical Articles SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_news/e8d3/test/98b75f50-814d-11e9-b0be-cb6d2b512d8b.jpg"`;
 
 exports[`Canonical Articles SEO OG image alt 1`] = `"Pauline Clayton"`;
 
@@ -393,7 +393,7 @@ exports[`Canonical Articles SEO Twitter description 1`] = `"Royal wedding flower
 
 exports[`Canonical Articles SEO Twitter image alt 1`] = `"Pauline Clayton"`;
 
-exports[`Canonical Articles SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_news/e8d3/test/98b75f50-814d-11e9-b0be-cb6d2b512d8b.jpg"`;
+exports[`Canonical Articles SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_news/e8d3/test/98b75f50-814d-11e9-b0be-cb6d2b512d8b.jpg"`;
 
 exports[`Canonical Articles SEO Twitter site 1`] = `"@BBCNews"`;
 

--- a/ws-nextjs-app/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/persianMediaPlayer/__snapshots__/amp.test.ts.snap
@@ -223,7 +223,7 @@ exports[`AMP Articles SEO Linked data should match text 2`] = `
 
 exports[`AMP Articles SEO OG description 1`] = `"این تصویر آزمایشی ، کپی رایت بی بی سی ، نقشه ای از فرانسه را نشان می دهد. تصویر در سه بلوک اول است و این عنوان را دارد."`;
 
-exports[`AMP Articles SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_persian/0d65/test/e28c1b30-e691-11e9-88d6-81aa2ccc6d4c.jpg"`;
+exports[`AMP Articles SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_persian/0d65/test/e28c1b30-e691-11e9-88d6-81aa2ccc6d4c.jpg"`;
 
 exports[`AMP Articles SEO OG image alt 1`] = `
 "این تصویر آزمایشی ، کپی رایت بی بی سی ، نقشه ای از فرانسه را نشان می دهد. تصویر در سه بلوک اول است و این عنوان را دارد.
@@ -255,7 +255,7 @@ exports[`AMP Articles SEO Twitter image alt 1`] = `
 "
 `;
 
-exports[`AMP Articles SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_persian/0d65/test/e28c1b30-e691-11e9-88d6-81aa2ccc6d4c.jpg"`;
+exports[`AMP Articles SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_persian/0d65/test/e28c1b30-e691-11e9-88d6-81aa2ccc6d4c.jpg"`;
 
 exports[`AMP Articles SEO Twitter site 1`] = `"@bbcpersian"`;
 

--- a/ws-nextjs-app/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.ts.snap
@@ -589,7 +589,7 @@ exports[`Canonical Articles SEO Linked data should match text 2`] = `
 
 exports[`Canonical Articles SEO OG description 1`] = `"این تصویر آزمایشی ، کپی رایت بی بی سی ، نقشه ای از فرانسه را نشان می دهد. تصویر در سه بلوک اول است و این عنوان را دارد."`;
 
-exports[`Canonical Articles SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_persian/0d65/test/e28c1b30-e691-11e9-88d6-81aa2ccc6d4c.jpg"`;
+exports[`Canonical Articles SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_persian/0d65/test/e28c1b30-e691-11e9-88d6-81aa2ccc6d4c.jpg"`;
 
 exports[`Canonical Articles SEO OG image alt 1`] = `
 "این تصویر آزمایشی ، کپی رایت بی بی سی ، نقشه ای از فرانسه را نشان می دهد. تصویر در سه بلوک اول است و این عنوان را دارد.
@@ -621,7 +621,7 @@ exports[`Canonical Articles SEO Twitter image alt 1`] = `
 "
 `;
 
-exports[`Canonical Articles SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_persian/0d65/test/e28c1b30-e691-11e9-88d6-81aa2ccc6d4c.jpg"`;
+exports[`Canonical Articles SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_persian/0d65/test/e28c1b30-e691-11e9-88d6-81aa2ccc6d4c.jpg"`;
 
 exports[`Canonical Articles SEO Twitter site 1`] = `"@bbcpersian"`;
 

--- a/ws-nextjs-app/integration/pages/mediaArticlePage/pidgin/__snapshots__/amp.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/mediaArticlePage/pidgin/__snapshots__/amp.test.ts.snap
@@ -386,7 +386,7 @@ exports[`AMP Media Article Page SEO Linked data should match text 2`] = `
 
 exports[`AMP Media Article Page SEO OG description 1`] = `"Professor Mahmood Yakubu speak wit BBC on Inec plans to conduct free and fair elections."`;
 
-exports[`AMP Media Article Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_pidgin/1a8b/live/c4ce3eb0-98a5-11ed-86bf-4b2f5da2cf01.jpg"`;
+exports[`AMP Media Article Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_pidgin/1a8b/live/c4ce3eb0-98a5-11ed-86bf-4b2f5da2cf01.jpg"`;
 
 exports[`AMP Media Article Page SEO OG image alt 1`] = `"Inec boss Prof. Mahmood Yakubu"`;
 
@@ -412,7 +412,7 @@ exports[`AMP Media Article Page SEO Twitter description 1`] = `"Professor Mahmoo
 
 exports[`AMP Media Article Page SEO Twitter image alt 1`] = `"Inec boss Prof. Mahmood Yakubu"`;
 
-exports[`AMP Media Article Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_pidgin/1a8b/live/c4ce3eb0-98a5-11ed-86bf-4b2f5da2cf01.jpg"`;
+exports[`AMP Media Article Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_pidgin/1a8b/live/c4ce3eb0-98a5-11ed-86bf-4b2f5da2cf01.jpg"`;
 
 exports[`AMP Media Article Page SEO Twitter site 1`] = `"@BBCNews"`;
 

--- a/ws-nextjs-app/integration/pages/mediaArticlePage/pidgin/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/mediaArticlePage/pidgin/__snapshots__/canonical.test.ts.snap
@@ -338,7 +338,7 @@ exports[`Canonical Media Article Page SEO Linked data should match text 2`] = `
 
 exports[`Canonical Media Article Page SEO OG description 1`] = `"Professor Mahmood Yakubu speak wit BBC on Inec plans to conduct free and fair elections."`;
 
-exports[`Canonical Media Article Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_pidgin/1a8b/live/c4ce3eb0-98a5-11ed-86bf-4b2f5da2cf01.jpg"`;
+exports[`Canonical Media Article Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_pidgin/1a8b/live/c4ce3eb0-98a5-11ed-86bf-4b2f5da2cf01.jpg"`;
 
 exports[`Canonical Media Article Page SEO OG image alt 1`] = `"Inec boss Prof. Mahmood Yakubu"`;
 
@@ -364,7 +364,7 @@ exports[`Canonical Media Article Page SEO Twitter description 1`] = `"Professor 
 
 exports[`Canonical Media Article Page SEO Twitter image alt 1`] = `"Inec boss Prof. Mahmood Yakubu"`;
 
-exports[`Canonical Media Article Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_pidgin/1a8b/live/c4ce3eb0-98a5-11ed-86bf-4b2f5da2cf01.jpg"`;
+exports[`Canonical Media Article Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_pidgin/1a8b/live/c4ce3eb0-98a5-11ed-86bf-4b2f5da2cf01.jpg"`;
 
 exports[`Canonical Media Article Page SEO Twitter site 1`] = `"@BBCNews"`;
 

--- a/ws-nextjs-app/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.ts.snap
@@ -230,7 +230,7 @@ exports[`Canonical Media Asset Page SEO Linked data should match text 1`] = `
 
 exports[`Canonical Media Asset Page SEO OG description 1`] = `"شركة شارب للإلكترونيات تحث موظفيها على شراء منتجاتها"`;
 
-exports[`Canonical Media Asset Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_arabic/worldservice/test/assets/images/2014/09/22/140922130059_144x81.jpg"`;
+exports[`Canonical Media Asset Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_arabic/worldservice/test/assets/images/2014/09/22/140922130059_144x81.jpg"`;
 
 exports[`Canonical Media Asset Page SEO OG image alt 1`] = `"BBC News عربي"`;
 
@@ -256,7 +256,7 @@ exports[`Canonical Media Asset Page SEO Twitter description 1`] = `"شركة ش�
 
 exports[`Canonical Media Asset Page SEO Twitter image alt 1`] = `"BBC News عربي"`;
 
-exports[`Canonical Media Asset Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_arabic/worldservice/test/assets/images/2014/09/22/140922130059_144x81.jpg"`;
+exports[`Canonical Media Asset Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_arabic/worldservice/test/assets/images/2014/09/22/140922130059_144x81.jpg"`;
 
 exports[`Canonical Media Asset Page SEO Twitter site 1`] = `"@BBCArabic"`;
 

--- a/ws-nextjs-app/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.ts.snap
@@ -294,7 +294,7 @@ exports[`AMP Media Asset Page SEO Linked data should match text 2`] = `
 
 exports[`AMP Media Asset Page SEO OG description 1`] = `"Trump summary text"`;
 
-exports[`AMP Media Asset Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_persian/14DFC/test/_63700558_p01lmkk5.jpg"`;
+exports[`AMP Media Asset Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_persian/14DFC/test/_63700558_p01lmkk5.jpg"`;
 
 exports[`AMP Media Asset Page SEO OG image alt 1`] = `"Trump getting upset"`;
 
@@ -320,7 +320,7 @@ exports[`AMP Media Asset Page SEO Twitter description 1`] = `"Trump summary text
 
 exports[`AMP Media Asset Page SEO Twitter image alt 1`] = `"Trump getting upset"`;
 
-exports[`AMP Media Asset Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_persian/14DFC/test/_63700558_p01lmkk5.jpg"`;
+exports[`AMP Media Asset Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_persian/14DFC/test/_63700558_p01lmkk5.jpg"`;
 
 exports[`AMP Media Asset Page SEO Twitter site 1`] = `"@bbcpersian"`;
 

--- a/ws-nextjs-app/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.ts.snap
@@ -246,7 +246,7 @@ exports[`Canonical Media Asset Page SEO Linked data should match text 2`] = `
 
 exports[`Canonical Media Asset Page SEO OG description 1`] = `"Trump summary text"`;
 
-exports[`Canonical Media Asset Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_persian/14DFC/test/_63700558_p01lmkk5.jpg"`;
+exports[`Canonical Media Asset Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_persian/14DFC/test/_63700558_p01lmkk5.jpg"`;
 
 exports[`Canonical Media Asset Page SEO OG image alt 1`] = `"Trump getting upset"`;
 
@@ -272,7 +272,7 @@ exports[`Canonical Media Asset Page SEO Twitter description 1`] = `"Trump summar
 
 exports[`Canonical Media Asset Page SEO Twitter image alt 1`] = `"Trump getting upset"`;
 
-exports[`Canonical Media Asset Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_persian/14DFC/test/_63700558_p01lmkk5.jpg"`;
+exports[`Canonical Media Asset Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_persian/14DFC/test/_63700558_p01lmkk5.jpg"`;
 
 exports[`Canonical Media Asset Page SEO Twitter site 1`] = `"@bbcpersian"`;
 

--- a/ws-nextjs-app/integration/pages/mediaAssetPage/pidgin/__snapshots__/amp.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/mediaAssetPage/pidgin/__snapshots__/amp.test.ts.snap
@@ -304,7 +304,7 @@ exports[`AMP Media Asset Page SEO Linked data should match text 2`] = `
 
 exports[`AMP Media Asset Page SEO OG description 1`] = `"Lorem ipsum dolor sit amet, consectetur this is a change"`;
 
-exports[`AMP Media Asset Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_pidgin/6FC4/test/_63721682_p01kx435.jpg"`;
+exports[`AMP Media Asset Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_pidgin/6FC4/test/_63721682_p01kx435.jpg"`;
 
 exports[`AMP Media Asset Page SEO OG image alt 1`] = `"connectionAltText"`;
 
@@ -330,7 +330,7 @@ exports[`AMP Media Asset Page SEO Twitter description 1`] = `"Lorem ipsum dolor 
 
 exports[`AMP Media Asset Page SEO Twitter image alt 1`] = `"connectionAltText"`;
 
-exports[`AMP Media Asset Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_pidgin/6FC4/test/_63721682_p01kx435.jpg"`;
+exports[`AMP Media Asset Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_pidgin/6FC4/test/_63721682_p01kx435.jpg"`;
 
 exports[`AMP Media Asset Page SEO Twitter site 1`] = `"@BBCNews"`;
 

--- a/ws-nextjs-app/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.ts.snap
@@ -256,7 +256,7 @@ exports[`Canonical Media Asset Page SEO Linked data should match text 2`] = `
 
 exports[`Canonical Media Asset Page SEO OG description 1`] = `"Lorem ipsum dolor sit amet, consectetur this is a change"`;
 
-exports[`Canonical Media Asset Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_pidgin/6FC4/test/_63721682_p01kx435.jpg"`;
+exports[`Canonical Media Asset Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_pidgin/6FC4/test/_63721682_p01kx435.jpg"`;
 
 exports[`Canonical Media Asset Page SEO OG image alt 1`] = `"connectionAltText"`;
 
@@ -282,7 +282,7 @@ exports[`Canonical Media Asset Page SEO Twitter description 1`] = `"Lorem ipsum 
 
 exports[`Canonical Media Asset Page SEO Twitter image alt 1`] = `"connectionAltText"`;
 
-exports[`Canonical Media Asset Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_pidgin/6FC4/test/_63721682_p01kx435.jpg"`;
+exports[`Canonical Media Asset Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_pidgin/6FC4/test/_63721682_p01kx435.jpg"`;
 
 exports[`Canonical Media Asset Page SEO Twitter site 1`] = `"@BBCNews"`;
 

--- a/ws-nextjs-app/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.ts.snap
@@ -299,7 +299,7 @@ exports[`AMP Photo Gallery Page SEO Linked data should match text 1`] = `
 
 exports[`AMP Photo Gallery Page SEO OG description 1`] = `"La estética de la ropa deportiva ha ido evolucionando en cada edición olímpica, pero no solo se trata de lucir bien, pues en varias competencias contar con un traje adecuado puede ser un factor que contribuya al triunfo."`;
 
-exports[`AMP Photo Gallery Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_mundo/16506/production/_90689319_gettyimages-2642105-1.jpg"`;
+exports[`AMP Photo Gallery Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_mundo/16506/production/_90689319_gettyimages-2642105-1.jpg"`;
 
 exports[`AMP Photo Gallery Page SEO OG image alt 1`] = `"Gimnastas en los primeros juegos"`;
 
@@ -325,7 +325,7 @@ exports[`AMP Photo Gallery Page SEO Twitter description 1`] = `"La estética de 
 
 exports[`AMP Photo Gallery Page SEO Twitter image alt 1`] = `"Gimnastas en los primeros juegos"`;
 
-exports[`AMP Photo Gallery Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_mundo/16506/production/_90689319_gettyimages-2642105-1.jpg"`;
+exports[`AMP Photo Gallery Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_mundo/16506/production/_90689319_gettyimages-2642105-1.jpg"`;
 
 exports[`AMP Photo Gallery Page SEO Twitter site 1`] = `"@bbcmundo"`;
 

--- a/ws-nextjs-app/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.ts.snap
@@ -251,7 +251,7 @@ exports[`Canonical Photo Gallery Page SEO Linked data should match text 1`] = `
 
 exports[`Canonical Photo Gallery Page SEO OG description 1`] = `"La estética de la ropa deportiva ha ido evolucionando en cada edición olímpica, pero no solo se trata de lucir bien, pues en varias competencias contar con un traje adecuado puede ser un factor que contribuya al triunfo."`;
 
-exports[`Canonical Photo Gallery Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_mundo/16506/production/_90689319_gettyimages-2642105-1.jpg"`;
+exports[`Canonical Photo Gallery Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_mundo/16506/production/_90689319_gettyimages-2642105-1.jpg"`;
 
 exports[`Canonical Photo Gallery Page SEO OG image alt 1`] = `"Gimnastas en los primeros juegos"`;
 
@@ -277,7 +277,7 @@ exports[`Canonical Photo Gallery Page SEO Twitter description 1`] = `"La estéti
 
 exports[`Canonical Photo Gallery Page SEO Twitter image alt 1`] = `"Gimnastas en los primeros juegos"`;
 
-exports[`Canonical Photo Gallery Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_mundo/16506/production/_90689319_gettyimages-2642105-1.jpg"`;
+exports[`Canonical Photo Gallery Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_mundo/16506/production/_90689319_gettyimages-2642105-1.jpg"`;
 
 exports[`Canonical Photo Gallery Page SEO Twitter site 1`] = `"@bbcmundo"`;
 

--- a/ws-nextjs-app/integration/pages/photoGalleryPage/thai/__snapshots__/amp.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/photoGalleryPage/thai/__snapshots__/amp.test.ts.snap
@@ -305,7 +305,7 @@ exports[`AMP Photo Gallery Page SEO Linked data should match text 1`] = `
 
 exports[`AMP Photo Gallery Page SEO OG description 1`] = `"มหาวิทยาลัยธรรมศาสตร์ ซึ่งมีสภาพไม่ต่างจาก “ลานประหาร” ในวันล้อมปราบนักศึกษาและประชาชน ได้จัดกิจกรรมรำลึก 43 ปี 6 ตุลา 2519 มีพิธีทำบุญตักบาตรพระสงฆ์จำนวน 19 รูป พิธีวางพวงมาลาและดอกไม้ ณ ประติมานุสรณ์ และกล่าวไว้อาลัยแด่ผู้เสียชีวิตในเหตุการณ์ พร้อมอ่านรายชื่อของทุกคนด้วย"`;
 
-exports[`AMP Photo Gallery Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_thai/17431/production/_109118259_01.jpg"`;
+exports[`AMP Photo Gallery Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_thai/17431/production/_109118259_01.jpg"`;
 
 exports[`AMP Photo Gallery Page SEO OG image alt 1`] = `"ดอกไม้ถูกนำมาวางไว้ที่ประติมานุสรณ์"`;
 
@@ -331,7 +331,7 @@ exports[`AMP Photo Gallery Page SEO Twitter description 1`] = `"มหาวิ�
 
 exports[`AMP Photo Gallery Page SEO Twitter image alt 1`] = `"ดอกไม้ถูกนำมาวางไว้ที่ประติมานุสรณ์"`;
 
-exports[`AMP Photo Gallery Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_thai/17431/production/_109118259_01.jpg"`;
+exports[`AMP Photo Gallery Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_thai/17431/production/_109118259_01.jpg"`;
 
 exports[`AMP Photo Gallery Page SEO Twitter site 1`] = `"@bbc_thailand"`;
 

--- a/ws-nextjs-app/integration/pages/photoGalleryPage/thai/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/photoGalleryPage/thai/__snapshots__/canonical.test.ts.snap
@@ -257,7 +257,7 @@ exports[`Canonical Photo Gallery Page SEO Linked data should match text 1`] = `
 
 exports[`Canonical Photo Gallery Page SEO OG description 1`] = `"มหาวิทยาลัยธรรมศาสตร์ ซึ่งมีสภาพไม่ต่างจาก “ลานประหาร” ในวันล้อมปราบนักศึกษาและประชาชน ได้จัดกิจกรรมรำลึก 43 ปี 6 ตุลา 2519 มีพิธีทำบุญตักบาตรพระสงฆ์จำนวน 19 รูป พิธีวางพวงมาลาและดอกไม้ ณ ประติมานุสรณ์ และกล่าวไว้อาลัยแด่ผู้เสียชีวิตในเหตุการณ์ พร้อมอ่านรายชื่อของทุกคนด้วย"`;
 
-exports[`Canonical Photo Gallery Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_thai/17431/production/_109118259_01.jpg"`;
+exports[`Canonical Photo Gallery Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_thai/17431/production/_109118259_01.jpg"`;
 
 exports[`Canonical Photo Gallery Page SEO OG image alt 1`] = `"ดอกไม้ถูกนำมาวางไว้ที่ประติมานุสรณ์"`;
 
@@ -283,7 +283,7 @@ exports[`Canonical Photo Gallery Page SEO Twitter description 1`] = `"มหา�
 
 exports[`Canonical Photo Gallery Page SEO Twitter image alt 1`] = `"ดอกไม้ถูกนำมาวางไว้ที่ประติมานุสรณ์"`;
 
-exports[`Canonical Photo Gallery Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_thai/17431/production/_109118259_01.jpg"`;
+exports[`Canonical Photo Gallery Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_thai/17431/production/_109118259_01.jpg"`;
 
 exports[`Canonical Photo Gallery Page SEO Twitter site 1`] = `"@bbc_thailand"`;
 

--- a/ws-nextjs-app/integration/pages/storyPage/hausa/__snapshots__/amp.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/storyPage/hausa/__snapshots__/amp.test.ts.snap
@@ -314,7 +314,7 @@ exports[`AMP Story Page SEO Linked data should match text 2`] = `
 
 exports[`AMP Story Page SEO OG description 1`] = `"French football fans sing God Save The Queen ahead of the match between France and England in tribute to the victims of attacks in London and Manchester."`;
 
-exports[`AMP Story Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_hausa/1745C/test/_63542359_hi035712328.jpg"`;
+exports[`AMP Story Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_hausa/1745C/test/_63542359_hi035712328.jpg"`;
 
 exports[`AMP Story Page SEO OG image alt 1`] = `"hai;le"`;
 
@@ -340,7 +340,7 @@ exports[`AMP Story Page SEO Twitter description 1`] = `"French football fans sin
 
 exports[`AMP Story Page SEO Twitter image alt 1`] = `"hai;le"`;
 
-exports[`AMP Story Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_hausa/1745C/test/_63542359_hi035712328.jpg"`;
+exports[`AMP Story Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_hausa/1745C/test/_63542359_hi035712328.jpg"`;
 
 exports[`AMP Story Page SEO Twitter site 1`] = `"@bbchausa"`;
 

--- a/ws-nextjs-app/integration/pages/storyPage/hausa/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/storyPage/hausa/__snapshots__/canonical.test.ts.snap
@@ -296,7 +296,7 @@ exports[`Canonical Story Page SEO Linked data should match text 2`] = `
 
 exports[`Canonical Story Page SEO OG description 1`] = `"French football fans sing God Save The Queen ahead of the match between France and England in tribute to the victims of attacks in London and Manchester."`;
 
-exports[`Canonical Story Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_hausa/1745C/test/_63542359_hi035712328.jpg"`;
+exports[`Canonical Story Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_hausa/1745C/test/_63542359_hi035712328.jpg"`;
 
 exports[`Canonical Story Page SEO OG image alt 1`] = `"hai;le"`;
 
@@ -322,7 +322,7 @@ exports[`Canonical Story Page SEO Twitter description 1`] = `"French football fa
 
 exports[`Canonical Story Page SEO Twitter image alt 1`] = `"hai;le"`;
 
-exports[`Canonical Story Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_hausa/1745C/test/_63542359_hi035712328.jpg"`;
+exports[`Canonical Story Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_hausa/1745C/test/_63542359_hi035712328.jpg"`;
 
 exports[`Canonical Story Page SEO Twitter site 1`] = `"@bbchausa"`;
 

--- a/ws-nextjs-app/integration/pages/storyPage/kyrgyz/__snapshots__/amp.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/storyPage/kyrgyz/__snapshots__/amp.test.ts.snap
@@ -298,7 +298,7 @@ exports[`AMP Story Page SEO Linked data should match text 1`] = `
 
 exports[`AMP Story Page SEO OG description 1`] = `"A test STY for social embeds"`;
 
-exports[`AMP Story Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_kyrgyz/CF33/test/_63734035_socialmedia.jpg"`;
+exports[`AMP Story Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_kyrgyz/CF33/test/_63734035_socialmedia.jpg"`;
 
 exports[`AMP Story Page SEO OG image alt 1`] = `"social media"`;
 
@@ -324,7 +324,7 @@ exports[`AMP Story Page SEO Twitter description 1`] = `"A test STY for social em
 
 exports[`AMP Story Page SEO Twitter image alt 1`] = `"social media"`;
 
-exports[`AMP Story Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_kyrgyz/CF33/test/_63734035_socialmedia.jpg"`;
+exports[`AMP Story Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_kyrgyz/CF33/test/_63734035_socialmedia.jpg"`;
 
 exports[`AMP Story Page SEO Twitter site 1`] = `"@bbckyrgyz"`;
 

--- a/ws-nextjs-app/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.ts.snap
@@ -288,7 +288,7 @@ exports[`Canonical Story Page SEO Linked data should match text 1`] = `
 
 exports[`Canonical Story Page SEO OG description 1`] = `"A test STY for social embeds"`;
 
-exports[`Canonical Story Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_kyrgyz/CF33/test/_63734035_socialmedia.jpg"`;
+exports[`Canonical Story Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_kyrgyz/CF33/test/_63734035_socialmedia.jpg"`;
 
 exports[`Canonical Story Page SEO OG image alt 1`] = `"social media"`;
 
@@ -314,7 +314,7 @@ exports[`Canonical Story Page SEO Twitter description 1`] = `"A test STY for soc
 
 exports[`Canonical Story Page SEO Twitter image alt 1`] = `"social media"`;
 
-exports[`Canonical Story Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_kyrgyz/CF33/test/_63734035_socialmedia.jpg"`;
+exports[`Canonical Story Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_kyrgyz/CF33/test/_63734035_socialmedia.jpg"`;
 
 exports[`Canonical Story Page SEO Twitter site 1`] = `"@bbckyrgyz"`;
 

--- a/ws-nextjs-app/integration/pages/storyPage/mundo/__snapshots__/amp.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/storyPage/mundo/__snapshots__/amp.test.ts.snap
@@ -299,7 +299,7 @@ exports[`AMP Story Page SEO Linked data should match text 1`] = `
 
 exports[`AMP Story Page SEO OG description 1`] = `"Tras casi cuatro años de desacuerdos y negociaciones, este viernes Reino Unido dejará formalmente la Unión Europea. ¿Qué cambios supone esto para quienes quieran hacer turismo, estudiar o trabajar en Reino Unido?"`;
 
-exports[`AMP Story Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_mundo/17D42/production/_110620679_gettyimages-542984918.jpg"`;
+exports[`AMP Story Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_mundo/17D42/production/_110620679_gettyimages-542984918.jpg"`;
 
 exports[`AMP Story Page SEO OG image alt 1`] = `"A person holding a union jack umbrella in front of Big Ben"`;
 
@@ -325,7 +325,7 @@ exports[`AMP Story Page SEO Twitter description 1`] = `"Tras casi cuatro años d
 
 exports[`AMP Story Page SEO Twitter image alt 1`] = `"A person holding a union jack umbrella in front of Big Ben"`;
 
-exports[`AMP Story Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_mundo/17D42/production/_110620679_gettyimages-542984918.jpg"`;
+exports[`AMP Story Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_mundo/17D42/production/_110620679_gettyimages-542984918.jpg"`;
 
 exports[`AMP Story Page SEO Twitter site 1`] = `"@bbcmundo"`;
 

--- a/ws-nextjs-app/integration/pages/storyPage/mundo/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/storyPage/mundo/__snapshots__/canonical.test.ts.snap
@@ -329,7 +329,7 @@ exports[`Canonical Story Page SEO Linked data should match text 1`] = `
 
 exports[`Canonical Story Page SEO OG description 1`] = `"Tras casi cuatro años de desacuerdos y negociaciones, este viernes Reino Unido dejará formalmente la Unión Europea. ¿Qué cambios supone esto para quienes quieran hacer turismo, estudiar o trabajar en Reino Unido?"`;
 
-exports[`Canonical Story Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_mundo/17D42/production/_110620679_gettyimages-542984918.jpg"`;
+exports[`Canonical Story Page SEO OG image 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_mundo/17D42/production/_110620679_gettyimages-542984918.jpg"`;
 
 exports[`Canonical Story Page SEO OG image alt 1`] = `"A person holding a union jack umbrella in front of Big Ben"`;
 
@@ -355,7 +355,7 @@ exports[`Canonical Story Page SEO Twitter description 1`] = `"Tras casi cuatro a
 
 exports[`Canonical Story Page SEO Twitter image alt 1`] = `"A person holding a union jack umbrella in front of Big Ben"`;
 
-exports[`Canonical Story Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1024/branded_mundo/17D42/production/_110620679_gettyimages-542984918.jpg"`;
+exports[`Canonical Story Page SEO Twitter image src 1`] = `"https://ichef.bbci.co.uk/news/1200/branded_mundo/17D42/production/_110620679_gettyimages-542984918.jpg"`;
 
 exports[`Canonical Story Page SEO Twitter site 1`] = `"@bbcmundo"`;
 

--- a/ws-nextjs-app/pages/api/[service]/og/utils/index.ts
+++ b/ws-nextjs-app/pages/api/[service]/og/utils/index.ts
@@ -81,7 +81,7 @@ export const extractArticleData = ({
   const defaultImage = getDefaultImage(service);
 
   const brandedImage = promoImage?.locator
-    ? getBrandedImage(promoImage?.locator, service)
+    ? getBrandedImage({ locator: promoImage?.locator, service })
     : defaultImage;
 
   const isInTopStories = Boolean(
@@ -127,7 +127,7 @@ export const extractLiveData = ({
     ?.join('/');
 
   const brandedImage = imageLocator
-    ? getBrandedImage(imageLocator, service)
+    ? getBrandedImage({ locator: imageLocator, service })
     : defaultImage;
 
   return {


### PR DESCRIPTION
Resolves JIRA: [WS-2218](https://bbc.atlassian.net/browse/WS-2218)

Summary
======
Sets og:image for Article type pages to have width of 1200px to allow usage in google discover

max-image-preview:large is already in [code](https://github.com/bbc/simorgh/blob/37e9dcc640d2efdb1f53a7f0ec930d5042be5b30/src/app/components/Metadata/index.tsx#L201)

Code changes
======
- Change getBrandedImage function to accept custom width
- Update getBrandedImage to new function parameters
- Update snapshots

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._


[WS-2218]: https://bbc.atlassian.net/browse/WS-2218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ