### PR TITLE
Fix Magyarul & Romania secondary nav tests

### DIFF
--- a/ws-nextjs-app/cypress/e2e/testsForAllAMPPages.ts
+++ b/ws-nextjs-app/cypress/e2e/testsForAllAMPPages.ts
@@ -12,7 +12,9 @@ export default ({ service, pageType }: ServiceParametersType) => {
       const twoTierNavServices = {
         local: null, // Don't test two tier nav locally as the local environment can't fetch config
         test: ['arabic', 'tamil'], // Test env isn't guaranteed to have the new nav config, so only run tests for services we know have it
-        live: SERVICES_WITH_NEW_NAV,
+        live: SERVICES_WITH_NEW_NAV.filter(
+          s => !['magyarul', 'romania'].includes(s),
+        ), // As of 13/07/2026, Magyarul and Romania do not have enough content for the new nav to be rendered, so these are excluded for now.
       };
 
       const cypressAppEnv = getAppEnv();

--- a/ws-nextjs-app/cypress/e2e/testsForAllAMPPages.ts
+++ b/ws-nextjs-app/cypress/e2e/testsForAllAMPPages.ts
@@ -9,12 +9,15 @@ export default ({ service, pageType }: ServiceParametersType) => {
     describe('Header Tests', () => {
       const serviceName = config[service]?.name || service;
 
+      // As of 13/07/2026, Magyarul and Romania do not have enough content for the new nav to be rendered
+      const excludedNavServices = ['magyarul', 'romania'];
+
       const twoTierNavServices = {
         local: null, // Don't test two tier nav locally as the local environment can't fetch config
         test: ['arabic', 'tamil'], // Test env isn't guaranteed to have the new nav config, so only run tests for services we know have it
         live: SERVICES_WITH_NEW_NAV.filter(
-          s => !['magyarul', 'romania'].includes(s),
-        ), // As of 13/07/2026, Magyarul and Romania do not have enough content for the new nav to be rendered, so these are excluded for now.
+          s => !excludedNavServices.includes(s),
+        ),
       };
 
       const cypressAppEnv = getAppEnv();

--- a/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
+++ b/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
@@ -32,7 +32,9 @@ export default ({ service, pageType }: ServiceParametersType) => {
     const twoTierNavServices = {
       local: null, // Don't test two tier nav locally as the local environment can't fetch config
       test: ['arabic', 'tamil'], // Test env isn't guaranteed to have the new nav config, so only run tests for services we know have it
-      live: SERVICES_WITH_NEW_NAV,
+      live: SERVICES_WITH_NEW_NAV.filter(
+        s => !['magyarul', 'romania'].includes(s),
+      ), // As of 13/07/2026, Magyarul and Romania do not have enough content for the new nav to be rendered, so these are excluded for now.
     };
 
     const cypressAppEnv = getAppEnv();

--- a/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
+++ b/ws-nextjs-app/cypress/e2e/testsForAllCanonicalPages.ts
@@ -29,12 +29,13 @@ export default ({ service, pageType }: ServiceParametersType) => {
   describe('Header Tests', () => {
     const serviceName = config[service]?.name || service;
 
+    // As of 13/07/2026, Magyarul and Romania do not have enough content for the new nav to be rendered
+    const excludedNavServices = ['magyarul', 'romania'];
+
     const twoTierNavServices = {
       local: null, // Don't test two tier nav locally as the local environment can't fetch config
       test: ['arabic', 'tamil'], // Test env isn't guaranteed to have the new nav config, so only run tests for services we know have it
-      live: SERVICES_WITH_NEW_NAV.filter(
-        s => !['magyarul', 'romania'].includes(s),
-      ), // As of 13/07/2026, Magyarul and Romania do not have enough content for the new nav to be rendered, so these are excluded for now.
+      live: SERVICES_WITH_NEW_NAV.filter(s => !excludedNavServices.includes(s)),
     };
 
     const cypressAppEnv = getAppEnv();


### PR DESCRIPTION
Resolves JIRA: 

Summary
======
Removes magyarul and romania from two tier nav tests only, not the config. Should only affect/fix tests

Code changes
======
- _List key code changes that have been made._

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
