### PR TITLE
WS-3038: Server-side experiments not tracking Optimizely page metrics

### DIFF
--- a/src/app/components/OptimizelyPageMetrics/experimentsForPageMetrics.ts
+++ b/src/app/components/OptimizelyPageMetrics/experimentsForPageMetrics.ts
@@ -11,7 +11,10 @@ type ExperimentsForPageTypeMetrics = {
 const experimentsForPageMetrics: ExperimentsForPageTypeMetrics = [
   {
     pageType: ARTICLE_PAGE,
-    activeExperiments: ['test_page_views_aa_3'],
+    activeExperiments: [
+      'test_page_views_aa_3',
+      'newswb_ws_article_account_promo_banner',
+    ],
   },
   {
     pageType: MEDIA_ARTICLE_PAGE,

--- a/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.client.test.tsx
+++ b/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.client.test.tsx
@@ -405,11 +405,36 @@ describe('withOptimizelyProvider HOC', () => {
       expect(mockTrack).not.toHaveBeenCalled();
     });
 
-    it('should not call optimizely.track when flagKey is missing', () => {
+    it('should not call optimizely.track when both flagKey and experimentKey are missing', () => {
       capturedDecisionListener?.({
         decisionInfo: {
           variationKey: 'on',
           decisionEventDispatched: true,
+        },
+      });
+
+      expect(mockTrack).not.toHaveBeenCalled();
+    });
+
+    it('should call optimizely.track with page-views for a legacy activate() decision (experimentKey without decisionEventDispatched)', () => {
+      capturedDecisionListener?.({
+        decisionInfo: {
+          experimentKey: 'newswb_ws_article_account_promo_banner',
+          variationKey: 'on',
+        },
+      });
+
+      expect(mockTrack.mock.calls.map(call => call[0])).toEqual([
+        'visit',
+        'page-views',
+      ]);
+    });
+
+    it('should not call optimizely.track for a legacy activate() decision when variationKey is off', () => {
+      capturedDecisionListener?.({
+        decisionInfo: {
+          experimentKey: 'newswb_ws_article_account_promo_banner',
+          variationKey: 'off',
         },
       });
 

--- a/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.tsx
+++ b/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.tsx
@@ -46,6 +46,7 @@ optimizely?.notificationCenter?.addNotificationListener(
     notification: ListenerPayload & {
       decisionInfo?: {
         flagKey?: string;
+        experimentKey?: string;
         variationKey?: string;
         decisionEventDispatched?: boolean;
       };
@@ -53,30 +54,37 @@ optimizely?.notificationCenter?.addNotificationListener(
   ) => {
     if (!onClient()) return;
 
-    const flagKey = notification.decisionInfo?.flagKey;
-    const variationKey = notification.decisionInfo?.variationKey;
+    const { decisionInfo } = notification;
+    const variationKey = decisionInfo?.variationKey;
 
-    if (flagKey && variationKey && variationKey !== 'off') {
-      const decisionEventDispatched =
-        notification.decisionInfo?.decisionEventDispatched;
+    // Flag decisions (decide API) expose flagKey; legacy experiment decisions
+    // (activate API, used by server-side experiments) expose experimentKey.
+    const experimentKey = decisionInfo?.flagKey ?? decisionInfo?.experimentKey;
 
-      if (decisionEventDispatched) {
-        const currentUrl = window.location.pathname + window.location.search;
-        if (currentUrl !== lastTrackedUrl) {
-          lastTrackedUrl = currentUrl;
+    if (!experimentKey || !variationKey || variationKey === 'off') return;
 
-          // the visit (denominator) must be sent before the page view (numerator)
-          // so the page view falls inside Optimizely's ratio metric attribution window
-          if (registerVisitActivity(Date.now())) {
-            optimizely.track(VISIT_EVENT_NAME);
-          }
+    // Flag decisions only send an impression when decisionEventDispatched is true.
+    // Legacy activate() always sends an impression, so no such flag is provided.
+    const impressionDispatched = decisionInfo?.flagKey
+      ? Boolean(decisionInfo?.decisionEventDispatched)
+      : true;
 
-          optimizely.track(PAGE_VIEW_EVENT_NAME);
+    if (impressionDispatched) {
+      const currentUrl = window.location.pathname + window.location.search;
+      if (currentUrl !== lastTrackedUrl) {
+        lastTrackedUrl = currentUrl;
+
+        // the visit (denominator) must be sent before the page view (numerator)
+        // so the page view falls inside Optimizely's ratio metric attribution window
+        if (registerVisitActivity(Date.now())) {
+          optimizely.track(VISIT_EVENT_NAME);
         }
-      }
 
-      notifyDecision(flagKey);
+        optimizely.track(PAGE_VIEW_EVENT_NAME);
+      }
     }
+
+    notifyDecision(experimentKey);
   },
 );
 

--- a/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.tsx
+++ b/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.tsx
@@ -47,13 +47,13 @@ type DecisionInfo = {
   decisionEventDispatched?: boolean;
 };
 
-// Downstream (decision store + page metrics) every experiment is keyed by a
-// single identifier. Optimizely's DECISION notification exposes that identifier
-// differently depending on the experiment type:
-// - Client-side experiments use the Flags (decide) API, identified by a flag key,
-//   and only count an impression when `decisionEventDispatched` is true.
-// - Server-side experiments use the legacy activate API, identified by a rule key
-//   (exposed by the SDK as `experimentKey`), and always dispatch an impression.
+// Optimizely reports a decision in one of two shapes depending on the experiment type.
+// We normalise both into a single `decisionKey` + `impressionDispatched` so the rest
+// of the app doesn't need to know which type it was:
+// - Client-side (Flags/decide API): uses `flagKey`; an impression is only counted
+//   when `decisionEventDispatched` is true.
+// - Server-side (legacy activate API): uses `experimentKey` (the rule key) and
+//   always counts an impression.
 const resolveDecision = (decisionInfo?: DecisionInfo) => {
   const clientSideFlagKey = decisionInfo?.flagKey;
   const serverSideRuleKey = decisionInfo?.experimentKey;

--- a/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.tsx
+++ b/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.tsx
@@ -54,37 +54,35 @@ optimizely?.notificationCenter?.addNotificationListener(
   ) => {
     if (!onClient()) return;
 
-    const { decisionInfo } = notification;
-    const variationKey = decisionInfo?.variationKey;
+    const flagKey = notification.decisionInfo?.flagKey;
+    const experimentKey = flagKey ?? notification.decisionInfo?.experimentKey;
+    const variationKey = notification.decisionInfo?.variationKey;
 
-    // Flag decisions (decide API) expose flagKey; legacy experiment decisions
-    // (activate API, used by server-side experiments) expose experimentKey.
-    const experimentKey = decisionInfo?.flagKey ?? decisionInfo?.experimentKey;
+    if (experimentKey && variationKey && variationKey !== 'off') {
+      // Flag decisions (decide API) only send an impression when
+      // decisionEventDispatched is true; legacy activate() decisions
+      // (server-side experiments) always send one.
+      const decisionEventDispatched = flagKey
+        ? notification.decisionInfo?.decisionEventDispatched
+        : true;
 
-    if (!experimentKey || !variationKey || variationKey === 'off') return;
+      if (decisionEventDispatched) {
+        const currentUrl = window.location.pathname + window.location.search;
+        if (currentUrl !== lastTrackedUrl) {
+          lastTrackedUrl = currentUrl;
 
-    // Flag decisions only send an impression when decisionEventDispatched is true.
-    // Legacy activate() always sends an impression, so no such flag is provided.
-    const impressionDispatched = decisionInfo?.flagKey
-      ? Boolean(decisionInfo?.decisionEventDispatched)
-      : true;
+          // the visit (denominator) must be sent before the page view (numerator)
+          // so the page view falls inside Optimizely's ratio metric attribution window
+          if (registerVisitActivity(Date.now())) {
+            optimizely.track(VISIT_EVENT_NAME);
+          }
 
-    if (impressionDispatched) {
-      const currentUrl = window.location.pathname + window.location.search;
-      if (currentUrl !== lastTrackedUrl) {
-        lastTrackedUrl = currentUrl;
-
-        // the visit (denominator) must be sent before the page view (numerator)
-        // so the page view falls inside Optimizely's ratio metric attribution window
-        if (registerVisitActivity(Date.now())) {
-          optimizely.track(VISIT_EVENT_NAME);
+          optimizely.track(PAGE_VIEW_EVENT_NAME);
         }
-
-        optimizely.track(PAGE_VIEW_EVENT_NAME);
       }
-    }
 
-    notifyDecision(experimentKey);
+      notifyDecision(experimentKey);
+    }
   },
 );
 

--- a/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.tsx
+++ b/src/app/legacy/containers/PageHandlers/withOptimizelyProvider/index.tsx
@@ -40,33 +40,47 @@ const optimizely = createInstance({
   eventFlushInterval: 100,
 });
 
+type DecisionInfo = {
+  flagKey?: string;
+  experimentKey?: string;
+  variationKey?: string;
+  decisionEventDispatched?: boolean;
+};
+
+// Downstream (decision store + page metrics) every experiment is keyed by a
+// single identifier. Optimizely's DECISION notification exposes that identifier
+// differently depending on the experiment type:
+// - Client-side experiments use the Flags (decide) API, identified by a flag key,
+//   and only count an impression when `decisionEventDispatched` is true.
+// - Server-side experiments use the legacy activate API, identified by a rule key
+//   (exposed by the SDK as `experimentKey`), and always dispatch an impression.
+const resolveDecision = (decisionInfo?: DecisionInfo) => {
+  const clientSideFlagKey = decisionInfo?.flagKey;
+  const serverSideRuleKey = decisionInfo?.experimentKey;
+  const isClientSideDecision = Boolean(clientSideFlagKey);
+
+  return isClientSideDecision
+    ? {
+        decisionKey: clientSideFlagKey,
+        impressionDispatched: Boolean(decisionInfo?.decisionEventDispatched),
+      }
+    : {
+        decisionKey: serverSideRuleKey,
+        impressionDispatched: Boolean(serverSideRuleKey),
+      };
+};
+
 optimizely?.notificationCenter?.addNotificationListener(
   enums.NOTIFICATION_TYPES.DECISION,
-  (
-    notification: ListenerPayload & {
-      decisionInfo?: {
-        flagKey?: string;
-        experimentKey?: string;
-        variationKey?: string;
-        decisionEventDispatched?: boolean;
-      };
-    },
-  ) => {
+  (notification: ListenerPayload & { decisionInfo?: DecisionInfo }) => {
     if (!onClient()) return;
 
-    const flagKey = notification.decisionInfo?.flagKey;
-    const experimentKey = flagKey ?? notification.decisionInfo?.experimentKey;
-    const variationKey = notification.decisionInfo?.variationKey;
+    const { decisionInfo } = notification;
+    const variationKey = decisionInfo?.variationKey;
+    const { decisionKey, impressionDispatched } = resolveDecision(decisionInfo);
 
-    if (experimentKey && variationKey && variationKey !== 'off') {
-      // Flag decisions (decide API) only send an impression when
-      // decisionEventDispatched is true; legacy activate() decisions
-      // (server-side experiments) always send one.
-      const decisionEventDispatched = flagKey
-        ? notification.decisionInfo?.decisionEventDispatched
-        : true;
-
-      if (decisionEventDispatched) {
+    if (decisionKey && variationKey && variationKey !== 'off') {
+      if (impressionDispatched) {
         const currentUrl = window.location.pathname + window.location.search;
         if (currentUrl !== lastTrackedUrl) {
           lastTrackedUrl = currentUrl;
@@ -81,7 +95,7 @@ optimizely?.notificationCenter?.addNotificationListener(
         }
       }
 
-      notifyDecision(experimentKey);
+      notifyDecision(decisionKey);
     }
   },
 );


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-3038

Summary
======
Server-side experiments (e.g. the account promo banner) weren't recording any Optimizely page metrics - Page Views showed 0 despite a ~50/50 visitor split, and completes/scroll depth never fired. This PR makes page metrics work for server-side experiments.

Code changes
======
- `withOptimizelyProvider`: the DECISION listener now also handles legacy `activate()` decisions (server-side), keying off `experimentKey` when `flagKey` is absent. Legacy activations always dispatch an impression, so `page-views`/`visit` are tracked directly, and `notifyDecision` now fires — populating the decision store that gates `OptimizelyPageMetrics` (previously `activatedExperiments` stayed empty).
- `experimentsForPageMetrics`: registered `newswb_ws_article_account_promo_banner` on `ARTICLE_PAGE` to opt it into page complete + scroll depth.
- Added tests for the legacy `activate()` path (tracks `visit`/`page-views`, skips when variation is `off`).