### PR TITLE
WS-1382 Add magyarul and romania as a service to the /ws/languages navigation

### DIFF
--- a/src/app/lib/config/services/ws.ts
+++ b/src/app/lib/config/services/ws.ts
@@ -565,6 +565,12 @@ export const service: DefaultServiceConfig = {
             lang: 'cy',
           },
           {
+            id: 'magyarul',
+            href: 'https://www.bbc.com/magyarul',
+            label: 'BBC News Magyarul',
+            lang: 'hu',
+          },
+          {
             id: 'kyrgyz',
             href: 'https://www.bbc.com/kyrgyz',
             label: 'BBC News Кыргыз Кызматы',
@@ -581,6 +587,12 @@ export const service: DefaultServiceConfig = {
             id: 'polska',
             href: 'https://www.bbc.com/polska',
             label: 'BBC News Polska',
+          },
+          {
+            id: 'romania',
+            href: 'https://www.bbc.com/romania',
+            label: 'BBC News România',
+            lang: 'ro',
           },
           {
             id: 'russian',


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-1382

Summary
======

Adds magyarul and romania as a service to the /ws/languages navigation

Code changes
======
- Adds magyarul and romania config to `config/sercices/ws.ts`

Testing
======
1. Visit http://localhost:7081/ws/languages and see Magyarul and Romania listed under the Europe drop down

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
