### PR TITLE
Ws 2854 translations for topic discovery component

### DIFF
--- a/src/app/components/TopicDiscovery/index.styles.ts
+++ b/src/app/components/TopicDiscovery/index.styles.ts
@@ -114,19 +114,19 @@ const styles = {
       height: `${pixelsToRem(12)}rem`,
       background: `linear-gradient(to right, ${palette.GREY_4} 0%, ${palette.GREY_3} 100%)`,
     }),
-  skeletonMoreFromLinkContainer: () =>
+  skeletonMoreAboutLinkContainer: () =>
     css({
       display: 'flex',
       alignItems: 'flex-start',
     }),
-  skeletonMoreFromLink: ({ palette, spacings }: Theme) =>
+  skeletonMoreAboutLink: ({ palette, spacings }: Theme) =>
     css({
       height: `${pixelsToRem(18)}rem`,
       width: '40%',
       marginTop: `${spacings.DOUBLE}rem`,
       background: `linear-gradient(to right, ${palette.GREY_4} 0%, ${palette.GREY_3} 100%)`,
     }),
-  moreFromLink: ({ palette, spacings, fontSizes, fontVariants }: Theme) =>
+  moreAboutLink: ({ palette, spacings, fontSizes, fontVariants }: Theme) =>
     css({
       ...fontVariants.sansBold,
       ...fontSizes.longPrimer,

--- a/src/app/components/TopicDiscovery/index.test.tsx
+++ b/src/app/components/TopicDiscovery/index.test.tsx
@@ -114,7 +114,7 @@ describe('TopicDiscovery', () => {
     expect(screen.getByText(secondTopicTitle)).toBeInTheDocument();
   });
 
-  it('renders the "more from" section with topic title last if {topic} is last in the config', async () => {
+  it('renders the "more about" section with topic title last if {topic} is last in the config', async () => {
     const config: ServiceConfig = { ...portugueseConfig.default };
     render(
       <ServiceContext.Provider value={config}>
@@ -122,9 +122,9 @@ describe('TopicDiscovery', () => {
       </ServiceContext.Provider>,
     );
     // Wait for loading to finish and the link to appear
-    const moreFrom = await screen.findByTestId('topic-discovery-more-from');
-    expect(moreFrom).toHaveTextContent(
-      `Mais de ${topicTagsFixture[0].topicName}`,
+    const moreAbout = await screen.findByTestId('topic-discovery-more-from');
+    expect(moreAbout).toHaveTextContent(
+      `Mais sobre ${topicTagsFixture[0].topicName}`,
     );
   });
 
@@ -142,7 +142,7 @@ describe('TopicDiscovery', () => {
     );
   });
 
-  it('renders the "more from" section with fallback if moreFrom is missing', async () => {
+  it('renders the "more about" section with fallback if moreAbout is missing', async () => {
     const portugueseTranslations = {
       ...portugueseConfig.default.translations,
       topicDiscovery: { heading: 'Discover more' },
@@ -156,7 +156,7 @@ describe('TopicDiscovery', () => {
         <TopicDiscovery topics={topicTagsFixture} />
       </ServiceContext.Provider>,
     );
-    await screen.findByText(`More from ${topicTagsFixture[0].topicName}`);
+    await screen.findByText(`More about ${topicTagsFixture[0].topicName}`);
   });
 
   it('should not render when there are no valid topics', () => {
@@ -179,7 +179,7 @@ describe('TopicDiscovery', () => {
     });
 
     expect(
-      await screen.findByText('Falha ao carregar. Tente novamente mais tarde.'),
+      await screen.findByText('Falha ao carregar. Tente novamente'),
     ).toBeInTheDocument();
 
     expect(
@@ -280,7 +280,7 @@ describe('TopicDiscovery', () => {
         groupTracker,
         itemTracker: {
           type: 'topic-discovery-more-from-link',
-          text: `Mais de ${topicTagsFixture[0].topicName}`,
+          text: `Mais sobre ${topicTagsFixture[0].topicName}`,
           resourceId: topicTagsFixture[0].topicId,
         },
       });

--- a/src/app/components/TopicDiscovery/index.test.tsx
+++ b/src/app/components/TopicDiscovery/index.test.tsx
@@ -122,13 +122,13 @@ describe('TopicDiscovery', () => {
       </ServiceContext.Provider>,
     );
     // Wait for loading to finish and the link to appear
-    const moreAbout = await screen.findByTestId('topic-discovery-more-from');
+    const moreAbout = await screen.findByTestId('topic-discovery-more-about');
     expect(moreAbout).toHaveTextContent(
       `Mais sobre ${topicTagsFixture[0].topicName}`,
     );
   });
 
-  it('renders the "more from" section with topic title first if {topic} is first in the config', async () => {
+  it('renders the "more about" section with topic title first if {topic} is first in the config', async () => {
     const config: ServiceConfig = { ...turkceConfig.default };
     render(
       <ServiceContext.Provider value={config}>
@@ -136,8 +136,8 @@ describe('TopicDiscovery', () => {
       </ServiceContext.Provider>,
     );
     // Wait for loading to finish and the link to appear
-    const moreFrom = await screen.findByTestId('topic-discovery-more-from');
-    expect(moreFrom).toHaveTextContent(
+    const moreAbout = await screen.findByTestId('topic-discovery-more-about');
+    expect(moreAbout).toHaveTextContent(
       `${topicTagsFixture[0].topicName} hakkında daha fazla`,
     );
   });
@@ -183,7 +183,7 @@ describe('TopicDiscovery', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.queryByTestId('topic-discovery-more-from'),
+      screen.queryByTestId('topic-discovery-more-about'),
     ).not.toBeInTheDocument();
   });
 
@@ -257,7 +257,7 @@ describe('TopicDiscovery', () => {
       clickTrackerSpy.mockRestore();
     });
 
-    it('should call useClickTrackerHandler when "more from" link is clicked', async () => {
+    it('should call useClickTrackerHandler when "more about" link is clicked', async () => {
       const mockClickHandler = jest.fn();
       jest
         .spyOn(clickTracking, 'default')
@@ -267,19 +267,19 @@ describe('TopicDiscovery', () => {
         service: 'portuguese',
       });
 
-      const moreFromLink = await screen.findByTestId(
-        'topic-discovery-more-from',
+      const moreAboutLink = await screen.findByTestId(
+        'topic-discovery-more-about',
       );
 
-      fireEvent.click(moreFromLink);
+      fireEvent.click(moreAboutLink);
 
       expect(mockClickHandler).toHaveBeenCalledTimes(1);
 
       expect(clickTracking.default).toHaveBeenCalledWith({
-        componentName: 'topic-discovery-more-from-link',
+        componentName: 'topic-discovery-more-about-link',
         groupTracker,
         itemTracker: {
-          type: 'topic-discovery-more-from-link',
+          type: 'topic-discovery-more-about-link',
           text: `Mais sobre ${topicTagsFixture[0].topicName}`,
           resourceId: topicTagsFixture[0].topicId,
         },

--- a/src/app/components/TopicDiscovery/index.tsx
+++ b/src/app/components/TopicDiscovery/index.tsx
@@ -61,11 +61,11 @@ const TopicDiscovery = ({
     componentName: 'topic-discovery-fetch-error-message',
   });
 
-  const moreFromLinkClickTracker = useClickTrackerHandler({
-    componentName: 'topic-discovery-more-from-link',
+  const moreAboutLinkClickTracker = useClickTrackerHandler({
+    componentName: 'topic-discovery-more-about-link',
     groupTracker,
     itemTracker: {
-      type: 'topic-discovery-more-from-link',
+      type: 'topic-discovery-more-about-link',
       text: currentTopic
         ? moreAboutTopic.replace('{topic}', currentTopic.topicName)
         : undefined,
@@ -124,8 +124,8 @@ const TopicDiscovery = ({
                       </div>
                     ))}
                   </div>
-                  <div css={styles.skeletonMoreFromLinkContainer}>
-                    <div css={styles.skeletonMoreFromLink} aria-hidden />
+                  <div css={styles.skeletonMoreAboutLinkContainer}>
+                    <div css={styles.skeletonMoreAboutLink} aria-hidden />
                   </div>
                 </>
               );
@@ -155,10 +155,10 @@ const TopicDiscovery = ({
                     }}
                   />
                   <a
-                    css={styles.moreFromLink}
+                    css={styles.moreAboutLink}
                     href={selectedTopic.topicUrl}
-                    data-testid="topic-discovery-more-from"
-                    {...moreFromLinkClickTracker}
+                    data-testid="topic-discovery-more-about"
+                    {...moreAboutLinkClickTracker}
                   >
                     {moreAboutTopic.replace('{topic}', selectedTopic.topicName)}
                   </a>

--- a/src/app/components/TopicDiscovery/index.tsx
+++ b/src/app/components/TopicDiscovery/index.tsx
@@ -27,7 +27,7 @@ const TopicDiscovery = ({
   const { translations } = use(ServiceContext);
   const {
     heading = 'Discover more',
-    moreFromTopic = 'More from {topic}',
+    moreAboutTopic = 'More about {topic}',
     fetchErrorMessage = 'Failed to load. Please try again later.',
   } = translations.topicDiscovery || {};
 
@@ -67,7 +67,7 @@ const TopicDiscovery = ({
     itemTracker: {
       type: 'topic-discovery-more-from-link',
       text: currentTopic
-        ? moreFromTopic.replace('{topic}', currentTopic.topicName)
+        ? moreAboutTopic.replace('{topic}', currentTopic.topicName)
         : undefined,
       resourceId: currentTopic?.topicId,
     },
@@ -160,7 +160,7 @@ const TopicDiscovery = ({
                     data-testid="topic-discovery-more-from"
                     {...moreFromLinkClickTracker}
                   >
-                    {moreFromTopic.replace('{topic}', selectedTopic.topicName)}
+                    {moreAboutTopic.replace('{topic}', selectedTopic.topicName)}
                   </a>
                 </>
               );

--- a/src/app/lib/config/services/afaanoromoo.ts
+++ b/src/app/lib/config/services/afaanoromoo.ts
@@ -79,7 +79,7 @@ export const service: DefaultServiceConfig = {
       home: 'Oduu',
       topicDiscovery: {
         heading: 'Dabalata argadhu',
-        moreFromTopic: '{topic} irraa dabalata',
+        moreAboutTopic: '{topic} irratti dabalata',
         fetchErrorMessage: "Wal bira hin geenye. Mee irra deebi'ii yaali",
       },
       currentPage: 'Fuula kan ammaa',

--- a/src/app/lib/config/services/afaanoromoo.ts
+++ b/src/app/lib/config/services/afaanoromoo.ts
@@ -77,6 +77,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'Hunda ilaali',
       home: 'Oduu',
+      topicDiscovery: {
+        heading: 'Dabalata argadhu',
+        moreFromTopic: '{topic} irraa dabalata',
+        fetchErrorMessage: "Wal bira hin geenye. Mee irra deebi'ii yaali",
+      },
       currentPage: 'Fuula kan ammaa',
       skipLinkText: 'Qabiyyeetti darbi',
       relatedContent: 'Odeessa kana irratti dabalata',

--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -83,7 +83,7 @@ export const service: DefaultServiceConfig = {
       home: 'Accueil',
       topicDiscovery: {
         heading: 'Découvrir davantage',
-        moreFromTopic: 'Plus de {topic}',
+        moreAboutTopic: 'Plus sur {topic}',
         fetchErrorMessage: 'Échec du chargement. Veuillez réessayer',
       },
       continueReading: 'Continuer la lecture',

--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -81,6 +81,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'Tout voir',
       home: 'Accueil',
+      topicDiscovery: {
+        heading: 'Découvrir davantage',
+        moreFromTopic: 'Plus de {topic}',
+        fetchErrorMessage: 'Échec du chargement. Veuillez réessayer',
+      },
       continueReading: 'Continuer la lecture',
       currentPage: 'Page en cours',
       skipLinkText: 'Aller au contenu',

--- a/src/app/lib/config/services/amharic.ts
+++ b/src/app/lib/config/services/amharic.ts
@@ -76,6 +76,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'ሁሉንም ይመልከቱ',
       home: 'ዜና',
+      topicDiscovery: {
+        heading: 'ተጨማሪ ያግኙ',
+        moreFromTopic: 'ከ {topic} ተጨማሪ',
+        fetchErrorMessage: 'መጫን አልተሳካም። እባክዎ እንደገና ይሞክሩ',
+      },
       currentPage: 'መነሻ ገፅ',
       skipLinkText: 'ወደ ዋናው ይዘት ይለፉ',
       relatedContent: 'በዚህ ዘገባ ላይ ተጨማሪ መረጃ',

--- a/src/app/lib/config/services/amharic.ts
+++ b/src/app/lib/config/services/amharic.ts
@@ -78,7 +78,7 @@ export const service: DefaultServiceConfig = {
       home: 'ዜና',
       topicDiscovery: {
         heading: 'ተጨማሪ ያግኙ',
-        moreFromTopic: 'ከ {topic} ተጨማሪ',
+        moreAboutTopic: 'ስለ {topic} ተጨማሪ',
         fetchErrorMessage: 'መጫን አልተሳካም። እባክዎ እንደገና ይሞክሩ',
       },
       currentPage: 'መነሻ ገፅ',

--- a/src/app/lib/config/services/arabic.ts
+++ b/src/app/lib/config/services/arabic.ts
@@ -82,6 +82,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'المزيد',
       home: 'الرئيسية',
+      topicDiscovery: {
+        heading: 'اكتشف المزيد',
+        moreFromTopic: 'المزيد من {topic}',
+        fetchErrorMessage: 'فشل في التحميل. يرجى المحاولة مرة أخرى',
+      },
       continueReading: 'واصل القراءة',
       currentPage: 'الصفحة الحالية',
       skipLinkText: 'إذهب الى المحتوى',

--- a/src/app/lib/config/services/arabic.ts
+++ b/src/app/lib/config/services/arabic.ts
@@ -84,7 +84,7 @@ export const service: DefaultServiceConfig = {
       home: 'الرئيسية',
       topicDiscovery: {
         heading: 'اكتشف المزيد',
-        moreFromTopic: 'المزيد من {topic}',
+        moreAboutTopic: 'المزيد عن {topic}',
         fetchErrorMessage: 'فشل في التحميل. يرجى المحاولة مرة أخرى',
       },
       continueReading: 'واصل القراءة',

--- a/src/app/lib/config/services/azeri.ts
+++ b/src/app/lib/config/services/azeri.ts
@@ -84,7 +84,8 @@ export const service: DefaultServiceConfig = {
       topicDiscovery: {
         heading: 'Daha çox kəşf et',
         moreFromTopic: '{topic} üzrə daha çox',
-        fetchErrorMessage: 'Yükləmə uğursuz oldu. Zəhmət olmasa yenidən yoxlayın',
+        fetchErrorMessage:
+          'Yükləmə uğursuz oldu. Zəhmət olmasa yenidən yoxlayın',
       },
       currentPage: 'Hazırda olduğunuz səhifə',
       skipLinkText: 'Mətnə keçid',

--- a/src/app/lib/config/services/azeri.ts
+++ b/src/app/lib/config/services/azeri.ts
@@ -81,6 +81,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'Hamısına baxın',
       home: 'Xəbərlər',
+      topicDiscovery: {
+        heading: 'Daha çox kəşf et',
+        moreFromTopic: '{topic} üzrə daha çox',
+        fetchErrorMessage: 'Yükləmə uğursuz oldu. Zəhmət olmasa yenidən yoxlayın',
+      },
       currentPage: 'Hazırda olduğunuz səhifə',
       skipLinkText: 'Mətnə keçid',
       relatedContent: 'Bu barədə daha geniş',

--- a/src/app/lib/config/services/azeri.ts
+++ b/src/app/lib/config/services/azeri.ts
@@ -83,7 +83,7 @@ export const service: DefaultServiceConfig = {
       home: 'Xəbərlər',
       topicDiscovery: {
         heading: 'Daha çox kəşf et',
-        moreFromTopic: '{topic} üzrə daha çox',
+        moreAboutTopic: '{topic} haqqında daha çox',
         fetchErrorMessage:
           'Yükləmə uğursuz oldu. Zəhmət olmasa yenidən yoxlayın',
       },

--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -84,8 +84,8 @@ export const service: DefaultServiceConfig = {
       seeAll: 'সবগুলো খবর দেখুন',
       home: 'মূলপাতা',
       topicDiscovery: {
-        heading: 'আরো আবিষ্কার করুন',
-        moreFromTopic: '{topic} থেকে আরো',
+        heading: 'আরও আবিষ্কার করুন',
+        moreFromTopic: '{topic} থেকে আরও',
         fetchErrorMessage: 'লোড হতে ব্যর্থ। অনুগ্রহ করে আবার চেষ্টা করুন',
       },
       currentPage: 'বর্তমান পেজ',

--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -85,7 +85,7 @@ export const service: DefaultServiceConfig = {
       home: 'মূলপাতা',
       topicDiscovery: {
         heading: 'আরও আবিষ্কার করুন',
-        moreFromTopic: '{topic} থেকে আরও',
+        moreAboutTopic: '{topic} সম্পর্কে আরও',
         fetchErrorMessage: 'লোড হতে ব্যর্থ। অনুগ্রহ করে আবার চেষ্টা করুন',
       },
       currentPage: 'বর্তমান পেজ',

--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -83,6 +83,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'সবগুলো খবর দেখুন',
       home: 'মূলপাতা',
+      topicDiscovery: {
+        heading: 'আরো আবিষ্কার করুন',
+        moreFromTopic: '{topic} থেকে আরো',
+        fetchErrorMessage: 'লোড হতে ব্যর্থ। অনুগ্রহ করে আবার চেষ্টা করুন',
+      },
       currentPage: 'বর্তমান পেজ',
       skipLinkText: 'সরাসরি কনটেন্টে যান',
       relatedContent: 'এই খবর নিয়ে আরো তথ্য',

--- a/src/app/lib/config/services/burmese.ts
+++ b/src/app/lib/config/services/burmese.ts
@@ -79,7 +79,7 @@ export const service: DefaultServiceConfig = {
       home: 'ပင်မစာမျက်နှာ',
       topicDiscovery: {
         heading: 'ပိုမိုရှာဖွေပါ',
-        moreFromTopic: '{topic} မှ ပိုမို',
+        moreAboutTopic: '{topic} အကြောင်း ပိုမို',
         fetchErrorMessage: 'ဖွင့်ရန် မအောင်မြင်ပါ။ ထပ်ကြိုးစားပါ',
       },
       currentPage: 'လက်ရှိကြည့်နေသော စာမျက်နှာ',

--- a/src/app/lib/config/services/burmese.ts
+++ b/src/app/lib/config/services/burmese.ts
@@ -77,6 +77,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'အားလုံးကြည့်ရန်',
       home: 'ပင်မစာမျက်နှာ',
+      topicDiscovery: {
+        heading: 'ပိုမိုရှာဖွေပါ',
+        moreFromTopic: '{topic} မှ ပိုမို',
+        fetchErrorMessage: 'ဖွင့်ရန် မအောင်မြင်ပါ။ ထပ်ကြိုးစားပါ',
+      },
       currentPage: 'လက်ရှိကြည့်နေသော စာမျက်နှာ',
       skipLinkText: 'အကြောင်းအရာများဆီ ကျော်သွားရန်',
       relatedContent: 'ဒီသတင်းနဲ့ ပတ်သက်သမျှ',

--- a/src/app/lib/config/services/dari.ts
+++ b/src/app/lib/config/services/dari.ts
@@ -64,7 +64,7 @@ export const service: DefaultServiceConfig = {
       home: 'صفحه اول',
       topicDiscovery: {
         heading: 'بیشتر کشف کنید',
-        moreFromTopic: 'بیشتر از {topic}',
+        moreAboutTopic: 'بیشتر درباره {topic}',
         fetchErrorMessage: 'بارگیری ناموفق بود. لطفاً دوباره تلاش کنید',
       },
       currentPage: 'صفحه فعلی',

--- a/src/app/lib/config/services/dari.ts
+++ b/src/app/lib/config/services/dari.ts
@@ -62,6 +62,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'بیشتر',
       home: 'صفحه اول',
+      topicDiscovery: {
+        heading: 'بیشتر کشف کنید',
+        moreFromTopic: 'بیشتر از {topic}',
+        fetchErrorMessage: 'بارگیری ناموفق بود. لطفاً دوباره تلاش کنید',
+      },
       currentPage: 'صفحه فعلی',
       skipLinkText: 'مشاهده محتوا',
       relatedContent: 'مطالب مرتبط',

--- a/src/app/lib/config/services/gahuza.ts
+++ b/src/app/lib/config/services/gahuza.ts
@@ -75,6 +75,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'Raba vyose',
       home: `Urupapuro rw'itangiriro`,
+      topicDiscovery: {
+        heading: 'Menya byinshi',
+        moreFromTopic: 'Ibindi biturutse kuri {topic}',
+        fetchErrorMessage: 'Ntibyashoboye gufunguka. Ongera ugerageze',
+      },
       continueReading: 'Komeza usome',
       currentPage: 'Uru rupapuro',
       skipLinkText: 'Simbira ku birimwo',

--- a/src/app/lib/config/services/gahuza.ts
+++ b/src/app/lib/config/services/gahuza.ts
@@ -77,7 +77,7 @@ export const service: DefaultServiceConfig = {
       home: `Urupapuro rw'itangiriro`,
       topicDiscovery: {
         heading: 'Menya byinshi',
-        moreFromTopic: 'Ibindi biturutse kuri {topic}',
+        moreAboutTopic: 'Ibindi bijyanye na {topic}',
         fetchErrorMessage: 'Ntibyashoboye gufunguka. Ongera ugerageze',
       },
       continueReading: 'Komeza usome',

--- a/src/app/lib/config/services/gujarati.ts
+++ b/src/app/lib/config/services/gujarati.ts
@@ -82,7 +82,7 @@ export const service: DefaultServiceConfig = {
       home: 'સમાચાર',
       topicDiscovery: {
         heading: 'વધુ શોધો',
-        moreFromTopic: '{topic}માંથી વધુ',
+        moreAboutTopic: '{topic} વિશે વધુ',
         fetchErrorMessage: 'લોડ કરવામાં નિષ્ફળ. કૃપા કરીને ફરી પ્રયાસ કરો',
       },
       continueReading: 'આગળ વાંચો',

--- a/src/app/lib/config/services/gujarati.ts
+++ b/src/app/lib/config/services/gujarati.ts
@@ -80,6 +80,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'વધુ વાંચો',
       home: 'સમાચાર',
+      topicDiscovery: {
+        heading: 'વધુ શોધો',
+        moreFromTopic: '{topic}માંથી વધુ',
+        fetchErrorMessage: 'લોડ કરવામાં નિષ્ફળ. કૃપા કરીને ફરી પ્રયાસ કરો',
+      },
       continueReading: 'આગળ વાંચો',
       currentPage: 'વર્તમાન પેજ',
       skipLinkText: 'કન્ટેન્ટ પર જાવ',

--- a/src/app/lib/config/services/hausa.ts
+++ b/src/app/lib/config/services/hausa.ts
@@ -84,7 +84,7 @@ export const service: DefaultServiceConfig = {
       continueReading: 'Ci gaba da karantawa',
       topicDiscovery: {
         heading: 'Gano ƙari',
-        moreFromTopic: 'Ƙari daga {topic}',
+        moreAboutTopic: 'Ƙari game da {topic}',
         fetchErrorMessage: 'An kasa lodawa. Da fatan a sake gwadawa',
       },
       currentPage: 'Shafin da ake ciki',

--- a/src/app/lib/config/services/hausa.ts
+++ b/src/app/lib/config/services/hausa.ts
@@ -83,10 +83,9 @@ export const service: DefaultServiceConfig = {
       home: 'Labaran Duniya',
       continueReading: 'Ci gaba da karantawa',
       topicDiscovery: {
-        heading: 'Gano ƙarin abubuwa',
-        moreFromTopic: 'Ƙarin labarai daga {topic}',
-        fetchErrorMessage:
-          'An kasa lodawa. Da fatan za a sake gwadawa daga baya.',
+        heading: 'Gano ƙari',
+        moreFromTopic: 'Ƙari daga {topic}',
+        fetchErrorMessage: 'An kasa lodawa. Da fatan a sake gwadawa',
       },
       currentPage: 'Shafin da ake ciki',
       skipLinkText: 'Tsallaka zuwa abubuwan da ke ciki',

--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -82,6 +82,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'सब देखें',
       home: 'होम पेज',
+      topicDiscovery: {
+        heading: 'और जानें',
+        moreFromTopic: '{topic} से अधिक',
+        fetchErrorMessage: 'लोड नहीं हो पाया। कृपया पुनः प्रयास करें',
+      },
       continueReading: 'पढ़ना जारी रखें',
       currentPage: 'मौजूदा पन्ना',
       skipLinkText: 'सामग्री को स्किप करें',

--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -84,7 +84,7 @@ export const service: DefaultServiceConfig = {
       home: 'होम पेज',
       topicDiscovery: {
         heading: 'और जानें',
-        moreFromTopic: '{topic} से अधिक',
+        moreAboutTopic: '{topic} के बारे में अधिक',
         fetchErrorMessage: 'लोड नहीं हो पाया। कृपया पुनः प्रयास करें',
       },
       continueReading: 'पढ़ना जारी रखें',

--- a/src/app/lib/config/services/igbo.ts
+++ b/src/app/lib/config/services/igbo.ts
@@ -80,7 +80,12 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'Lee ha niile',
       home: 'Akụkọ',
-      continueReading: 'Gaa n’ihu gụọ',
+      topicDiscovery: {
+        heading: 'Chọpụta karịa',
+        moreFromTopic: 'Ndị ọzọ si {topic}',
+        fetchErrorMessage: 'Ọ dara ịgbakwunye. Biko nwalee ọzọ',
+      },
+      continueReading: "Gaa n'ihu gụọ",
       currentPage: 'Peegi ị nọ ugbua',
       skipLinkText: 'Wụga n’ọdịnaya',
       relatedContent: "Ihe ndị ọzọ n'akụkọ a",

--- a/src/app/lib/config/services/igbo.ts
+++ b/src/app/lib/config/services/igbo.ts
@@ -82,7 +82,7 @@ export const service: DefaultServiceConfig = {
       home: 'Akụkọ',
       topicDiscovery: {
         heading: 'Chọpụta karịa',
-        moreFromTopic: 'Ndị ọzọ si {topic}',
+        moreAboutTopic: 'Ihe ndị ọzọzọ banyere {topic}',
         fetchErrorMessage: 'Ọ dara ịgbakwunye. Biko nwalee ọzọ',
       },
       continueReading: "Gaa n'ihu gụọ",

--- a/src/app/lib/config/services/indonesia.ts
+++ b/src/app/lib/config/services/indonesia.ts
@@ -85,8 +85,8 @@ export const service: DefaultServiceConfig = {
       home: 'Berita',
       topicDiscovery: {
         heading: 'Temukan lebih banyak',
-        moreFromTopic: 'Selengkapnya dari {topic}',
-        fetchErrorMessage: 'Gagal memuat. Silakan coba lagi nanti.',
+        moreFromTopic: 'Lebih banyak dari {topic}',
+        fetchErrorMessage: 'Gagal memuat. Silakan coba lagi',
       },
       currentPage: 'Halaman saat ini',
       skipLinkText: 'Langsung ke konten',

--- a/src/app/lib/config/services/indonesia.ts
+++ b/src/app/lib/config/services/indonesia.ts
@@ -85,7 +85,7 @@ export const service: DefaultServiceConfig = {
       home: 'Berita',
       topicDiscovery: {
         heading: 'Temukan lebih banyak',
-        moreFromTopic: 'Lebih banyak dari {topic}',
+        moreAboutTopic: 'Lebih banyak tentang {topic}',
         fetchErrorMessage: 'Gagal memuat. Silakan coba lagi',
       },
       currentPage: 'Halaman saat ini',

--- a/src/app/lib/config/services/japanese.ts
+++ b/src/app/lib/config/services/japanese.ts
@@ -65,7 +65,7 @@ export const service: DefaultServiceConfig = {
       home: 'ホーム',
       topicDiscovery: {
         heading: 'もっと見る',
-        moreFromTopic: '{topic} のその他',
+        moreAboutTopic: '{topic} についてもっと',
         fetchErrorMessage: '読み込みに失敗しました。もう一度お試しください',
       },
       currentPage: '現在のページ',

--- a/src/app/lib/config/services/japanese.ts
+++ b/src/app/lib/config/services/japanese.ts
@@ -63,6 +63,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: '全ての記事を見る',
       home: 'ホーム',
+      topicDiscovery: {
+        heading: 'もっと見る',
+        moreFromTopic: '{topic} のその他',
+        fetchErrorMessage: '読み込みに失敗しました。もう一度お試しください',
+      },
       currentPage: '現在のページ',
       skipLinkText: 'コンテンツへ移動',
       relatedContent: '関連コンテンツ',

--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -64,7 +64,7 @@ export const service: DefaultServiceConfig = {
       home: '홈',
       topicDiscovery: {
         heading: '더 알아보기',
-        moreFromTopic: '{topic} 더 보기',
+        moreAboutTopic: '{topic}에 대해 더 보기',
         fetchErrorMessage: '로드하지 못했습니다. 다시 시도해 주세요',
       },
       currentPage: '현재 페이지',

--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -62,6 +62,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: '모든 기사 보기',
       home: '홈',
+      topicDiscovery: {
+        heading: '더 알아보기',
+        moreFromTopic: '{topic} 더 보기',
+        fetchErrorMessage: '로드하지 못했습니다. 다시 시도해 주세요',
+      },
       currentPage: '현재 페이지',
       skipLinkText: '내용 보기',
       relatedContent: '관련 기사 더 보기',

--- a/src/app/lib/config/services/kyrgyz.ts
+++ b/src/app/lib/config/services/kyrgyz.ts
@@ -83,7 +83,7 @@ export const service: DefaultServiceConfig = {
       home: 'Башталгыч бет',
       topicDiscovery: {
         heading: 'Көбүрөөк табуу',
-        moreFromTopic: '{topic} боюнча көбүрөөк',
+        moreAboutTopic: '{topic} жөнүндө көбүрөөк',
         fetchErrorMessage: 'Жүктөө ишке ашкан жок. Кайра аракет кылыңыз',
       },
       currentPage: 'Ачылып турган баракча',

--- a/src/app/lib/config/services/kyrgyz.ts
+++ b/src/app/lib/config/services/kyrgyz.ts
@@ -81,6 +81,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'Баарын көрүү',
       home: 'Башталгыч бет',
+      topicDiscovery: {
+        heading: 'Көбүрөөк табуу',
+        moreFromTopic: '{topic} боюнча көбүрөөк',
+        fetchErrorMessage: 'Жүктөө ишке ашкан жок. Кайра аракет кылыңыз',
+      },
       currentPage: 'Ачылып турган баракча',
       skipLinkText: 'Сайтка өтүү',
       relatedContent: 'Тема боюнча башка макалалар',

--- a/src/app/lib/config/services/magyarul.ts
+++ b/src/app/lib/config/services/magyarul.ts
@@ -67,7 +67,7 @@ export const service: DefaultServiceConfig = {
       home: 'Főoldal',
       topicDiscovery: {
         heading: 'Továbbiak felfedezése',
-        moreFromTopic: 'Továbbiak innen: {topic}',
+        moreAboutTopic: 'Több a {topic} témáról',
         fetchErrorMessage: 'Nem sikerült betölteni. Kérjük, próbálja újra',
       },
       currentPage: 'Jelenlegi oldal',

--- a/src/app/lib/config/services/magyarul.ts
+++ b/src/app/lib/config/services/magyarul.ts
@@ -65,6 +65,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'Összes megtekintése',
       home: 'Főoldal',
+      topicDiscovery: {
+        heading: 'Továbbiak felfedezése',
+        moreFromTopic: 'Továbbiak innen: {topic}',
+        fetchErrorMessage: 'Nem sikerült betölteni. Kérjük, próbálja újra',
+      },
       currentPage: 'Jelenlegi oldal',
       skipLinkText: 'Ugrás a tartalomra',
       relatedContent: 'Kapcsolódó tartalom',

--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -80,7 +80,7 @@ export const service: DefaultServiceConfig = {
       continueReading: 'पुढे वाचा',
       topicDiscovery: {
         heading: 'अधिक शोधा',
-        moreFromTopic: '{topic} पासून अधिक',
+        moreFromTopic: '{topic} मधील अधिक',
         fetchErrorMessage: 'लोड करण्यात अयशस्वी. कृपया पुन्हा प्रयत्न करा',
       },
       currentPage: 'सध्याचे पान',

--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -80,7 +80,7 @@ export const service: DefaultServiceConfig = {
       continueReading: 'पुढे वाचा',
       topicDiscovery: {
         heading: 'अधिक शोधा',
-        moreFromTopic: '{topic} मधील अधिक',
+        moreAboutTopic: '{topic} बद्दल अधिक',
         fetchErrorMessage: 'लोड करण्यात अयशस्वी. कृपया पुन्हा प्रयत्न करा',
       },
       currentPage: 'सध्याचे पान',

--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -80,9 +80,8 @@ export const service: DefaultServiceConfig = {
       continueReading: 'पुढे वाचा',
       topicDiscovery: {
         heading: 'अधिक शोधा',
-        moreFromTopic: '{topic} मधील अधिक',
-        fetchErrorMessage:
-          'लोड करण्यात अयशस्वी. कृपया नंतर पुन्हा प्रयत्न करा.',
+        moreFromTopic: '{topic} पासून अधिक',
+        fetchErrorMessage: 'लोड करण्यात अयशस्वी. कृपया पुन्हा प्रयत्न करा',
       },
       currentPage: 'सध्याचे पान',
       skipLinkText: 'थेट मजकुरावर जा',

--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -108,7 +108,7 @@ export const service: DefaultServiceConfig = {
       home: 'Página de inicio',
       topicDiscovery: {
         heading: 'Descubre más',
-        moreFromTopic: 'Más de {topic}',
+        moreAboutTopic: 'Más sobre {topic}',
         fetchErrorMessage: 'Error al cargar. Inténtalo de nuevo',
       },
       continueReading: 'Continuar leyendo',

--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -106,6 +106,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'Ver todo',
       home: 'Página de inicio',
+      topicDiscovery: {
+        heading: 'Descubre más',
+        moreFromTopic: 'Más de {topic}',
+        fetchErrorMessage: 'Error al cargar. Inténtalo de nuevo',
+      },
       continueReading: 'Continuar leyendo',
       currentPage: 'Página actual',
       skipLinkText: 'Ir al contenido',

--- a/src/app/lib/config/services/nepali.ts
+++ b/src/app/lib/config/services/nepali.ts
@@ -65,7 +65,7 @@ export const service: DefaultServiceConfig = {
       home: 'होमपेज',
       topicDiscovery: {
         heading: 'थप पत्ता लगाउनुहोस्',
-        moreFromTopic: '{topic} बाट थप',
+        moreAboutTopic: '{topic} बारे थप',
         fetchErrorMessage: 'लोड गर्न असफल भयो। कृपया फेरि प्रयास गर्नुहोस्',
       },
       currentPage: 'अहिलेको पृष्ठ',

--- a/src/app/lib/config/services/nepali.ts
+++ b/src/app/lib/config/services/nepali.ts
@@ -63,6 +63,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'सबै हेर्नुहोस्',
       home: 'होमपेज',
+      topicDiscovery: {
+        heading: 'थप पत्ता लगाउनुहोस्',
+        moreFromTopic: '{topic} बाट थप',
+        fetchErrorMessage: 'लोड गर्न असफल भयो। कृपया फेरि प्रयास गर्नुहोस्',
+      },
       currentPage: 'अहिलेको पृष्ठ',
       skipLinkText: 'सामग्रीमा जानुहोस्',
       relatedContent: 'सम्बन्धित सामग्री',

--- a/src/app/lib/config/services/pashto.ts
+++ b/src/app/lib/config/services/pashto.ts
@@ -67,7 +67,7 @@ export const service: DefaultServiceConfig = {
       home: 'کور پاڼه',
       topicDiscovery: {
         heading: 'نور وپلټئ',
-        moreFromTopic: '{topic} څخه نور',
+        moreAboutTopic: 'د {topic} په اړه نور',
         fetchErrorMessage: 'پورته کول ناکام شول. مهرباني وکړئ بیا هڅه وکړئ',
       },
       currentPage: 'اوسنۍ پاڼه',

--- a/src/app/lib/config/services/pashto.ts
+++ b/src/app/lib/config/services/pashto.ts
@@ -67,7 +67,7 @@ export const service: DefaultServiceConfig = {
       home: 'کور پاڼه',
       topicDiscovery: {
         heading: 'نور وپلټئ',
-        moreFromTopic: '{topic} ځخه نور',
+        moreFromTopic: '{topic} څخه نور',
         fetchErrorMessage: 'پورته کول ناکام شول. مهرباني وکړئ بیا هڅه وکړئ',
       },
       currentPage: 'اوسنۍ پاڼه',

--- a/src/app/lib/config/services/pashto.ts
+++ b/src/app/lib/config/services/pashto.ts
@@ -65,6 +65,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'ټول وګورئ',
       home: 'کور پاڼه',
+      topicDiscovery: {
+        heading: 'نور وپلټئ',
+        moreFromTopic: '{topic} ځخه نور',
+        fetchErrorMessage: 'پورته کول ناکام شول. مهرباني وکړئ بیا هڅه وکړئ',
+      },
       currentPage: 'اوسنۍ پاڼه',
       skipLinkText: 'مطلب ته ورشئ',
       relatedContent: 'ورته مطالب',

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -85,7 +85,7 @@ export const service: DefaultServiceConfig = {
       home: 'صفحه اول',
       topicDiscovery: {
         heading: 'بیشتر کشف کنید',
-        moreFromTopic: 'بیشتر از {topic}',
+        moreAboutTopic: 'بیشتر درباره {topic}',
         fetchErrorMessage: 'بارگذاری ناموفق بود. لطفاً دوباره تلاش کنید',
       },
       continueReading: 'ادامه مطلب را بخوانید',

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -83,6 +83,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'بیشتر',
       home: 'صفحه اول',
+      topicDiscovery: {
+        heading: 'بیشتر کشف کنید',
+        moreFromTopic: 'بیشتر از {topic}',
+        fetchErrorMessage: 'بارگذاری ناموفق بود. لطفاً دوباره تلاش کنید',
+      },
       continueReading: 'ادامه مطلب را بخوانید',
       currentPage: 'صفحه فعلی',
       skipLinkText: 'مشاهده محتوا',

--- a/src/app/lib/config/services/pidgin.ts
+++ b/src/app/lib/config/services/pidgin.ts
@@ -65,7 +65,7 @@ export const service: DefaultServiceConfig = {
       home: 'Home',
       topicDiscovery: {
         heading: 'Discover more',
-        moreFromTopic: 'More from {topic}',
+        moreAboutTopic: 'More about {topic}',
         fetchErrorMessage: 'E no load. Abeg try again',
       },
       continueReading: 'Kontinu to dey read',

--- a/src/app/lib/config/services/pidgin.ts
+++ b/src/app/lib/config/services/pidgin.ts
@@ -63,6 +63,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'See everitin',
       home: 'Home',
+      topicDiscovery: {
+        heading: 'Discover more',
+        moreFromTopic: 'More from {topic}',
+        fetchErrorMessage: 'E no load. Abeg try again',
+      },
       continueReading: 'Kontinu to dey read',
       currentPage: 'Page where you dey',
       skipLinkText: 'Waka go wetin de inside',

--- a/src/app/lib/config/services/polska.ts
+++ b/src/app/lib/config/services/polska.ts
@@ -69,6 +69,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'Zobacz wszystkie',
       home: 'Strona główna',
+      topicDiscovery: {
+        heading: 'Odkryj więcej',
+        moreFromTopic: 'Więcej od {topic}',
+        fetchErrorMessage: 'Nie udało się załadować. Spróbuj ponownie',
+      },
       currentPage: 'Strona bieżąca',
       skipLinkText: 'Przejdź do treści',
       relatedContent: 'Powiązane treści',

--- a/src/app/lib/config/services/polska.ts
+++ b/src/app/lib/config/services/polska.ts
@@ -71,7 +71,7 @@ export const service: DefaultServiceConfig = {
       home: 'Strona główna',
       topicDiscovery: {
         heading: 'Odkryj więcej',
-        moreFromTopic: 'Więcej od {topic}',
+        moreFromTopic: 'Więcej z {topic}',
         fetchErrorMessage: 'Nie udało się załadować. Spróbuj ponownie',
       },
       currentPage: 'Strona bieżąca',

--- a/src/app/lib/config/services/polska.ts
+++ b/src/app/lib/config/services/polska.ts
@@ -71,7 +71,7 @@ export const service: DefaultServiceConfig = {
       home: 'Strona główna',
       topicDiscovery: {
         heading: 'Odkryj więcej',
-        moreFromTopic: 'Więcej z {topic}',
+        moreAboutTopic: 'Więcej o {topic}',
         fetchErrorMessage: 'Nie udało się załadować. Spróbuj ponownie',
       },
       currentPage: 'Strona bieżąca',

--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -108,7 +108,7 @@ export const service: DefaultServiceConfig = {
       continueReading: 'Continue lendo',
       topicDiscovery: {
         heading: 'Descubra mais',
-        moreFromTopic: 'Mais de {topic}',
+        moreAboutTopic: 'Mais sobre {topic}',
         fetchErrorMessage: 'Falha ao carregar. Tente novamente',
       },
       currentPage: 'Página atual',

--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -109,7 +109,7 @@ export const service: DefaultServiceConfig = {
       topicDiscovery: {
         heading: 'Descubra mais',
         moreFromTopic: 'Mais de {topic}',
-        fetchErrorMessage: 'Falha ao carregar. Tente novamente mais tarde.',
+        fetchErrorMessage: 'Falha ao carregar. Tente novamente',
       },
       currentPage: 'Página atual',
       skipLinkText: 'Vá para o conteúdo',

--- a/src/app/lib/config/services/punjabi.ts
+++ b/src/app/lib/config/services/punjabi.ts
@@ -64,7 +64,7 @@ export const service: DefaultServiceConfig = {
       home: 'ਹੋਮ ਪੇਜ',
       topicDiscovery: {
         heading: 'ਹੋਰ ਖੋਜੋ',
-        moreFromTopic: '{topic} ਤੋਂ ਹੋਰ',
+        moreAboutTopic: '{topic} ਬਾਰੇ ਹੋਰ',
         fetchErrorMessage: 'ਲੋਡ ਨਹੀਂ ਹੋਇਆ। ਕਿਰਪਾ ਕਰਕੇ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ',
       },
       continueReading: 'ਅੱਗੇ ਪੜ੍ਹੋ',

--- a/src/app/lib/config/services/punjabi.ts
+++ b/src/app/lib/config/services/punjabi.ts
@@ -62,6 +62,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'ਸਭ ਦੋਖੇ',
       home: 'ਹੋਮ ਪੇਜ',
+      topicDiscovery: {
+        heading: 'ਹੋਰ ਖੋਜੋ',
+        moreFromTopic: '{topic} ਤੋਂ ਹੋਰ',
+        fetchErrorMessage: 'ਲੋਡ ਨਹੀਂ ਹੋਇਆ। ਕਿਰਪਾ ਕਰਕੇ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ',
+      },
       continueReading: 'ਅੱਗੇ ਪੜ੍ਹੋ',
       currentPage: 'ਮੌਜੂਦਾ ਪੇਜ',
       skipLinkText: `ਸਮੱਗਰੀ 'ਤੇ ਜਾਓ`,

--- a/src/app/lib/config/services/romania.ts
+++ b/src/app/lib/config/services/romania.ts
@@ -68,6 +68,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'Vezi integral',
       home: 'Știri',
+      topicDiscovery: {
+        heading: 'Descoperă mai mult',
+        moreFromTopic: 'Mai mult de la {topic}',
+        fetchErrorMessage: 'Încărcarea a eșuat. Vă rugăm să încercați din nou',
+      },
       currentPage: 'Pagina curentă',
       skipLinkText: 'Acces direct la conținut',
       relatedContent: 'Articole similare',

--- a/src/app/lib/config/services/romania.ts
+++ b/src/app/lib/config/services/romania.ts
@@ -70,7 +70,7 @@ export const service: DefaultServiceConfig = {
       home: 'Știri',
       topicDiscovery: {
         heading: 'Descoperă mai mult',
-        moreFromTopic: 'Mai mult de la {topic}',
+        moreAboutTopic: 'Mai mult despre {topic}',
         fetchErrorMessage: 'Încărcarea a eșuat. Vă rugăm să încercați din nou',
       },
       currentPage: 'Pagina curentă',

--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -118,7 +118,7 @@ export const service: DefaultServiceConfig = {
       ...headerFooterTranslations,
       topicDiscovery: {
         heading: 'Узнать больше',
-        moreFromTopic: 'Больше по теме {topic}',
+        moreAboutTopic: 'Больше о {topic}',
         fetchErrorMessage: 'Не удалось загрузить. Пожалуйста, попробуйте снова',
       },
       sport: {

--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -116,6 +116,11 @@ export const service: DefaultServiceConfig = {
       },
       ...russianUkrainianSharedTranslations,
       ...headerFooterTranslations,
+      topicDiscovery: {
+        heading: 'Узнать больше',
+        moreFromTopic: 'Больше от {topic}',
+        fetchErrorMessage: 'Не удалось загрузить. Пожалуйста, попробуйте снова',
+      },
       sport: {
         matchSummary: 'Обзор матча',
         assists: 'Голевые передачи',

--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -118,7 +118,7 @@ export const service: DefaultServiceConfig = {
       ...headerFooterTranslations,
       topicDiscovery: {
         heading: 'Узнать больше',
-        moreFromTopic: 'Больше от {topic}',
+        moreFromTopic: 'Больше по теме {topic}',
         fetchErrorMessage: 'Не удалось загрузить. Пожалуйста, попробуйте снова',
       },
       sport: {

--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -145,7 +145,7 @@ export const service: SerbianConfig = {
       home: 'Glavna stranica',
       topicDiscovery: {
         heading: 'Otkrijte više',
-        moreFromTopic: 'Više od {topic}',
+        moreFromTopic: 'Više iz {topic}',
         fetchErrorMessage: 'Učitavanje nije uspelo. Pokušajte ponovo',
       },
       currentPage: 'Otvorena stranica',

--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -145,9 +145,8 @@ export const service: SerbianConfig = {
       home: 'Glavna stranica',
       topicDiscovery: {
         heading: 'Otkrijte više',
-        moreFromTopic: 'Više iz {topic}',
-        fetchErrorMessage:
-          'Učitavanje nije uspelo. Molimo pokušajte ponovo kasnije.',
+        moreFromTopic: 'Više od {topic}',
+        fetchErrorMessage: 'Učitavanje nije uspelo. Pokušajte ponovo',
       },
       currentPage: 'Otvorena stranica',
       skipLinkText: 'Pređite na sadržaj',
@@ -619,9 +618,8 @@ export const service: SerbianConfig = {
       home: 'Главна страница',
       topicDiscovery: {
         heading: 'Откријте више',
-        moreFromTopic: 'Више из {topic}',
-        fetchErrorMessage:
-          'Учитавање није успело. Молимо покушајте поново касније.',
+        moreFromTopic: 'Више од {topic}',
+        fetchErrorMessage: 'Учитавање није успело. Покушајте поново',
       },
       currentPage: 'Отворена страница',
       skipLinkText: 'Пређите на садржај',

--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -618,7 +618,7 @@ export const service: SerbianConfig = {
       home: 'Главна страница',
       topicDiscovery: {
         heading: 'Откријте више',
-        moreFromTopic: 'Више од {topic}',
+        moreFromTopic: 'Више из {topic}',
         fetchErrorMessage: 'Учитавање није успело. Покушајте поново',
       },
       currentPage: 'Отворена страница',

--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -145,7 +145,7 @@ export const service: SerbianConfig = {
       home: 'Glavna stranica',
       topicDiscovery: {
         heading: 'Otkrijte više',
-        moreFromTopic: 'Više iz {topic}',
+        moreAboutTopic: 'Više o {topic}',
         fetchErrorMessage: 'Učitavanje nije uspelo. Pokušajte ponovo',
       },
       currentPage: 'Otvorena stranica',
@@ -618,7 +618,7 @@ export const service: SerbianConfig = {
       home: 'Главна страница',
       topicDiscovery: {
         heading: 'Откријте више',
-        moreFromTopic: 'Више из {topic}',
+        moreAboutTopic: 'Више о {topic}',
         fetchErrorMessage: 'Учитавање није успело. Покушајте поново',
       },
       currentPage: 'Отворена страница',

--- a/src/app/lib/config/services/sinhala.ts
+++ b/src/app/lib/config/services/sinhala.ts
@@ -79,7 +79,7 @@ export const service: DefaultServiceConfig = {
       home: 'ප්‍රධාන පුවත්',
       topicDiscovery: {
         heading: 'තවත් සොයා බලන්න',
-        moreFromTopic: '{topic} තවත්',
+        moreAboutTopic: '{topic} ගැන තවත්',
         fetchErrorMessage: 'පූරණය අසාර්ථකයි. කරුණාකර නැවත උත්සාහ කරන්න',
       },
       currentPage: 'දැන් සිටින පිටුව',

--- a/src/app/lib/config/services/sinhala.ts
+++ b/src/app/lib/config/services/sinhala.ts
@@ -77,6 +77,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'සියල්ල දැකගන්න',
       home: 'ප්‍රධාන පුවත්',
+      topicDiscovery: {
+        heading: 'තවත් සොයා බලන්න',
+        moreFromTopic: '{topic} තවත්',
+        fetchErrorMessage: 'පූරණය අසාර්ථකයි. කරුණාකර නැවත උත්සාහ කරන්න',
+      },
       currentPage: 'දැන් සිටින පිටුව',
       skipLinkText: 'අන්තර්ගතයට පිවිසෙන්න',
       relatedContent: 'මේ පුවතට සම්බන්ධ තවත් විස්තර',

--- a/src/app/lib/config/services/somali.ts
+++ b/src/app/lib/config/services/somali.ts
@@ -84,7 +84,8 @@ export const service: DefaultServiceConfig = {
       topicDiscovery: {
         heading: 'Baro wax badan',
         moreFromTopic: 'Wax dheeraad ah oo ka socda {topic}',
-        fetchErrorMessage: 'Ku shubiddu waa fashilantay. Fadlan isku day mar kale',
+        fetchErrorMessage:
+          'Ku shubiddu waa fashilantay. Fadlan isku day mar kale',
       },
       continueReading: 'Sii Akhri',
       currentPage: 'Bogga hadda',

--- a/src/app/lib/config/services/somali.ts
+++ b/src/app/lib/config/services/somali.ts
@@ -81,6 +81,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'Arag dhammaan',
       home: 'War',
+      topicDiscovery: {
+        heading: 'Baro wax badan',
+        moreFromTopic: 'Wax dheeraad ah oo ka socda {topic}',
+        fetchErrorMessage: 'Ku shubiddu waa fashilantay. Fadlan isku day mar kale',
+      },
       continueReading: 'Sii Akhri',
       currentPage: 'Bogga hadda',
       skipLinkText: 'U gudub qaybta macluumaadka',

--- a/src/app/lib/config/services/somali.ts
+++ b/src/app/lib/config/services/somali.ts
@@ -83,7 +83,7 @@ export const service: DefaultServiceConfig = {
       home: 'War',
       topicDiscovery: {
         heading: 'Baro wax badan',
-        moreFromTopic: 'Wax dheeraad ah oo ka socda {topic}',
+        moreAboutTopic: 'Wax dheeraad ah oo ku saabsan {topic}',
         fetchErrorMessage:
           'Ku shubiddu waa fashilantay. Fadlan isku day mar kale',
       },

--- a/src/app/lib/config/services/swahili.ts
+++ b/src/app/lib/config/services/swahili.ts
@@ -82,6 +82,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'Tazama zote',
       home: 'Habari',
+      topicDiscovery: {
+        heading: 'Gundua zaidi',
+        moreFromTopic: 'Zaidi kutoka {topic}',
+        fetchErrorMessage: 'Imeshindwa kupakia. Tafadhali jaribu tena',
+      },
       continueReading: 'Soma zaidi',
       currentPage: 'Ukurasa uliopo ',
       skipLinkText: 'Ruka hadi maelezo',

--- a/src/app/lib/config/services/swahili.ts
+++ b/src/app/lib/config/services/swahili.ts
@@ -84,7 +84,7 @@ export const service: DefaultServiceConfig = {
       home: 'Habari',
       topicDiscovery: {
         heading: 'Gundua zaidi',
-        moreFromTopic: 'Zaidi kutoka {topic}',
+        moreAboutTopic: 'Zaidi kuhusu {topic}',
         fetchErrorMessage: 'Imeshindwa kupakia. Tafadhali jaribu tena',
       },
       continueReading: 'Soma zaidi',

--- a/src/app/lib/config/services/tamil.ts
+++ b/src/app/lib/config/services/tamil.ts
@@ -81,6 +81,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'அனைத்தும் பார்க்க',
       home: 'முகப்பு',
+      topicDiscovery: {
+        heading: 'மேலும் அறிக',
+        moreFromTopic: '{topic} இருந்து மேலும்',
+        fetchErrorMessage: 'ஏற்ற முடியவில்லை. மீண்டும் முயற்சிக்கவும்',
+      },
       continueReading: 'தொடர்ந்து படியுங்கள்',
       currentPage: 'தற்போதுள்ள பக்கம்',
       skipLinkText: 'உள்ளடக்கத்துக்குத் தாண்டிச் செல்க',

--- a/src/app/lib/config/services/tamil.ts
+++ b/src/app/lib/config/services/tamil.ts
@@ -83,7 +83,7 @@ export const service: DefaultServiceConfig = {
       home: 'முகப்பு',
       topicDiscovery: {
         heading: 'மேலும் அறிக',
-        moreFromTopic: '{topic} இருந்து மேலும்',
+        moreAboutTopic: '{topic} பற்றி மேலும்',
         fetchErrorMessage: 'ஏற்ற முடியவில்லை. மீண்டும் முயற்சிக்கவும்',
       },
       continueReading: 'தொடர்ந்து படியுங்கள்',

--- a/src/app/lib/config/services/telugu.ts
+++ b/src/app/lib/config/services/telugu.ts
@@ -64,7 +64,7 @@ export const service: DefaultServiceConfig = {
       home: 'హోమ్',
       topicDiscovery: {
         heading: 'ఇంకా తెలుసుకోండి',
-        moreFromTopic: '{topic} నుండి మరింత',
+        moreAboutTopic: '{topic} గురించి మరింత',
         fetchErrorMessage: 'లోడ్ విఫలమైంది. దయచేసి మళ్ళీ ప్రయత్నించండి',
       },
       continueReading: 'ఇంకా చదవండి',

--- a/src/app/lib/config/services/telugu.ts
+++ b/src/app/lib/config/services/telugu.ts
@@ -62,6 +62,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'అన్నీ చూడండి',
       home: 'హోమ్',
+      topicDiscovery: {
+        heading: 'ఇంకా తెలుసుకోండి',
+        moreFromTopic: '{topic} నుండి మరింత',
+        fetchErrorMessage: 'లోడ్ విఫలమైంది. దయచేసి మళ్ళీ ప్రయత్నించండి',
+      },
       continueReading: 'ఇంకా చదవండి',
       currentPage: 'ప్రస్తుత పేజీ',
       skipLinkText: 'కంటెంట్‌కు వెళ్లండి',

--- a/src/app/lib/config/services/thai.ts
+++ b/src/app/lib/config/services/thai.ts
@@ -62,6 +62,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'ดูทั้งหมด',
       home: 'หน้าแรก',
+      topicDiscovery: {
+        heading: 'ค้นพบเพิ่มเติม',
+        moreFromTopic: 'เพิ่มเติมจาก {topic}',
+        fetchErrorMessage: 'โหลดไม่สำเร็จ กรุณาลองอีกครั้ง',
+      },
       currentPage: 'หน้าปัจจุบัน',
       skipLinkText: 'ข้ามไปยังเนื้อหา',
       relatedContent: 'อ่านเรื่องที่เกี่ยวข้อง',

--- a/src/app/lib/config/services/thai.ts
+++ b/src/app/lib/config/services/thai.ts
@@ -64,7 +64,7 @@ export const service: DefaultServiceConfig = {
       home: 'หน้าแรก',
       topicDiscovery: {
         heading: 'ค้นพบเพิ่มเติม',
-        moreFromTopic: 'เพิ่มเติมจาก {topic}',
+        moreAboutTopic: 'เพิ่มเติมเกี่ยวกับ {topic}',
         fetchErrorMessage: 'โหลดไม่สำเร็จ กรุณาลองอีกครั้ง',
       },
       currentPage: 'หน้าปัจจุบัน',

--- a/src/app/lib/config/services/tigrinya.ts
+++ b/src/app/lib/config/services/tigrinya.ts
@@ -79,6 +79,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'ንኹሉ ርኣዩ',
       home: 'መእተዊ ገጽ',
+      topicDiscovery: {
+        heading: 'ተወሳኺ መርምር',
+        moreFromTopic: 'ተወሳኺ ካብ {topic}',
+        fetchErrorMessage: 'ምጫን ኣይከኣለን። እባክካ ዳግም ፈትን',
+      },
       continueReading: 'ምንባብ ቀጽል',
       currentPage: 'ዘለኹሞ ገጽ',
       skipLinkText: 'ናብቲ ትሕዝቶ ቀጽሉ',

--- a/src/app/lib/config/services/tigrinya.ts
+++ b/src/app/lib/config/services/tigrinya.ts
@@ -81,7 +81,7 @@ export const service: DefaultServiceConfig = {
       home: 'መእተዊ ገጽ',
       topicDiscovery: {
         heading: 'ተወሳኺ መርምር',
-        moreFromTopic: 'ተወሳኺ ካብ {topic}',
+        moreAboutTopic: 'ተወሳኩ ብዛዕባ {topic}',
         fetchErrorMessage: 'ምጫን ኣይከኣለን። እባክካ ዳግም ፈትን',
       },
       continueReading: 'ምንባብ ቀጽል',

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -68,7 +68,7 @@ export const service: DefaultServiceConfig = {
       continueReading: 'Okumaya devam edin',
       topicDiscovery: {
         heading: 'Daha fazlasını keşfet',
-        moreFromTopic: '{topic} hakkında daha fazla',
+        moreAboutTopic: '{topic} hakkında daha fazla',
         fetchErrorMessage: 'Yüklenemedi. Lütfen daha sonra tekrar deneyin',
       },
       currentPage: 'Bulunduğunuz sayfa',

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -68,8 +68,8 @@ export const service: DefaultServiceConfig = {
       continueReading: 'Okumaya devam edin',
       topicDiscovery: {
         heading: 'Daha fazlasını keşfet',
-        moreFromTopic: "{topic}'den daha fazlası",
-        fetchErrorMessage: 'Yüklenemedi. Lütfen tekrar deneyin',
+        moreFromTopic: '{topic} hakkında daha fazla',
+        fetchErrorMessage: 'Yüklenemedi. Lütfen daha sonra tekrar deneyin',
       },
       currentPage: 'Bulunduğunuz sayfa',
       skipLinkText: 'İçeriğe götür',

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -68,8 +68,8 @@ export const service: DefaultServiceConfig = {
       continueReading: 'Okumaya devam edin',
       topicDiscovery: {
         heading: 'Daha fazlasını keşfet',
-        moreFromTopic: '{topic} hakkında daha fazla',
-        fetchErrorMessage: 'Yüklenemedi. Lütfen daha sonra tekrar deneyin.',
+        moreFromTopic: "{topic}'den daha fazlası",
+        fetchErrorMessage: 'Yüklenemedi. Lütfen tekrar deneyin',
       },
       currentPage: 'Bulunduğunuz sayfa',
       skipLinkText: 'İçeriğe götür',

--- a/src/app/lib/config/services/ukrainian.ts
+++ b/src/app/lib/config/services/ukrainian.ts
@@ -80,7 +80,7 @@ const baseServiceConfig = {
     home: 'Головна',
     topicDiscovery: {
       heading: 'Дізнатися більше',
-      moreFromTopic: 'Більше від {topic}',
+      moreFromTopic: 'Більше з теми {topic}',
       fetchErrorMessage: 'Не вдалося завантажити. Спробуйте ще раз',
     },
     currentPage: 'Поточна сторінка',

--- a/src/app/lib/config/services/ukrainian.ts
+++ b/src/app/lib/config/services/ukrainian.ts
@@ -80,7 +80,7 @@ const baseServiceConfig = {
     home: 'Головна',
     topicDiscovery: {
       heading: 'Дізнатися більше',
-      moreFromTopic: 'Більше з теми {topic}',
+      moreAboutTopic: 'Більше про {topic}',
       fetchErrorMessage: 'Не вдалося завантажити. Спробуйте ще раз',
     },
     currentPage: 'Поточна сторінка',

--- a/src/app/lib/config/services/ukrainian.ts
+++ b/src/app/lib/config/services/ukrainian.ts
@@ -78,6 +78,11 @@ const baseServiceConfig = {
     },
     seeAll: 'Подивитись все',
     home: 'Головна',
+    topicDiscovery: {
+      heading: 'Дізнатися більше',
+      moreFromTopic: 'Більше від {topic}',
+      fetchErrorMessage: 'Не вдалося завантажити. Спробуйте ще раз',
+    },
     currentPage: 'Поточна сторінка',
     skipLinkText: 'Перейти до змісту',
     moreOnThis: '',

--- a/src/app/lib/config/services/urdu.ts
+++ b/src/app/lib/config/services/urdu.ts
@@ -84,7 +84,7 @@ export const service: DefaultServiceConfig = {
       home: 'صفحۂ اول',
       topicDiscovery: {
         heading: 'مزید دریافت کریں',
-        moreFromTopic: '{topic} سے مزید',
+        moreAboutTopic: '{topic} کے بارے میں مزید',
         fetchErrorMessage: 'لوڈ نہیں ہو سکا۔ براہ کرم دوبارہ کوشش کریں',
       },
       continueReading: 'پڑھتے رہیے',

--- a/src/app/lib/config/services/urdu.ts
+++ b/src/app/lib/config/services/urdu.ts
@@ -82,6 +82,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'سب دیکھیں',
       home: 'صفحۂ اول',
+      topicDiscovery: {
+        heading: 'مزید دریافت کریں',
+        moreFromTopic: '{topic} سے مزید',
+        fetchErrorMessage: 'لوڈ نہیں ہو سکا۔ براہ کرم دوبارہ کوشش کریں',
+      },
       continueReading: 'پڑھتے رہیے',
       currentPage: 'موجودہ صفحہ',
       skipLinkText: 'مواد پر جائیں',

--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -75,6 +75,11 @@ const defaultCyrillicConfig = {
     },
     seeAll: 'Ҳаммасини кўринг',
     home: 'Бош саҳифа',
+    topicDiscovery: {
+      heading: 'Кўпроқ кашф қилинг',
+      moreFromTopic: '{topic}дан кўпроқ',
+      fetchErrorMessage: 'Юклаб бўлмади. Илтимос, яна уриниб кўринг',
+    },
     currentPage: 'Жорий саҳифа',
     skipLinkText: 'Саҳифага ўтиш',
     relatedContent: 'Мавзуга алоқадор',
@@ -481,6 +486,11 @@ export const service: UzbekConfig = {
       },
       seeAll: 'Hammasini ko‘ring',
       home: 'Bosh sahifa',
+      topicDiscovery: {
+        heading: "Ko'proq kashf qiling",
+        moreFromTopic: "{topic}dan ko'proq",
+        fetchErrorMessage: "Yuklab bo'lmadi. Iltimos, yana urinib ko'ring",
+      },
       currentPage: 'Joriy sahifa',
       skipLinkText: 'Sahifaga o‘tish',
       relatedContent: 'Mavzuga aloqador',

--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -77,7 +77,7 @@ const defaultCyrillicConfig = {
     home: 'Бош саҳифа',
     topicDiscovery: {
       heading: 'Кўпроқ кашф қилинг',
-      moreFromTopic: '{topic}дан кўпроқ',
+      moreAboutTopic: '{topic} ҳақида кӯпроқ',
       fetchErrorMessage: 'Юклаб бўлмади. Илтимос, яна уриниб кўринг',
     },
     currentPage: 'Жорий саҳифа',
@@ -488,7 +488,7 @@ export const service: UzbekConfig = {
       home: 'Bosh sahifa',
       topicDiscovery: {
         heading: "Ko'proq kashf qiling",
-        moreFromTopic: "{topic}dan ko'proq",
+        moreAboutTopic: "{topic} haqida ko'proq",
         fetchErrorMessage: "Yuklab bo'lmadi. Iltimos, yana urinib ko'ring",
       },
       currentPage: 'Joriy sahifa',

--- a/src/app/lib/config/services/vietnamese.ts
+++ b/src/app/lib/config/services/vietnamese.ts
@@ -66,7 +66,7 @@ export const service: DefaultServiceConfig = {
       home: 'Tin chính',
       topicDiscovery: {
         heading: 'Khám phá thêm',
-        moreFromTopic: 'Thêm từ {topic}',
+        moreAboutTopic: 'Thêm về {topic}',
         fetchErrorMessage: 'Tải không thành công. Vui lòng thử lại',
       },
       currentPage: 'Trang hiện nay',

--- a/src/app/lib/config/services/vietnamese.ts
+++ b/src/app/lib/config/services/vietnamese.ts
@@ -64,6 +64,11 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'Xem tất cả',
       home: 'Tin chính',
+      topicDiscovery: {
+        heading: 'Khám phá thêm',
+        moreFromTopic: 'Thêm từ {topic}',
+        fetchErrorMessage: 'Tải không thành công. Vui lòng thử lại',
+      },
       currentPage: 'Trang hiện nay',
       skipLinkText: 'Bỏ qua để xem nội dung',
       relatedContent: 'Tin liên quan',

--- a/src/app/lib/config/services/yoruba.ts
+++ b/src/app/lib/config/services/yoruba.ts
@@ -81,7 +81,7 @@ export const service: DefaultServiceConfig = {
         moreFromTopic: 'Díẹ̀ síi láti {topic}',
         fetchErrorMessage: 'Ó kuna láti ṣàkójọpọ̀. Jọ̀wọ́ gbìyànjú lẹ́ẹ̀kan síi',
       },
-      currentPage: 'Ojú ewé to wà yìi',
+      currentPage: 'Ojú ewé to wà yìí',
       skipLinkText: 'Fò kọjá sí nnkan tí ó wà nínú rẹ̀',
       relatedContent: 'Àwọn afíkun lórí ìròyìn yìí',
       relatedTopics: 'Àwọn Àkórí Tójọra',

--- a/src/app/lib/config/services/yoruba.ts
+++ b/src/app/lib/config/services/yoruba.ts
@@ -78,7 +78,7 @@ export const service: DefaultServiceConfig = {
       home: 'Ìròyìn',
       topicDiscovery: {
         heading: 'Ṣawari síi',
-        moreFromTopic: 'Díẹ̀ síi láti {topic}',
+        moreAboutTopic: 'Díẹ̀ síì nípa {topic}',
         fetchErrorMessage: 'Ó kuna láti ṣàkójọpọ̀. Jọ̀wọ́ gbìyànjú lẹ́ẹ̀kan síi',
       },
       currentPage: 'Ojú ewé to wà yìí',

--- a/src/app/lib/config/services/yoruba.ts
+++ b/src/app/lib/config/services/yoruba.ts
@@ -76,7 +76,12 @@ export const service: DefaultServiceConfig = {
       },
       seeAll: 'Wo gbogbo ẹ̀',
       home: 'Ìròyìn',
-      currentPage: 'Ojú ewé to wà yìí',
+      topicDiscovery: {
+        heading: 'Ṣawari síi',
+        moreFromTopic: 'Díẹ̀ síi láti {topic}',
+        fetchErrorMessage: 'Ó kuna láti ṣàkójọpọ̀. Jọ̀wọ́ gbìyànjú lẹ́ẹ̀kan síi',
+      },
+      currentPage: 'Ojú ewé to wà yìi',
       skipLinkText: 'Fò kọjá sí nnkan tí ó wà nínú rẹ̀',
       relatedContent: 'Àwọn afíkun lórí ìròyìn yìí',
       relatedTopics: 'Àwọn Àkórí Tójọra',

--- a/src/app/lib/config/services/zhongwen.ts
+++ b/src/app/lib/config/services/zhongwen.ts
@@ -151,7 +151,7 @@ export const service: ZhongwenConfig = {
       home: '主页',
       topicDiscovery: {
         heading: '发现更多',
-        moreFromTopic: '更多来自{topic}',
+        moreAboutTopic: '更多关于{topic}',
         fetchErrorMessage: '加载失败。请重试',
       },
       currentPage: '目前页面',
@@ -529,7 +529,7 @@ export const service: ZhongwenConfig = {
       home: '主頁',
       topicDiscovery: {
         heading: '探索更多',
-        moreFromTopic: '更多來自{topic}',
+        moreAboutTopic: '更多關於{topic}',
         fetchErrorMessage: '載入失敗。請再試一次',
       },
       currentPage: '目前頁面',

--- a/src/app/lib/config/services/zhongwen.ts
+++ b/src/app/lib/config/services/zhongwen.ts
@@ -149,6 +149,11 @@ export const service: ZhongwenConfig = {
       },
       seeAll: '浏览全部',
       home: '主页',
+      topicDiscovery: {
+        heading: '发现更多',
+        moreFromTopic: '更多来自{topic}',
+        fetchErrorMessage: '加载失败。请重试',
+      },
       currentPage: '目前页面',
       skipLinkText: '跳过此内容',
       relatedContent: '更多相关内容',
@@ -522,6 +527,11 @@ export const service: ZhongwenConfig = {
       },
       seeAll: '瀏覽全部',
       home: '主頁',
+      topicDiscovery: {
+        heading: '探索更多',
+        moreFromTopic: '更多來自{topic}',
+        fetchErrorMessage: '載入失敗。請再試一次',
+      },
       currentPage: '目前頁面',
       skipLinkText: '跳過此內容',
       relatedContent: '更多相關內容',

--- a/src/app/models/types/translations.ts
+++ b/src/app/models/types/translations.ts
@@ -81,7 +81,7 @@ export interface Translations {
   continueReading?: string;
   topicDiscovery?: {
     heading: string;
-    moreFromTopic: string;
+    moreAboutTopic: string;
     fetchErrorMessage?: string;
   };
   readTime?: Partial<{

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -417,11 +417,7 @@ const ArticlePage = ({
 
   const authors = bylineLinkedData?.map(data => data?.authorName).join(',');
 
-  const showTopicDiscovery =
-    (showTopicDiscoveryComponent ||
-      topicDiscoveryVariant === 'topic_discovery') &&
-    !isAmp &&
-    !isLite;
+  const showTopicDiscovery = true;
 
   const showRelatedTopicsComponent = Boolean(
     showRelatedTopics && topics.length > 0 && !showTopicDiscovery,

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -417,7 +417,11 @@ const ArticlePage = ({
 
   const authors = bylineLinkedData?.map(data => data?.authorName).join(',');
 
-  const showTopicDiscovery = true;
+  const showTopicDiscovery =
+    (showTopicDiscoveryComponent ||
+      topicDiscoveryVariant === 'topic_discovery') &&
+    !isAmp &&
+    !isLite;
 
   const showRelatedTopicsComponent = Boolean(
     showRelatedTopics && topics.length > 0 && !showTopicDiscovery,


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2854




UPDATE TO BELOW:

Based on a conversation in the thread here https://bbc-tpg.slack.com/archives/C03RMKNL7GC/p1782572179402929?thread_ts=1782317427.415749&cid=C03RMKNL7GC

I have changed 'More from [topic}' to 'More about {topic}' for clarity and ease of translation.


I asked copilot about the translations that change the ones we had before. I don't know which is correct of course!

**Hausa:**

Before: Ƙarin labarai daga {topic} = "More news from {topic}"
After: Ƙari daga {topic} = "More from {topic}"

The first explicitly mentions news/articles, while the second is more generic.

**Indonesian:**

Before: 'Gagal memuat. Silakan coba lagi nanti.'
After: 'Gagal memuat. Silakan coba lagi'
First = "Failed to load. Please try again later."
Second = "Failed to load. Please try again."

Use the first only if the English source contains "later".

Before: Selengkapnya dari {topic} = "More details/more content from {topic}"
After: Lebih banyak dari {topic} = literal "More from {topic}"

**Marathi:**

Before: {topic} मधील अधिक = "More in/from {topic}" (natural)
After: {topic} पासून अधिक = literally "More from since/from {topic}" and sounds awkward.

**Turkce:**

Before: {topic} hakkında daha fazla = "More about {topic}"
After: {topic}'den daha fazlası = "More from {topic}"

For a topic page, "More about {topic}" is usually more natural.


Before: 'Yüklenemedi. Lütfen daha sonra tekrar deneyin.'
After: 'Yüklenemedi. Lütfen tekrar deneyin'

First = "Couldn't load. Please try again later."
Second = "Couldn't load. Please try again."

Choose based on the source string.

**Serbian:**

Before: 'Више из {topic}'
After: 'Више од {topic}'

Више из {topic} = "More from {topic}" ✅
Више од {topic} = "More than {topic}" ❌ changes the meaning.

The same distinction applies as in Cyrillic:

✅ Više iz {topic} = "More from {topic}"
❌ Više od {topic} = "More than {topic}"

Before: 'Учитавање није успело. Молимо покушајте поново касније.'
After: 'Учитавање није успело. Покушајте поново'

Both are correct:

First = "...please try again later."
Second = "...please try again."

Again, depends on the source text.

**Polish:**

Polish: Więcej od {topic}

Why it sounds wrong

    In Polish UI/content navigation, “od” usually marks origin from a person/source (“from X”, “by X”).
    For topics/categories, idiomatic options are:
        z (“from/out of” a set/category)
        o/na temat (“about”)

Best options

    If English source is “More from {topic}” → Więcej z {topic}
    If source is “More about {topic}” → Więcej na temat {topic} (or shorter Więcej o {topic})

**Russian:**
Russian: Больше от {topic}

Why it sounds wrong

    от in Russian also tends to mean “from/by (someone/source)” rather than “about this topic section”.
    For a topic hub/discovery module, native phrasing is usually:
        о for “about”
        or “из раздела/по теме” for “from this topic area”

Best options

    If English is “More from {topic}”:
        Больше из раздела «{topic}» (most explicit/clear in product UI)
        or Больше по теме «{topic}»
    If English is “More about {topic}”:
        Больше о «{topic}»


**Ukrainian:**

Ukrainian: Більше від {topic}

Why it sounds wrong

    Same pattern as Russian/Polish: від implies source/agent more than topical grouping.
    For topic navigation in Ukrainian, natural patterns are:
        про (“about”)
        з теми / за темою (“from/on the topic”)

Best options

    If English is “More from {topic}”:
        Більше з теми «{topic}» (very clear)
        or Більше за темою «{topic}»
    If English is “More about {topic}”:
        Більше про «{topic}»


Summary
======
_A very high-level summary of easily-reproducible changes that can be understood by non-devs, and why these changes where made._

Code changes
======
- _List key code changes that have been made._

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
