### PR TITLE
WS-NA: Fix dark mode leak with revert of recent DarkUI colour changes

### DIFF
--- a/src/app/components/FrostedGlassPromo/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/FrostedGlassPromo/__snapshots__/index.test.tsx.snap
@@ -298,12 +298,6 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-8 {
-    color: #E6E8EA;
-  }
-}
-
 @media (min-width: 25rem) {
   .emotion-8 {
     font-size: 0.875rem;
@@ -504,12 +498,6 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
   .emotion-8 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-8 {
-    color: #E6E8EA;
   }
 }
 
@@ -716,12 +704,6 @@ exports[`Frosted Glass Promo when given props for a Optimo promo 1`] = `
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-8 {
-    color: #E6E8EA;
-  }
-}
-
 @media (min-width: 25rem) {
   .emotion-8 {
     font-size: 0.875rem;
@@ -922,12 +904,6 @@ exports[`Frosted Glass Promo when given props for an a Optimo promo with no imag
   .emotion-8 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-8 {
-    color: #E6E8EA;
   }
 }
 

--- a/src/app/components/MostRead/Canonical/LastUpdated/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/MostRead/Canonical/LastUpdated/__snapshots__/index.test.tsx.snap
@@ -25,12 +25,6 @@ exports[`MostReadCanonical - LastUpdated should render LastUpdated correctly 1`]
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-0 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <time
     class="emotion-0 emotion-1"

--- a/src/app/legacy/components/Promo/a.jsx
+++ b/src/app/legacy/components/Promo/a.jsx
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled';
 
 const A = styled.a`
-  color: ${({ theme }) =>
-    theme.isDarkUi ? theme.palette.GREY_2 : theme.palette.GREY_10};
+  color: ${props => props.theme.palette.GREY_10};
   text-decoration: none;
   display: block;
   &:hover,
@@ -10,9 +9,7 @@ const A = styled.a`
     text-decoration: underline;
   }
   &:visited {
-    color: ${({ theme }) =>
-      theme.isDarkUi ? theme.palette.GREY_4 : theme.palette.GREY_6};
-  }
+    color: ${props => props.theme.palette.GREY_6};
   &:before {
     position: absolute;
     bottom: 0;

--- a/src/app/legacy/components/Promo/a.jsx
+++ b/src/app/legacy/components/Promo/a.jsx
@@ -1,10 +1,8 @@
 import styled from '@emotion/styled';
 
 const A = styled.a`
-  color: ${props =>
-    props.theme.isDarkUi
-      ? props.theme.palette.GREY_2
-      : props.theme.palette.GREY_10};
+  color: ${({ theme }) =>
+    theme.isDarkUi ? theme.palette.GREY_2 : theme.palette.GREY_10};
   text-decoration: none;
   display: block;
   &:hover,
@@ -12,10 +10,8 @@ const A = styled.a`
     text-decoration: underline;
   }
   &:visited {
-    color: ${props =>
-      props.theme.isDarkUi
-        ? props.theme.palette.GREY_4
-        : props.theme.palette.GREY_6};
+    color: ${({ theme }) =>
+      theme.isDarkUi ? theme.palette.GREY_4 : theme.palette.GREY_6};
   }
   &:before {
     position: absolute;
@@ -24,17 +20,6 @@ const A = styled.a`
     left: 0;
     right: 0;
     content: '';
-  }
-
-  @media (prefers-color-scheme: dark) {
-    ${props =>
-      !props.theme.isDarkUi &&
-      `
-      color: ${props.theme.palette.GREY_2};
-      &:visited {
-        color: ${props.theme.palette.GREY_4};
-      }
-      `}
   }
 `;
 

--- a/src/app/legacy/components/Promo/body.jsx
+++ b/src/app/legacy/components/Promo/body.jsx
@@ -3,13 +3,11 @@ import styled from '@emotion/styled';
 const P = styled.p`
   ${({ theme: { fontVariants } }) => fontVariants.sansRegular};
   ${({ theme: { fontSizes } }) => fontSizes.bodyCopy};
-  color: ${props =>
-    props.theme.isDarkUi
-      ? props.theme.palette.GREY_3
-      : props.theme.palette.EBON};
+  color: ${({ theme }) =>
+    theme.isDarkUi ? theme.palette.GREY_3 : theme.palette.EBON};
 
   @media (prefers-color-scheme: dark) {
-    ${props => !props.theme.isDarkUi && `color: ${props.theme.palette.GREY_3};`}
+    ${({ theme }) => !theme.isDarkUi && `color: ${theme.palette.GREY_3};`}
   }
 `;
 

--- a/src/app/legacy/components/Promo/body.jsx
+++ b/src/app/legacy/components/Promo/body.jsx
@@ -3,12 +3,7 @@ import styled from '@emotion/styled';
 const P = styled.p`
   ${({ theme: { fontVariants } }) => fontVariants.sansRegular};
   ${({ theme: { fontSizes } }) => fontSizes.bodyCopy};
-  color: ${({ theme }) =>
-    theme.isDarkUi ? theme.palette.GREY_3 : theme.palette.EBON};
-
-  @media (prefers-color-scheme: dark) {
-    ${({ theme }) => !theme.isDarkUi && `color: ${theme.palette.GREY_3};`}
-  }
+  color: ${props => props.theme.palette.EBON};
 `;
 
 export default P;

--- a/src/app/legacy/components/Promo/heading.jsx
+++ b/src/app/legacy/components/Promo/heading.jsx
@@ -3,13 +3,9 @@ import styled from '@emotion/styled';
 const Heading = styled.h2`
   ${props => props.theme.fontVariants.serifMedium}
   ${props => props.theme.fontSizes.bodyCopy}
-  color: ${({ theme }) =>
-    theme.isDarkUi ? theme.palette.GREY_2 : theme.palette.EBON};
+  color: ${props => props.theme.palette.EBON};
   margin-top: 0;
   margin-bottom: ${props => `${props.theme.spacings.FULL}rem`};
-  @media (prefers-color-scheme: dark) {
-    ${({ theme }) => !theme.isDarkUi && `color: ${theme.palette.GREY_2};`}
-  }
 `;
 
 export default Heading;

--- a/src/app/legacy/components/Promo/heading.jsx
+++ b/src/app/legacy/components/Promo/heading.jsx
@@ -3,15 +3,12 @@ import styled from '@emotion/styled';
 const Heading = styled.h2`
   ${props => props.theme.fontVariants.serifMedium}
   ${props => props.theme.fontSizes.bodyCopy}
-  color: ${props =>
-    props.theme.isDarkUi
-      ? props.theme.palette.GREY_2
-      : props.theme.palette.EBON};
+  color: ${({ theme }) =>
+    theme.isDarkUi ? theme.palette.GREY_2 : theme.palette.EBON};
   margin-top: 0;
   margin-bottom: ${props => `${props.theme.spacings.FULL}rem`};
-
   @media (prefers-color-scheme: dark) {
-    ${props => !props.theme.isDarkUi && `color: ${props.theme.palette.GREY_2};`}
+    ${({ theme }) => !theme.isDarkUi && `color: ${theme.palette.GREY_2};`}
   }
 `;
 

--- a/src/app/legacy/components/RadioSchedule/StartTime/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/components/RadioSchedule/StartTime/__snapshots__/index.test.jsx.snap
@@ -114,12 +114,6 @@ exports[`StartTime should render LTR correctly 1`] = `
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-8 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -271,12 +265,6 @@ exports[`StartTime should render RTL correctly 1`] = `
   .emotion-8 {
     font-size: 0.8125rem;
     line-height: 1.25rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-8 {
-    color: #E6E8EA;
   }
 }
 

--- a/src/app/legacy/components/RadioSchedule/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/components/RadioSchedule/__snapshots__/index.test.jsx.snap
@@ -342,12 +342,6 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-16 {
-    color: #E6E8EA;
-  }
-}
-
 .emotion-18 {
   padding-top: 0.5rem;
   background-color: #FFFFFF;
@@ -1650,12 +1644,6 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   .emotion-16 {
     font-size: 0.8125rem;
     line-height: 1.25rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-16 {
-    color: #E6E8EA;
   }
 }
 

--- a/src/app/legacy/containers/ArticleTimestamp/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/ArticleTimestamp/__snapshots__/index.test.jsx.snap
@@ -152,12 +152,6 @@ exports[`ArticleTimestamp should render a 'created' Timestamp correctly 1`] = `
   padding-bottom: 1rem;
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-4 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1 emotion-2"
@@ -328,12 +322,6 @@ exports[`ArticleTimestamp should render both a 'created' and an 'updated' Timest
 
 .emotion-4:last-child {
   padding-bottom: 1rem;
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-4 {
-    color: #E6E8EA;
-  }
 }
 
 <div>
@@ -516,12 +504,6 @@ exports[`ArticleTimestamp should render with a prefix 1`] = `
   padding-bottom: 1rem;
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-4 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1 emotion-2"
@@ -702,12 +684,6 @@ exports[`ArticleTimestamp should render with a suffix 1`] = `
   padding-bottom: 1rem;
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-4 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1 emotion-2"
@@ -886,12 +862,6 @@ exports[`ArticleTimestamp should render with no suffix or prefix 1`] = `
 
 .emotion-4:last-child {
   padding-bottom: 1rem;
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-4 {
-    color: #E6E8EA;
-  }
 }
 
 <div>

--- a/src/app/legacy/containers/EpisodeList/RecentAudioEpisodes/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/EpisodeList/RecentAudioEpisodes/__snapshots__/index.test.jsx.snap
@@ -344,12 +344,6 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-39 {
-    color: #E6E8EA;
-  }
-}
-
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
   .emotion-39 {
     font-size: 0.875rem;

--- a/src/app/legacy/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
@@ -509,12 +509,6 @@ exports[`RadioSchedule With initial data renders correctly for a service 1`] = `
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-31 {
-    color: #E6E8EA;
-  }
-}
-
 .emotion-33 {
   padding-top: 0.5rem;
   background-color: #FFFFFF;

--- a/src/app/legacy/containers/StoryPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/StoryPromo/__snapshots__/index.test.jsx.snap
@@ -313,12 +313,6 @@ exports[`StoryPromo Container should render audio correctly for amp 1`] = `
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-27 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -753,12 +747,6 @@ exports[`StoryPromo Container should render audio correctly for canonical 1`] = 
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-28 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -1072,12 +1060,6 @@ exports[`StoryPromo Container should render audio promoType leading on amp 1`] =
   .emotion-12 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-12 {
-    color: #E6E8EA;
   }
 }
 
@@ -1642,12 +1624,6 @@ exports[`StoryPromo Container should render audio promoType top on amp 1`] = `
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-27 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -2072,12 +2048,6 @@ exports[`StoryPromo Container should render audio with no duration correctly for
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-24 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -2497,12 +2467,6 @@ exports[`StoryPromo Container should render audio with no duration correctly for
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-25 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -2805,12 +2769,6 @@ exports[`StoryPromo Container should render audio with no duration promoType lea
   .emotion-11 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-11 {
-    color: #E6E8EA;
   }
 }
 
@@ -3356,12 +3314,6 @@ exports[`StoryPromo Container should render audio with no duration promoType top
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-24 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -3717,12 +3669,6 @@ exports[`StoryPromo Container should render featureLink correctly for amp 1`] = 
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-17 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -4049,12 +3995,6 @@ exports[`StoryPromo Container should render featureLink correctly for canonical 
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-18 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -4310,12 +4250,6 @@ exports[`StoryPromo Container should render featureLink promoType leading on amp
   .emotion-10 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-10 {
-    color: #E6E8EA;
   }
 }
 
@@ -4722,12 +4656,6 @@ exports[`StoryPromo Container should render featureLink promoType top on amp 1`]
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-17 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -5051,12 +4979,6 @@ exports[`StoryPromo Container should render full width promos correctly for amp 
   .emotion-18 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-18 {
-    color: #E6E8EA;
   }
 }
 
@@ -5392,12 +5314,6 @@ exports[`StoryPromo Container should render full width promos correctly for cano
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-19 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1 emotion-2"
@@ -5719,12 +5635,6 @@ exports[`StoryPromo Container should render item without an image correctly for 
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-18 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -6035,12 +5945,6 @@ exports[`StoryPromo Container should render item without an image correctly for 
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-18 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -6285,12 +6189,6 @@ exports[`StoryPromo Container should render item without an image promoType lead
   .emotion-10 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-10 {
-    color: #E6E8EA;
   }
 }
 
@@ -6686,12 +6584,6 @@ exports[`StoryPromo Container should render item without an image promoType top 
   .emotion-18 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-18 {
-    color: #E6E8EA;
   }
 }
 
@@ -8608,12 +8500,6 @@ exports[`StoryPromo Container should render multiple Index Alsos correctly for c
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-18 {
-    color: #E6E8EA;
-  }
-}
-
 .emotion-20 {
   position: relative;
   z-index: 2;
@@ -10290,12 +10176,6 @@ exports[`StoryPromo Container should render standard correctly for amp 1`] = `
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-17 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -10622,12 +10502,6 @@ exports[`StoryPromo Container should render standard correctly for canonical 1`]
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-18 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -10883,12 +10757,6 @@ exports[`StoryPromo Container should render standard promoType leading on amp 1`
   .emotion-10 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-10 {
-    color: #E6E8EA;
   }
 }
 
@@ -11295,12 +11163,6 @@ exports[`StoryPromo Container should render standard promoType top on amp 1`] = 
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-17 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -11618,12 +11480,6 @@ exports[`StoryPromo Container should render standardLink correctly for amp 1`] =
   .emotion-17 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-17 {
-    color: #E6E8EA;
   }
 }
 
@@ -11953,12 +11809,6 @@ exports[`StoryPromo Container should render standardLink correctly for canonical
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-18 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -12214,12 +12064,6 @@ exports[`StoryPromo Container should render standardLink promoType leading on am
   .emotion-10 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-10 {
-    color: #E6E8EA;
   }
 }
 
@@ -12626,12 +12470,6 @@ exports[`StoryPromo Container should render standardLink promoType top on amp 1`
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-17 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -12949,12 +12787,6 @@ exports[`StoryPromo Container should render standardOvertypedSummary correctly f
   .emotion-17 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-17 {
-    color: #E6E8EA;
   }
 }
 
@@ -13284,12 +13116,6 @@ exports[`StoryPromo Container should render standardOvertypedSummary correctly f
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-18 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -13545,12 +13371,6 @@ exports[`StoryPromo Container should render standardOvertypedSummary promoType l
   .emotion-10 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-10 {
-    color: #E6E8EA;
   }
 }
 
@@ -13957,12 +13777,6 @@ exports[`StoryPromo Container should render standardOvertypedSummary promoType t
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-17 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -14342,12 +14156,6 @@ exports[`StoryPromo Container should render video correctly for amp 1`] = `
   .emotion-27 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-27 {
-    color: #E6E8EA;
   }
 }
 
@@ -14792,12 +14600,6 @@ exports[`StoryPromo Container should render video correctly for canonical 1`] = 
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-28 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0 emotion-1"
@@ -15118,12 +14920,6 @@ exports[`StoryPromo Container should render video promoType leading on amp 1`] =
   .emotion-12 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-12 {
-    color: #E6E8EA;
   }
 }
 
@@ -15692,12 +15488,6 @@ exports[`StoryPromo Container should render video promoType top on amp 1`] = `
   .emotion-27 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-27 {
-    color: #E6E8EA;
   }
 }
 

--- a/src/app/legacy/psammead/psammead-timestamp-container/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-timestamp-container/src/__snapshots__/index.test.jsx.snap
@@ -30,12 +30,6 @@ exports[`Timestamp should add prefix and suffix 1`] = `
   padding-bottom: 1rem;
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-0 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <time
     class="emotion-0 emotion-1"
@@ -76,12 +70,6 @@ exports[`Timestamp should render correctly 1`] = `
   padding-bottom: 1rem;
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-0 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <time
     class="emotion-0 emotion-1"
@@ -120,12 +108,6 @@ exports[`Timestamp should render without a leading zero on the day 1`] = `
 
 .emotion-0:last-child {
   padding-bottom: 1rem;
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-0 {
-    color: #E6E8EA;
-  }
 }
 
 <div>

--- a/src/app/legacy/psammead/psammead-timestamp/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-timestamp/src/__snapshots__/index.test.jsx.snap
@@ -30,12 +30,6 @@ exports[`Timestamp should render Timestamp correctly 1`] = `
   padding-bottom: 1rem;
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-0 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <time
     class="emotion-0 emotion-1"
@@ -76,12 +70,6 @@ exports[`Timestamp should render Timestamp with a prefix 1`] = `
   padding-bottom: 1rem;
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-0 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <time
     class="emotion-0 emotion-1"
@@ -114,12 +102,6 @@ exports[`Timestamp should render Timestamp without padding 1`] = `
   .emotion-0 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-0 {
-    color: #E6E8EA;
   }
 }
 

--- a/src/app/legacy/psammead/psammead-timestamp/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-timestamp/src/index.jsx
@@ -18,10 +18,6 @@ const StyledTimestamp = styled.time`
   display: block;
   ${({ theme: { fontVariants } }) => fontVariants.sansRegular};
   ${props => props.padding && PADDING}
-
-  @media (prefers-color-scheme: dark) {
-    ${({ theme }) => !theme.isDarkUi && `color: ${theme.palette.GREY_3};`}
-  }
 `;
 
 const Timestamp = ({ children, datetime, padding = true, className = '' }) => (

--- a/src/app/pages/ArticlePage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/ArticlePage/__snapshots__/index.test.tsx.snap
@@ -834,12 +834,6 @@ exports[`Article Page should render a ltr article (pidgin) with most read correc
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-33 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <div
     class="emotion-0"
@@ -2029,12 +2023,6 @@ exports[`Article Page should render a news article correctly 1`] = `
   .emotion-37 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-37 {
-    color: #E6E8EA;
   }
 }
 
@@ -4195,12 +4183,6 @@ exports[`Article Page should render a rtl article (persian) with most read corre
   .emotion-33 {
     font-size: 0.8125rem;
     line-height: 1.25rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-33 {
-    color: #E6E8EA;
   }
 }
 

--- a/src/app/pages/LiveRadioPage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/LiveRadioPage/__snapshots__/index.test.tsx.snap
@@ -751,12 +751,6 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-42 {
-    color: #E6E8EA;
-  }
-}
-
 .emotion-44 {
   padding-top: 0.5rem;
   background-color: #FFFFFF;

--- a/src/app/pages/MediaArticlePage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/MediaArticlePage/__snapshots__/index.test.tsx.snap
@@ -629,12 +629,6 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   padding-bottom: 1rem;
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-28 {
-    color: #E6E8EA;
-  }
-}
-
 .emotion-32 {
   font-size: 1.25rem;
   line-height: 1.5rem;

--- a/src/app/pages/MostReadPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MostReadPage/__snapshots__/index.test.jsx.snap
@@ -640,12 +640,6 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-24 {
-    color: #E6E8EA;
-  }
-}
-
 <div>
   <noscript
     id="analytics-noscript"

--- a/src/app/pages/OnDemandAudioPage/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OnDemandAudioPage/__snapshots__/index.test.tsx.snap
@@ -873,12 +873,6 @@ exports[`OnDemand Radio Page  should match snapshot 1`] = `
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-56 {
-    color: #E6E8EA;
-  }
-}
-
 .emotion-58 {
   padding-top: 0.5rem;
   background-color: #FFFFFF;
@@ -2874,12 +2868,6 @@ exports[`OnDemand Radio Page  should show the 'content not yet available' messag
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .emotion-58 {
-    color: #E6E8EA;
-  }
-}
-
 .emotion-60 {
   padding-top: 0.5rem;
   background-color: #FFFFFF;
@@ -4777,12 +4765,6 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
   .emotion-58 {
     font-size: 0.8125rem;
     line-height: 1rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .emotion-58 {
-    color: #E6E8EA;
   }
 }
 


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Rolls back darkUI changes introduced in https://github.com/bbc/simorgh/pull/14165

(Not saying this is the best approach - but it's the quickest) - Note this issue is only present for users with dark mode enabled - (browser, operating system - not sure? - context [here](https://bbc-tpg.slack.com/archives/C03RMKNL7GC/p1782998790336259))

Live for users on Chrome with dark mode enabled AND local on latest
<img width="1021" height="769" alt="Screenshot 2026-07-02 at 15 00 48" src="https://github.com/user-attachments/assets/256e5738-9de4-40ee-b3c8-5b8953042b0b" />

Local for this PR
<img width="1251" height="821" alt="Screenshot 2026-07-02 at 15 00 56" src="https://github.com/user-attachments/assets/7a5d9662-2107-4e3c-ae95-4c0cb471524c" />



Code changes
======
- _List key code changes that have been made._

Testing
======
1. Go to latest locally, see c

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
