### PR TITLE
FIX: Use World Service assets for AMP manifest checks

### DIFF
--- a/scripts/ampHtmlValidator/checkManifest/index.js
+++ b/scripts/ampHtmlValidator/checkManifest/index.js
@@ -14,16 +14,16 @@ const getManifestFile = async url => {
 };
 
 export default async () => {
-  const publicServiceUrls = [
-    '/news/articles/c0eg99qjynvo.amp',
-    '/sport/tennis/articles/cedlgl4lj23o.amp',
-    '/newsround/articles/cp8v6lm0ek6o.amp',
-    '/cymrufyw/erthyglau/c4ge78ry9dmo.amp',
-    '/naidheachdan/sgeulachdan/c3w14wqg1x8o.amp',
+  const worldServiceUrls = [
+    '/portuguese/articles/cqj1e51p7vko.amp',
+    '/afrique/articles/c3vynyl4n73o.amp',
+    '/japanese/articles/cn4d0275848o.amp',
+    '/magyarul/articles/cde4lnjr2e2o.amp',
+    '/burmese/articles/c4gyd17q651o.amp',
   ];
 
   const testResults = await Promise.all(
-    publicServiceUrls.map(async url => {
+    worldServiceUrls.map(async url => {
       const [, service] = url.split('/');
       const liveManifestFile = await getManifestFile(
         `https://www.bbc.co.uk${url}`,


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
AMP manifest validation checks are failing. This is due to Webcore redirect PS AMP traffic to Canonical where
the URL for the manifest is different from local Simorgh

Code changes
======
- Use World Service assets for manifest file validation.

BEFORE
<img width="1727" height="225" alt="Screenshot 2026-06-26 at 15 56 09" src="https://github.com/user-attachments/assets/b2d3cd70-b685-462e-9b01-c6f66efa406f" />

AFTER
<img width="971" height="161" alt="Screenshot 2026-06-26 at 16 36 58" src="https://github.com/user-attachments/assets/860617ce-814a-45a2-bb96-94b614eabc82" />


Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
