### PR TITLE
WS-2616: Adds elections podcast inline promo SVG based on promo link

### DIFF
--- a/src/app/legacy/containers/PodcastPromo/Inline.jsx
+++ b/src/app/legacy/containers/PodcastPromo/Inline.jsx
@@ -168,10 +168,18 @@ const icons = {
   whatsapp: mediaIcons.whatsapp,
 };
 
+const iconOverridesByUrl = {
+  '/portuguese/articles/czd2prld130o': mediaIcons.elections,
+};
+
 const getIconFromUrl = url => {
-  const match = Object.keys(icons).find(key =>
-    url?.toLowerCase().includes(key),
-  );
+  const lowerCaseUrl = url?.toLowerCase();
+
+  if (lowerCaseUrl && iconOverridesByUrl[lowerCaseUrl]) {
+    return iconOverridesByUrl[lowerCaseUrl];
+  }
+
+  const match = Object.keys(icons).find(key => lowerCaseUrl?.includes(key));
 
   return icons[match] || mediaIcons.communication;
 };

--- a/src/app/legacy/containers/PodcastPromo/index.stories.jsx
+++ b/src/app/legacy/containers/PodcastPromo/index.stories.jsx
@@ -59,6 +59,17 @@ const serviceContextMockWhatsapp = {
   },
 };
 
+const serviceContextMockElections = {
+  ...serviceContextMock,
+  podcastPromo: {
+    ...serviceContextMock.podcastPromo,
+    linkLabel: {
+      ...serviceContextMock.podcastPromo.linkLabel,
+      href: 'https://www.bbc.com/portuguese/articles/czd2prld130o',
+    },
+  },
+};
+
 
 
 const Component = ({ inline = false,  value = serviceContextMock }) => (
@@ -83,5 +94,8 @@ export const InlinePromoGeneric = () => <Component inline />;
 export const InlinePromoWhatsapp = () => <Component inline value={serviceContextMockWhatsapp}/>;
 export const InlinePromoYoutube = () => <Component inline value={serviceContextMockYoutube} />;
 export const InlinePromoPodcast = () => <Component inline value={serviceContextMockPodcast} />;
+export const InlinePromoElections = () => (
+  <Component inline value={serviceContextMockElections} />
+);
 
 

--- a/src/app/legacy/containers/PodcastPromo/index.test.jsx
+++ b/src/app/legacy/containers/PodcastPromo/index.test.jsx
@@ -38,6 +38,8 @@ const {
 } = russianServiceConfig.default.podcastPromo;
 
 describe('Inline', () => {
+  const electionsIconPathSnippet = 'M18.1,7.2v2.6h8.7';
+
   it('Should render a promo for podcasts correctly', () => {
     const { container } = render(
       <PromoWithContext inline config={burmeseServiceConfig} />,
@@ -89,6 +91,32 @@ describe('Inline', () => {
     );
     expect(container).toMatchSnapshot();
   });
+
+  it('should render the elections icon when the promo URL matches the elections article', () => {
+    const electionsPromoConfig = {
+      ...russianServiceConfig,
+      default: {
+        ...russianServiceConfig.default,
+        podcastPromo: {
+          ...russianServiceConfig.default.podcastPromo,
+          linkLabel: {
+            ...russianServiceConfig.default.podcastPromo.linkLabel,
+            href: 'https://www.bbc.com/portuguese/articles/czd2prld130o',
+          },
+        },
+      },
+    };
+
+    const { container } = render(
+      <PromoWithContext inline config={electionsPromoConfig} />,
+      {
+        service: 'russian',
+      },
+    );
+
+    expect(container.innerHTML).toContain(electionsIconPathSnippet);
+  });
+
   it('should show when all props are available', () => {
     const { getByText, getByRole } = render(<PromoWithContext inline />, {
       service: 'russian',

--- a/src/app/legacy/psammead/psammead-assets/src/__snapshots__/svgs.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-assets/src/__snapshots__/svgs.test.jsx.snap
@@ -72,6 +72,17 @@ exports[`mediaIcons SVG should render correctly 1`] = `
       d="M1,25.1h18.8v-8.4l-7.3-0.5v-5.7H1V25.1z M8.5,24.7h-4v4.7H6L8.5,24.7z M31,17.9V2.6H11.5v15.3H31z M28.6,15.5H14V5h14.6 V15.5z M23.5,17.5l2.5,4.7h1.5v-4.7H23.5z"
     />
   </InArticlePromoIcon>,
+  "elections": <InArticlePromoIcon
+    aria-hidden="true"
+    focusable="false"
+    height="32"
+    viewBox="0 0 32 32"
+    width="32"
+  >
+    <path
+      d="M18.1,7.2v2.6h8.7l-.3-.7-9.1,9.1h1.3l-5.8-5.9L1.8,23.3l2.1,1.9,9.8-9.7h-1.4l5.8,5.8,10.3-10.3-.7-.3v8.7h2.6V7.2h-12.2Z"
+    />
+  </InArticlePromoIcon>,
   "guidance": <GuidanceIcon
     aria-hidden="true"
     focusable="false"

--- a/src/app/legacy/psammead/psammead-assets/src/svgs/mediaIcons.jsx
+++ b/src/app/legacy/psammead/psammead-assets/src/svgs/mediaIcons.jsx
@@ -125,6 +125,16 @@ const mediaIcons = {
       />
     </InArticlePromoIcon>
   ),
+  elections: (
+    <InArticlePromoIcon
+      viewBox="0 0 32 32"
+      width="32"
+      height="32"
+      {...defaultAttrs}
+    >
+      <path d="M18.1,7.2v2.6h8.7l-.3-.7-9.1,9.1h1.3l-5.8-5.9L1.8,23.3l2.1,1.9,9.8-9.7h-1.4l5.8,5.8,10.3-10.3-.7-.3v8.7h2.6V7.2h-12.2Z" />
+    </InArticlePromoIcon>
+  ),
   youtube: (
     <InArticlePromoIcon
       viewBox="0 0 16 16"

--- a/ws-nextjs-app/integration/pages/articles/afrique/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/afrique/__snapshots__/canonical.test.ts.snap
@@ -38,7 +38,7 @@ exports[`Canonical Articles Media Loader renders a figure caption 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 e1xc513p1"
+        class="css-vja2s5 ew59ay91"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -115,7 +115,7 @@ exports[`Canonical Articles Media Loader renders a placeholder 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 e1xc513p1"
+        class="css-vja2s5 ew59ay91"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -196,7 +196,7 @@ exports[`Canonical Articles Media Loader renders a valid container 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="css-vja2s5 e1xc513p1"
+          class="css-vja2s5 ew59ay91"
           focusable="false"
           height="12"
           viewBox="0 0 12 12"

--- a/ws-nextjs-app/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.ts.snap
@@ -181,7 +181,7 @@ exports[`Canonical Articles Media Loader renders a figure caption 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 e1xc513p1"
+        class="css-vja2s5 ew59ay91"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -258,7 +258,7 @@ exports[`Canonical Articles Media Loader renders a placeholder 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 e1xc513p1"
+        class="css-vja2s5 ew59ay91"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -339,7 +339,7 @@ exports[`Canonical Articles Media Loader renders a valid container 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="css-vja2s5 e1xc513p1"
+          class="css-vja2s5 ew59ay91"
           focusable="false"
           height="12"
           viewBox="0 0 12 12"

--- a/ws-nextjs-app/integration/pages/av-embeds/russian/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/av-embeds/russian/__snapshots__/canonical.test.ts.snap
@@ -34,7 +34,7 @@ exports[`Canonical Av-embeds Media Loader renders a figure caption 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 e1xc513p1"
+        class="css-vja2s5 ew59ay91"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -111,7 +111,7 @@ exports[`Canonical Av-embeds Media Loader renders a placeholder 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 e1xc513p1"
+        class="css-vja2s5 ew59ay91"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -192,7 +192,7 @@ exports[`Canonical Av-embeds Media Loader renders a valid container 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="css-vja2s5 e1xc513p1"
+          class="css-vja2s5 ew59ay91"
           focusable="false"
           height="12"
           viewBox="0 0 12 12"

--- a/ws-nextjs-app/integration/pages/onDemandTVPage/hausa/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/onDemandTVPage/hausa/__snapshots__/canonical.test.ts.snap
@@ -166,7 +166,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a figure caption 1`] 
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 e1xc513p1"
+        class="css-vja2s5 ew59ay91"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -243,7 +243,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a placeholder 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 e1xc513p1"
+        class="css-vja2s5 ew59ay91"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -324,7 +324,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a valid container 1`]
       >
         <svg
           aria-hidden="true"
-          class="css-vja2s5 e1xc513p1"
+          class="css-vja2s5 ew59ay91"
           focusable="false"
           height="12"
           viewBox="0 0 12 12"

--- a/ws-nextjs-app/integration/pages/onDemandTVPage/pashtoBrand/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/onDemandTVPage/pashtoBrand/__snapshots__/canonical.test.ts.snap
@@ -169,7 +169,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a figure caption 1`] 
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 e1xc513p1"
+        class="css-vja2s5 ew59ay91"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -246,7 +246,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a placeholder 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 e1xc513p1"
+        class="css-vja2s5 ew59ay91"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -327,7 +327,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a valid container 1`]
       >
         <svg
           aria-hidden="true"
-          class="css-vja2s5 e1xc513p1"
+          class="css-vja2s5 ew59ay91"
           focusable="false"
           height="12"
           viewBox="0 0 12 12"


### PR DESCRIPTION
Resolves JIRA: [WS-2616](https://bbc.atlassian.net/browse/WS-2616)

Summary
======
Adds an elections icon when article inline promo link is a certain URL.

Code changes
======
- Adds elections SVG
- Adds logic to swap out icon in inline podcast promo based on a specific Portuguese URL
- Adds story in storybook for new icon usage

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._


[WS-2616]: https://bbc.atlassian.net/browse/WS-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ