### PR TITLE
[WS-2917]: Simorgh's static /public/images assets not being deployed

### DIFF
--- a/ws-nextjs-app/scripts/copyPublicFiles.ts
+++ b/ws-nextjs-app/scripts/copyPublicFiles.ts
@@ -4,13 +4,13 @@
 /* 
   Copies /public folder from root directory into the Next.js standalone output folder.
   This allows Next.js to serve the files in /public (namely sw.js and manifest.json).
-  Excludes the fonts and images directories as these are served from the CDN/static-assets route.
+  Excludes the fonts directory as these are served from the CDN/static-assets route.
 */
 
 import { cpSync } from 'fs';
 import { basename } from 'path';
 
-const EXCLUDED_DIRS = ['fonts', 'images'];
+const EXCLUDED_DIRS = ['fonts'];
 
 const PUBLIC_SRC = '../public';
 const PUBLIC_DEST = 'build/standalone/ws-nextjs-app/public';


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2917

# Summary

The Next.js standalone build was excluding the `images` directory when copying public files, so static images in `/public/images` were not being deployed.

# Code changes

- Remove `images` from `EXCLUDED_DIRS` in `ws-nextjs-app/scripts/copyPublicFiles.ts` so the directory is now copied into the build output.

# Testing

1. Deploy to a test environment and verify static images served from the `/public/images` path load correctly, more specifically:
1.1. Visit any `hindi` article on Test env.
1.2. Click on `Save for Later`
1.3. The sign-in prompt should display the [globe image asset](https://github.com/bbc/simorgh/blob/latest/public/images/news_desktop_image.webp).

## Useful Links

- [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
- [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
