### PR TITLE
WS-NA: Removes dud lite site link

### DIFF
--- a/src/app/lib/config/services/romania.ts
+++ b/src/app/lib/config/services/romania.ts
@@ -85,7 +85,6 @@ export const service: DefaultServiceConfig = {
         toMainSite: 'Înapoi la site-ul principal',
         informationPage:
           'Află mai multe despre această versiune care economisește date',
-        informationPageLink: '#',
         dataSaving: 'Versiune site cu minim trafic de date',
         articleDataSavingLinkText: 'Versiune site cu minim trafic de date',
       },


### PR DESCRIPTION
Resolves JIRA: WS-NA

Summary
======
Prevents link for Lite Site info page from rendering on Romaina. It currently renders with an invalid link, causing the e2e tests to fail.

(Have checked that editorial do not want to provide a lite info page [here](https://bbc-tpg.slack.com/archives/C03RMKNL7GC/p1784016854186249).)

Code changes
======
- Removes placeholder link from config (logic already exists that means if there is no link provided, the link will not render.)

Testing
======
1. Visit http://localhost.bbc.com:7081/romania/articles/cm2dmpzzv3eo.lite?renderer_env=live and check that only 'take me to the main site' link renders.

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
