### PR TITLE
Uzbek: Add in-article promo

### DIFF
--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -58,19 +58,18 @@ const defaultCyrillicConfig = {
   imageCaptionOffscreenText: 'Сурат тагсўзи, ',
   imageCopyrightOffscreenText: 'Сурат манбаси, ',
   podcastPromo: {
-      title: 'WhatsApp канали рекламаси',
-      brandTitle: 'Бизни WhatsApp да ҳам кузатинг',
-      brandDescription:
-        `BBC News O‘zbek контенти энди Сизнинг WhatsApp да`,
-      image: {
-        src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0nytqnd.png',
-        alt: `BBC News O'zbek Obuna bo'ling!`,
-      },
-      linkLabel: {
-        text: 'Аъзо бўлиш учун бу ерга босинг',
-        href: 'https://www.whatsapp.com/channel/0029Vb6cFgKHAdNMsH1hKy2H',
-      },
+    title: 'WhatsApp канали рекламаси',
+    brandTitle: 'Бизни WhatsApp да ҳам кузатинг',
+    brandDescription: `BBC News O‘zbek контенти энди Сизнинг WhatsApp да`,
+    image: {
+      src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0nytqnd.png',
+      alt: `BBC News O'zbek Obuna bo'ling!`,
     },
+    linkLabel: {
+      text: 'Аъзо бўлиш учун бу ерга босинг',
+      href: 'https://www.whatsapp.com/channel/0029Vb6cFgKHAdNMsH1hKy2H',
+    },
+  },
   translations: {
     and: 'ва',
     readTime: {
@@ -494,13 +493,12 @@ export const service: UzbekConfig = {
     imageCaptionOffscreenText: 'Surat tagso‘zi, ',
     imageCopyrightOffscreenText: 'Surat manbasi, ',
     podcastPromo: {
-        title: 'WhatsApp kanali reklamasi',
-        brandTitle: 'Bizni WhatsApp da ham kuzating',
-        brandDescription:
-          `BBC News O‘zbek kontenti endi Sizning WhatsApp da`,
-        image: {
-          src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0nytqnd.png',
-          alt: `BBC News O'zbek Obuna bo'ling!`,
+      title: 'WhatsApp kanali reklamasi',
+      brandTitle: 'Bizni WhatsApp da ham kuzating',
+      brandDescription: `BBC News O‘zbek kontenti endi Sizning WhatsApp da`,
+      image: {
+        src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0nytqnd.png',
+        alt: `BBC News O'zbek Obuna bo'ling!`,
       },
       linkLabel: {
         text: 'A’zo bo‘lish uchun bu erga bosing',

--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -29,20 +29,6 @@ const baseServiceConfig = {
   },
   showAdPlaceholder: true,
   showRelatedTopics: true,
-  podcastPromo: {
-      title: 'WhatsApp канали рекламаси',
-      brandTitle: 'Бизни WhatsApp да ҳам кузатинг',
-      brandDescription:
-        `BBC News O‘zbek контенти энди Сизнинг WhatsApp да`,
-      image: {
-        src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0nytqnd.png',
-        alt: `BBC News O'zbek Obuna bo'ling!`,
-      },
-      linkLabel: {
-        text: 'Аъзо бўлиш учун бу ерга босинг',
-        href: 'https://www.whatsapp.com/channel/0029Vb6cFgKHAdNMsH1hKy2H',
-      },
-    },
   timezone: 'GMT',
 };
 
@@ -71,6 +57,20 @@ const defaultCyrillicConfig = {
   videoCaptionOffscreenText: 'Видео тагсўзи, ',
   imageCaptionOffscreenText: 'Сурат тагсўзи, ',
   imageCopyrightOffscreenText: 'Сурат манбаси, ',
+  podcastPromo: {
+      title: 'WhatsApp канали рекламаси',
+      brandTitle: 'Бизни WhatsApp да ҳам кузатинг',
+      brandDescription:
+        `BBC News O‘zbek контенти энди Сизнинг WhatsApp да`,
+      image: {
+        src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0nytqnd.png',
+        alt: `BBC News O'zbek Obuna bo'ling!`,
+      },
+      linkLabel: {
+        text: 'Аъзо бўлиш учун бу ерга босинг',
+        href: 'https://www.whatsapp.com/channel/0029Vb6cFgKHAdNMsH1hKy2H',
+      },
+    },
   translations: {
     and: 'ва',
     readTime: {

--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -29,6 +29,20 @@ const baseServiceConfig = {
   },
   showAdPlaceholder: true,
   showRelatedTopics: true,
+  podcastPromo: {
+      title: 'WhatsApp канали рекламаси',
+      brandTitle: 'Бизни WhatsApp да ҳам кузатинг',
+      brandDescription:
+        `BBC News O‘zbek контенти энди Сизнинг WhatsApp да`,
+      image: {
+        src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0nytqnd.png',
+        alt: `BBC News O'zbek Obuna bo'ling!`,
+      },
+      linkLabel: {
+        text: 'Аъзо бўлиш учун бу ерга босинг',
+        href: 'https://www.whatsapp.com/channel/0029Vb6cFgKHAdNMsH1hKy2H',
+      },
+    },
   timezone: 'GMT',
 };
 
@@ -506,6 +520,20 @@ export const service: UzbekConfig = {
       skipLinkText: 'Sahifaga o‘tish',
       relatedContent: 'Mavzuga aloqador',
       relatedTopics: 'Aloqador mavzular',
+      podcastPromo: {
+        title: 'WhatsApp kanali reklamasi',
+        brandTitle: 'Bizni WhatsApp da ham kuzating',
+        brandDescription:
+          `BBC News O‘zbek kontenti endi Sizning WhatsApp da`,
+        image: {
+          src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0nytqnd.png',
+          alt: `BBC News O'zbek Obuna bo'ling!`,
+      },
+      linkLabel: {
+        text: 'A’zo bo‘lish uchun bu erga bosing',
+        href: 'https://www.whatsapp.com/channel/0029Vb6cFgKHAdNMsH1hKy2H',
+      },
+    },
       navMenuText: 'Bo‘limlar',
       liteSite: {
         onboardingMessage:

--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -493,6 +493,20 @@ export const service: UzbekConfig = {
     videoCaptionOffscreenText: 'Video tagso‘zi, ',
     imageCaptionOffscreenText: 'Surat tagso‘zi, ',
     imageCopyrightOffscreenText: 'Surat manbasi, ',
+    podcastPromo: {
+        title: 'WhatsApp kanali reklamasi',
+        brandTitle: 'Bizni WhatsApp da ham kuzating',
+        brandDescription:
+          `BBC News O‘zbek kontenti endi Sizning WhatsApp da`,
+        image: {
+          src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0nytqnd.png',
+          alt: `BBC News O'zbek Obuna bo'ling!`,
+      },
+      linkLabel: {
+        text: 'A’zo bo‘lish uchun bu erga bosing',
+        href: 'https://www.whatsapp.com/channel/0029Vb6cFgKHAdNMsH1hKy2H',
+      },
+    },
     translations: {
       and: 'va',
       readTime: {
@@ -520,20 +534,6 @@ export const service: UzbekConfig = {
       skipLinkText: 'Sahifaga o‘tish',
       relatedContent: 'Mavzuga aloqador',
       relatedTopics: 'Aloqador mavzular',
-      podcastPromo: {
-        title: 'WhatsApp kanali reklamasi',
-        brandTitle: 'Bizni WhatsApp da ham kuzating',
-        brandDescription:
-          `BBC News O‘zbek kontenti endi Sizning WhatsApp da`,
-        image: {
-          src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0nytqnd.png',
-          alt: `BBC News O'zbek Obuna bo'ling!`,
-      },
-      linkLabel: {
-        text: 'A’zo bo‘lish uchun bu erga bosing',
-        href: 'https://www.whatsapp.com/channel/0029Vb6cFgKHAdNMsH1hKy2H',
-      },
-    },
       navMenuText: 'Bo‘limlar',
       liteSite: {
         onboardingMessage:


### PR DESCRIPTION
Resolves JIRA:  n/a 

Overall changes
======
- Adds in-article promo for WhatsApp to BBC Uzbek






Code changes
======

- Added podcastPromo section to src/app/lib/config/services/uzbek.ts both on the default and Latin configurations 

Testing
======

Open a Uzbek Cyrillic article , the in-article prmo should show.
Same for a Latin article

<img width="323" height="479" alt="image" src="https://github.com/user-attachments/assets/57685825-cd9f-4db3-af68-cf760fc976ae" />
<img width="337" height="480" alt="image" src="https://github.com/user-attachments/assets/eeb430da-c0c7-4ac5-b95e-8ef15819766e" />






## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
