### PR TITLE
WS-2614 Remove vignette styling from live page header images

### DIFF
--- a/src/app/components/Image/index.tsx
+++ b/src/app/components/Image/index.tsx
@@ -25,6 +25,7 @@ export type ImageProps = {
   fetchPriority?: 'high';
   hasCaption?: boolean;
   isPortraitOrientation?: boolean;
+  style?: React.CSSProperties;
 };
 
 const roundNumber = (num: number) => Math.round(num * 100) / 100;
@@ -54,11 +55,11 @@ const Image = ({
   fetchPriority,
   hasCaption,
   isPortraitOrientation,
+  style,
 }: PropsWithChildren<ImageProps>) => {
   const { pageType, isLite, isAmp } = use(RequestContext);
   const [isLoaded, setIsLoaded] = useState(false);
   if (isLite) return null;
-
   const showPlaceholder = !src || (placeholder && !isLoaded);
   const hasDimensions = width && height;
   const hasFixedAspectRatio = !!aspectRatio || !!hasDimensions;
@@ -184,6 +185,7 @@ const Image = ({
                   aspectRatio: hasFixedAspectRatio
                     ? `${aspectRatioX} / ${aspectRatioY}`
                     : 'auto',
+                  ...style,
                 }} // aspectRatio used in combination with the objectFit:cover will center the image horizontally and vertically if aspectRatio prop is different from image's intrinsic aspect ratio
               />
             </ImageWrapper>

--- a/src/app/components/MaskedImage/index.test.tsx
+++ b/src/app/components/MaskedImage/index.test.tsx
@@ -7,7 +7,7 @@ import {
 import MaskedImage from './index';
 
 describe('Masked Image', () => {
-  it('should render a header image with the correct src', async () => {
+  it('should render an image with the correct src', async () => {
     await act(async () => {
       render(
         <MaskedImage
@@ -19,14 +19,14 @@ describe('Masked Image', () => {
     });
 
     await waitFor(() => {
-      const headerImage = screen.getByRole('presentation');
-      expect(headerImage.getAttribute('src')).toEqual(
+      const image = screen.getByRole('presentation');
+      expect(image.getAttribute('src')).toEqual(
         'https://ichef.bbci.co.uk/ace/standard/480/cpsdevpb/1d5b/test/5f969ec0-c4d8-11ed-8319-9b394d8ed0dd.jpg',
       );
     });
   });
 
-  it('should render a header image with empty alt text', async () => {
+  it('should render an image with empty alt text', async () => {
     await act(async () => {
       render(
         <MaskedImage
@@ -38,12 +38,12 @@ describe('Masked Image', () => {
     });
 
     await waitFor(() => {
-      const headerImage = screen.getByRole('presentation');
-      expect(headerImage.getAttribute('alt')).toEqual('');
+      const image = screen.getByRole('presentation');
+      expect(image.getAttribute('alt')).toEqual('');
     });
   });
 
-  it('should render a header image with alt text', async () => {
+  it('should render an image with alt text', async () => {
     await act(async () => {
       render(
         <MaskedImage
@@ -56,8 +56,8 @@ describe('Masked Image', () => {
     });
 
     await waitFor(() => {
-      const headerImage = screen.getByRole('img');
-      expect(headerImage.getAttribute('alt')).toEqual('alt text');
+      const image = screen.getByRole('img');
+      expect(image.getAttribute('alt')).toEqual('alt text');
     });
   });
 });

--- a/src/app/components/MaskedImage/index.tsx
+++ b/src/app/components/MaskedImage/index.tsx
@@ -1,7 +1,6 @@
 import { use } from 'react';
 import { ServiceContext } from '#contexts/ServiceContext';
 import Image from '#app/components/Image';
-import buildIChefURL from '#app/lib/utilities/ichefURL';
 import { createSrcsets } from '#app/lib/utilities/srcSet';
 import getOriginCode from '#app/lib/utilities/imageSrcHelpers/originCode';
 import getLocator from '#app/lib/utilities/imageSrcHelpers/locator';
@@ -14,7 +13,6 @@ type Props = {
   altText?: string;
   showPlaceholder?: boolean;
   showVignette?: boolean;
-  isLivePageHeaderImage?: boolean;
   singleImageLayout?: boolean;
 };
 
@@ -47,7 +45,6 @@ const MaskedImage = ({
   altText = '',
   showPlaceholder = true,
   showVignette = false,
-  isLivePageHeaderImage = false,
   singleImageLayout = false,
 }: Props) => {
   const { dir } = use(ServiceContext);
@@ -64,13 +61,6 @@ const MaskedImage = ({
       locator,
       originalImageWidth: imageWidth,
     });
-
-  const DEFAULT_IMAGE_RES = 480;
-  const srcWebp = buildIChefURL({
-    originCode,
-    locator,
-    resolution: DEFAULT_IMAGE_RES,
-  });
 
   const shouldFillHeight = singleImageLayout;
   const shouldDisableExtraWideMask = singleImageLayout;
@@ -91,7 +81,7 @@ const MaskedImage = ({
     >
       <Image
         alt={altText}
-        src={isLivePageHeaderImage ? srcWebp : imageUrl}
+        src={imageUrl}
         srcSet={primarySrcset || undefined}
         fallbackSrcSet={fallbackSrcset || undefined}
         mediaType={primaryMimeType || undefined}

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx
@@ -38,11 +38,9 @@ const Header = ({
   const {
     translations: { sport: { matchSummary = 'Match Summary' } = {} },
   } = use(ServiceContext);
-
   const watchVideoClickHandler = () => {
     setLiveMediaOpen(!isMediaOpen);
   };
-
   const url = imageUrlTemplate?.split('{width}')[1];
 
   const originCode = getOriginCode(url);
@@ -111,12 +109,12 @@ const Header = ({
       <div
         css={
           isWithImageLayout
-            ? styles.contentWithImageContainer
+            ? styles.contentWithImageContainer({ isMediaOpen })
             : styles.contentContainer
         }
       >
-        <div css={[isMediaOpen && styles.hideImage, styles.headerImage]}>
-          {isHeaderImage ? (
+        {isHeaderImage ? (
+          <div css={[isMediaOpen ? styles.hideImage : styles.headerImage]}>
             <Image
               alt=""
               src={srcWebp}
@@ -130,55 +128,64 @@ const Header = ({
               placeholder
               style={{ display: 'block' }}
             />
-          ) : null}
-        </div>
+          </div>
+        ) : null}
+
         <div
           css={[
-            isWithImageLayout && styles.textContainerWithImage,
-            !isWithImageLayout && styles.textContainerWithoutImage,
-            mediaCollections && styles.fixedHeight,
+            mediaCollections && styles.liveMediaAndTextContainer,
+            isWithImageLayout && !isMediaOpen && styles.textWrapper,
           ]}
         >
-          <Heading
-            size="trafalgar"
-            level={1}
-            id="content"
-            tabIndex={-1}
-            css={styles.heading}
+          <div
+            css={[
+              isWithImageLayout
+                ? styles.textContainerWithImage
+                : styles.textContainerWithoutImage,
+              mediaCollections && [styles.fixedHeight, { width: '100%' }],
+            ]}
           >
-            {showLiveLabel ? (
-              <LiveLabelHeader
-                isHeaderImage={isWithImageLayout}
-                showSportData={false}
-              >
-                {Title}
-              </LiveLabelHeader>
-            ) : (
-              Title
-            )}
-          </Heading>
-          {description && (
-            <Text
-              as="p"
-              css={[
-                styles.description,
-                showLiveLabel &&
-                  !isWithImageLayout &&
-                  styles.layoutWithLiveLabelNoImage,
-              ]}
+            <Heading
+              size="trafalgar"
+              level={1}
+              id="content"
+              tabIndex={-1}
+              css={styles.heading}
             >
-              {description}
-            </Text>
+              {showLiveLabel ? (
+                <LiveLabelHeader
+                  isHeaderImage={isWithImageLayout}
+                  showSportData={false}
+                >
+                  {Title}
+                </LiveLabelHeader>
+              ) : (
+                Title
+              )}
+            </Heading>
+            {description && (
+              <Text
+                as="p"
+                css={[
+                  styles.description,
+                  showLiveLabel &&
+                    !isWithImageLayout &&
+                    styles.layoutWithLiveLabelNoImage,
+                ]}
+              >
+                {description}
+              </Text>
+            )}
+          </div>
+          {mediaCollections && (
+            <div css={[styles.liveMedia, isMediaOpen && styles.liveMediaOpen]}>
+              <LiveHeaderMedia
+                mediaCollection={mediaCollections}
+                clickCallback={watchVideoClickHandler}
+              />
+            </div>
           )}
         </div>
-        {mediaCollections && (
-          <div css={[styles.liveMedia, isMediaOpen && styles.liveMediaOpen]}>
-            <LiveHeaderMedia
-              mediaCollection={mediaCollections}
-              clickCallback={watchVideoClickHandler}
-            />
-          </div>
-        )}
       </div>
     </div>
   );

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx
@@ -5,9 +5,13 @@ import LiveHeaderMedia from '#app/components/LiveHeaderMedia';
 import { MediaCollection } from '#app/components/MediaLoader/types';
 import VisuallyHiddenText from '#app/components/VisuallyHiddenText';
 import { ServiceContext } from '#app/contexts/ServiceContext';
-import MaskedImage from '#app/components/MaskedImage';
-import LiveLabelHeader from './LiveLabelHeader';
+import Image from '#app/components/Image';
+import buildIChefURL from '#app/lib/utilities/ichefURL';
+import { createSrcsets } from '#app/lib/utilities/srcSet';
+import getOriginCode from '#app/lib/utilities/imageSrcHelpers/originCode';
+import getLocator from '#app/lib/utilities/imageSrcHelpers/locator';
 import styles from './styles';
+import LiveLabelHeader from './LiveLabelHeader';
 
 const Header = ({
   showLiveLabel,
@@ -38,6 +42,25 @@ const Header = ({
   const watchVideoClickHandler = () => {
     setLiveMediaOpen(!isMediaOpen);
   };
+
+  const url = imageUrlTemplate?.split('{width}')[1];
+
+  const originCode = getOriginCode(url);
+  const locator = getLocator(url);
+
+  const { primarySrcset, primaryMimeType, fallbackSrcset, fallbackMimeType } =
+    createSrcsets({
+      originCode,
+      locator,
+      originalImageWidth: imageWidth,
+    });
+
+  const DEFAULT_IMAGE_RES = 480;
+  const srcWebp = buildIChefURL({
+    originCode,
+    locator,
+    resolution: DEFAULT_IMAGE_RES,
+  });
 
   const Title = (
     <span
@@ -86,13 +109,20 @@ const Header = ({
         <div css={styles.backgroundColor} />
       </div>
       <div css={styles.contentContainer}>
-        <div css={[isMediaOpen && styles.hideMaskedImage]}>
+        <div css={[isMediaOpen && styles.hideImage, styles.headerImage]}>
           {isHeaderImage ? (
-            <MaskedImage
-              imageUrl={imageUrl}
-              imageUrlTemplate={imageUrlTemplate}
-              imageWidth={imageWidth}
-              isLivePageHeaderImage
+            <Image
+              alt=""
+              src={srcWebp}
+              srcSet={primarySrcset || undefined}
+              fallbackSrcSet={fallbackSrcset || undefined}
+              mediaType={primaryMimeType || undefined}
+              fallbackMediaType={fallbackMimeType || undefined}
+              sizes="(min-width: 1008px) 660px, 100vw"
+              fetchPriority="high"
+              preload
+              placeholder
+              style={{ display: 'block' }}
             />
           ) : null}
         </div>

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx
@@ -107,11 +107,12 @@ const Header = ({
         <div css={styles.backgroundColor} />
       </div>
       <div
-        css={
+        css={[
           isWithImageLayout
-            ? styles.contentWithImageContainer({ isMediaOpen })
-            : styles.contentContainer
-        }
+            ? styles.contentWithImageContainer
+            : styles.contentContainer,
+          !isMediaOpen && isWithImageLayout && { gap: '2rem' },
+        ]}
       >
         {isHeaderImage ? (
           <div css={[isMediaOpen ? styles.hideImage : styles.headerImage]}>

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/index.tsx
@@ -108,7 +108,13 @@ const Header = ({
       <div css={styles.backgroundContainer}>
         <div css={styles.backgroundColor} />
       </div>
-      <div css={styles.contentContainer}>
+      <div
+        css={
+          isWithImageLayout
+            ? styles.contentWithImageContainer
+            : styles.contentContainer
+        }
+      >
         <div css={[isMediaOpen && styles.hideImage, styles.headerImage]}>
           {isHeaderImage ? (
             <Image

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -20,7 +20,7 @@ export default {
         outline: 'none',
       },
     }),
-  hideMaskedImage: ({ mq }: Theme) =>
+  hideImage: ({ mq }: Theme) =>
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
         opacity: 0,
@@ -46,13 +46,25 @@ export default {
     css({
       backgroundColor: palette.GREY_16, // non-concise view background colour - MVP
     }),
-  contentContainer: ({ mq, gridWidths }: Theme) =>
+  contentContainer: ({ mq }: Theme) =>
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
-        maxWidth: `${pixelsToRem(gridWidths[1280])}rem`,
-        margin: '0 auto',
-        position: 'relative',
-        width: '100%',
+        display: 'flex',
+        flexDirection: 'row-reverse',
+      },
+      [mq.GROUP_4_ONLY]: {
+        alignItems: 'center',
+      },
+    }),
+  headerImage: ({ mq, spacings }: Theme) =>
+    css({
+      aspectRatio: '16 / 9',
+      [mq.GROUP_4_MIN_WIDTH]: {
+        aspectRatio: 'auto',
+        display: 'flex',
+      },
+      [mq.GROUP_4_ONLY]: {
+        paddingRight: `${spacings.DOUBLE}rem`,
       },
     }),
   liveMedia: ({ mq, spacings }: Theme) =>
@@ -97,12 +109,8 @@ export default {
   textContainerWithImage: ({ mq, spacings }: Theme) =>
     css({
       position: 'relative',
-      padding: `${spacings.FULL}rem ${spacings.FULL}rem ${spacings.DOUBLE}rem`,
-      [mq.GROUP_2_MIN_WIDTH]: {
-        padding: `${spacings.FULL}rem ${spacings.DOUBLE}rem ${spacings.DOUBLE}rem`,
-      },
+      padding: `${spacings.DOUBLE}rem`,
       [mq.GROUP_4_MIN_WIDTH]: {
-        padding: `${spacings.DOUBLE}rem`,
         minHeight: `${pixelsToRem(440)}rem`, // calculation includes padding
         height: '100%',
         display: 'flex',

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -46,14 +46,15 @@ export default {
     css({
       backgroundColor: palette.GREY_16, // non-concise view background colour - MVP
     }),
-  contentContainer: ({ mq }: Theme) =>
+  contentContainer: ({ mq, spacings }: Theme) =>
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
         display: 'flex',
         flexDirection: 'row-reverse',
         justifyContent: 'center',
-        padding: '0 16px',
+        padding: `0 ${spacings.DOUBLE}rem`,
         margin: '0 auto',
+        gap: `${spacings.DOUBLE}rem`,
       },
       [mq.GROUP_4_ONLY]: {
         alignItems: 'center',
@@ -120,7 +121,6 @@ export default {
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'center',
-        maxWidth: '50%', // determines width of text overlay.
       },
     }),
   titleWithImage: ({ palette }: Theme) =>

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -55,7 +55,7 @@ export default {
         width: '100%',
       },
     }),
-  contentWithImageContainer: ({ mq, spacings }: Theme) =>
+  contentWithImageContainer: ({ gridWidths, mq, spacings }: Theme) =>
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
         display: 'flex',
@@ -64,7 +64,7 @@ export default {
         padding: `0 ${spacings.DOUBLE}rem`,
         margin: '0 auto',
         gap: `${spacings.DOUBLE}rem`,
-        maxWidth: `${pixelsToRem(1280)}rem`,
+        maxWidth: `${pixelsToRem(gridWidths[1280])}rem`,
       },
       [mq.GROUP_4_ONLY]: {
         alignItems: 'center',

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -55,6 +55,7 @@ export default {
         padding: `0 ${spacings.DOUBLE}rem`,
         margin: '0 auto',
         gap: `${spacings.DOUBLE}rem`,
+        maxWidth: `${pixelsToRem(1280)}rem`,
       },
       [mq.GROUP_4_ONLY]: {
         alignItems: 'center',
@@ -121,6 +122,7 @@ export default {
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'center',
+        padding: 0,
       },
     }),
   titleWithImage: ({ palette }: Theme) =>

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -46,7 +46,16 @@ export default {
     css({
       backgroundColor: palette.GREY_16, // non-concise view background colour - MVP
     }),
-  contentContainer: ({ mq, spacings }: Theme) =>
+  contentContainer: ({ mq, gridWidths }: Theme) =>
+    css({
+      [mq.GROUP_4_MIN_WIDTH]: {
+        maxWidth: `${pixelsToRem(gridWidths[1280])}rem`,
+        margin: '0 auto',
+        position: 'relative',
+        width: '100%',
+      },
+    }),
+  contentWithImageContainer: ({ mq, spacings }: Theme) =>
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
         display: 'flex',

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -55,25 +55,22 @@ export default {
         width: '100%',
       },
     }),
-  contentWithImageContainer:
-    ({ isMediaOpen }: { isMediaOpen: boolean }) =>
-    ({ gridWidths, mq, spacings }: Theme) =>
-      css({
-        [mq.GROUP_4_MIN_WIDTH]: {
-          display: 'flex',
-          flexDirection: 'row-reverse',
-          justifyContent: 'center',
-          width: '100%',
-          boxSizing: 'border-box',
-          padding: `0 ${spacings.DOUBLE}rem`,
-          margin: '0 auto',
-          gap: isMediaOpen ? 0 : `${spacings.QUADRUPLE}rem`,
-          maxWidth: `${pixelsToRem(gridWidths[1280])}rem`,
-        },
-        [mq.GROUP_4_ONLY]: {
-          alignItems: 'center',
-        },
-      }),
+  contentWithImageContainer: ({ gridWidths, mq, spacings }: Theme) =>
+    css({
+      [mq.GROUP_4_MIN_WIDTH]: {
+        display: 'flex',
+        flexDirection: 'row-reverse',
+        justifyContent: 'center',
+        width: '100%',
+        boxSizing: 'border-box',
+        padding: `0 ${spacings.DOUBLE}rem`,
+        margin: '0 auto',
+        maxWidth: `${pixelsToRem(gridWidths[1280])}rem`,
+      },
+      [mq.GROUP_4_ONLY]: {
+        alignItems: 'center',
+      },
+    }),
   textWrapper: ({ mq }: Theme) =>
     css({
       [mq.GROUP_4_MIN_WIDTH]: {

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -23,7 +23,7 @@ export default {
   hideImage: ({ mq }: Theme) =>
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
-        opacity: 0,
+        display: 'none',
       },
     }),
   backgroundContainer: () =>
@@ -55,19 +55,29 @@ export default {
         width: '100%',
       },
     }),
-  contentWithImageContainer: ({ gridWidths, mq, spacings }: Theme) =>
+  contentWithImageContainer:
+    ({ isMediaOpen }: { isMediaOpen: boolean }) =>
+    ({ gridWidths, mq, spacings }: Theme) =>
+      css({
+        [mq.GROUP_4_MIN_WIDTH]: {
+          display: 'flex',
+          flexDirection: 'row-reverse',
+          justifyContent: 'center',
+          width: '100%',
+          boxSizing: 'border-box',
+          padding: `0 ${spacings.DOUBLE}rem`,
+          margin: '0 auto',
+          gap: isMediaOpen ? 0 : `${spacings.QUADRUPLE}rem`,
+          maxWidth: `${pixelsToRem(gridWidths[1280])}rem`,
+        },
+        [mq.GROUP_4_ONLY]: {
+          alignItems: 'center',
+        },
+      }),
+  textWrapper: ({ mq }: Theme) =>
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
-        display: 'flex',
-        flexDirection: 'row-reverse',
-        justifyContent: 'center',
-        padding: `0 ${spacings.DOUBLE}rem`,
-        margin: '0 auto',
-        gap: `${spacings.DOUBLE}rem`,
-        maxWidth: `${pixelsToRem(gridWidths[1280])}rem`,
-      },
-      [mq.GROUP_4_ONLY]: {
-        alignItems: 'center',
+        width: '50%',
       },
     }),
   headerImage: ({ mq, spacings }: Theme) =>
@@ -78,7 +88,7 @@ export default {
         display: 'flex',
       },
       [mq.GROUP_4_ONLY]: {
-        paddingRight: `${spacings.DOUBLE}rem`,
+        paddingInlineEnd: `${spacings.DOUBLE}rem`,
       },
     }),
   liveMedia: ({ mq, spacings }: Theme) =>
@@ -95,7 +105,7 @@ export default {
   liveMediaOpen: ({ mq }: Theme) =>
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
-        maxWidth: '100%',
+        maxWidth: '80rem',
       },
     }),
   fixedHeight: ({ mq, spacings }: Theme) =>
@@ -103,8 +113,13 @@ export default {
       [mq.GROUP_4_MIN_WIDTH]: {
         minHeight: '0',
         padding: `${pixelsToRem(40)}rem ${spacings.DOUBLE}rem 0`,
-        maxWidth: '50%', // determines width of text overlay.
       },
+    }),
+  liveMediaAndTextContainer: () =>
+    css({
+      display: 'flex',
+      flexDirection: 'column',
+      width: '100%',
     }),
   textContainerWithoutImage: ({ mq, gridWidths, spacings }: Theme) =>
     css({
@@ -127,7 +142,6 @@ export default {
       [mq.GROUP_4_MIN_WIDTH]: {
         minHeight: `${pixelsToRem(440)}rem`, // calculation includes padding
         height: '100%',
-        width: '50%',
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'center',

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -51,6 +51,9 @@ export default {
       [mq.GROUP_4_MIN_WIDTH]: {
         display: 'flex',
         flexDirection: 'row-reverse',
+        justifyContent: 'center',
+        padding: '0 16px',
+        margin: '0 auto',
       },
       [mq.GROUP_4_ONLY]: {
         alignItems: 'center',
@@ -113,6 +116,7 @@ export default {
       [mq.GROUP_4_MIN_WIDTH]: {
         minHeight: `${pixelsToRem(440)}rem`, // calculation includes padding
         height: '100%',
+        width: '50%',
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'center',


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2614

Summary
======

Removes vignette styling from live page header images in line with PS.

Code changes
======
- Uses Image component directly in the header instead of MaskedImage
- Updates styling to align with PS approach
- Removes references to header image in MaskedImage

Testing
======
1. Visit http://localhost:7081/hausa/live/c36y31j4r6lt?renderer_env=live and observe removed vignette compared to https://www.bbc.com/hausa/live/c36y31j4r6lt

2. Check RTL implementation (and media in header) using http://localhost:7081/persian/live/cdx7j0gy8gzt?renderer_env=live

This implementation:


https://github.com/user-attachments/assets/9f402a7e-a71f-4e94-a3d7-ceef4628c649


PS implementation:

https://github.com/user-attachments/assets/bf12d569-b450-4b21-95ed-9f9bcacd241b



## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
