### PR TITLE
Update Hindi in-article promo

### DIFF
--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -50,11 +50,11 @@ export const service: DefaultServiceConfig = {
     googleSiteVerification: 'D-aEHUiyVaMoUJXjVRbDVkxS0dLTMUZLD3dLPTnWO4Q',
     podcastPromo: {
       title: 'पॉडकास्ट',
-      brandTitle: 'दिनभर: पूरा दिन,पूरी ख़बर (Dinbhar)',
+      brandTitle: 'Dinbhar: आवाज़ वही, अंदाज़ नया',
       brandDescription:
-        'वो राष्ट्रीय और अंतरराष्ट्रीय ख़बरें जो दिनभर सुर्खियां बनीं.',
+        'देश - दुनिया की बड़ी ख़बरें  जिन्होंने बटोरी सुर्खियां.',
       image: {
-        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p09ds7cb.jpg',
+        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0nq9t7p.jpg',
         alt: 'दिनभर',
       },
       linkLabel: {


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======

- Update BBC Hindi's in-article promo for the relaunch of Diinbahr


Code changes
======

- Edited podcasPromo section of src/app/lib/config/services/hindi.ts 

Testing
======
1. Open a article on the Hindi site, the in-article promo should display a new image, title and description:
<img width="642" height="884" alt="image" src="https://github.com/user-attachments/assets/1848b414-083e-4259-b8cc-98311f4734a0" />


