### PR TITLE
Add profiling support and CSS optimization for AMP/Lite builds

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,12 @@
       "command": "cd ws-nextjs-app && nvm use && yarn dev"
     },
     {
+      "name": "Profile Next.js: production standalone",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "cd ws-nextjs-app && nvm use && PROFILE_SERVER=1 yarn build && NODE_ENV=production HOSTNAME=127.0.0.1 PORT=7081 node build/standalone/ws-nextjs-app/server.js"
+    },
+    {
       "name": "Storybook debug",
       "type": "node-terminal",
       "request": "launch",

--- a/src/app/lib/logger.const.js
+++ b/src/app/lib/logger.const.js
@@ -94,6 +94,9 @@ const logCodes = {
   // Build manifest errors
   BUILD_MANIFEST_CSS_READ_ERROR: 'build_manifest_css_read_error',
   DYNAMIC_IMPORT_CSS_READ_ERROR: 'dynamic_import_css_read_error',
+
+  // AMP/Lite CSS size diagnostics
+  AMP_LITE_CSS_SIZE_METRIC: 'amp_lite_css_size_metric',
 };
 
 module.exports = logCodes;

--- a/ws-nextjs-app/next.config.js
+++ b/ws-nextjs-app/next.config.js
@@ -151,6 +151,17 @@ module.exports = {
       );
     }
 
+    // Opt-in only: disable server bundle minification and emit source maps so
+    // CPU profiles taken against a production build (e.g. via VS Code's
+    // "Take Performance Profile" or `node --cpu-prof`) show real function names
+    // and file locations instead of minified single-letter identifiers.
+    // Never enabled unless PROFILE_SERVER=1 is explicitly set, so normal
+    // production builds are completely unaffected.
+    if (isServer && !dev && process.env.PROFILE_SERVER === '1') {
+      config.optimization.minimize = false;
+      config.devtool = 'source-map';
+    }
+
     return config;
   },
 };

--- a/ws-nextjs-app/pages/_document.page.tsx
+++ b/ws-nextjs-app/pages/_document.page.tsx
@@ -26,6 +26,10 @@ import CanonicalToLiteRedirect from '#utilities/CanonicalToLiteRedirect';
 import addOperaMiniClassScript from '#app/lib/utilities/addOperaMiniClassScript';
 import handleServerLogging from '#utilities/handleServerLogging';
 import getAmpLiteCss from '#utilities/getAmpLiteCss';
+import pruneUnusedCssCustomProperties from '#utilities/getAmpLiteCss/pruneUnusedCssCustomProperties';
+import nodeLogger from '#lib/logger.node';
+import logCodes from '#app/lib/logger.const';
+import { writeFileSync } from 'fs';
 import ComponentTracking from '../renderers/ComponentTracking';
 import ReverbTemplate from '../renderers/ReverbTemplate';
 import litePageTransforms from '../renderers/litePageTransforms';
@@ -85,6 +89,50 @@ const optimiseAmpCss = (css: string): string =>
     .replace(/;\}/g, '}')
     .replace(/\s{2,}/g, ' ')
     .trim();
+
+const logger = nodeLogger(__filename);
+
+const toKb = (value: string): number =>
+  Math.round((Buffer.byteLength(value, 'utf8') / 1024) * 100) / 100;
+
+// Temporary diagnostic: logs the byte size (KB) of each CSS source at the point
+// they are combined, so we can assess how much the Emotion critical CSS vs the
+// CSS Modules AMP/Lite output each contribute to the total inlined payload.
+const logCssSizeMetric = ({
+  variant,
+  emotionCss,
+  ampLiteCss,
+  combinedCss,
+  optimisedCss,
+}: {
+  variant: 'amp' | 'lite';
+  emotionCss: string;
+  ampLiteCss: string;
+  combinedCss: string;
+  optimisedCss?: string;
+}): void => {
+  logger.info(logCodes.AMP_LITE_CSS_SIZE_METRIC, {
+    variant,
+    emotionCssKb: toKb(emotionCss),
+    ampLiteCssKb: toKb(ampLiteCss),
+    combinedCssKb: toKb(combinedCss),
+    ...(optimisedCss !== undefined && {
+      optimisedCssKb: toKb(optimisedCss),
+    }),
+  });
+
+  // Temporary diagnostic dump: writes the raw CSS sources to disk so they can be
+  // inspected directly for minification and duplication. Never runs unless
+  // DEBUG_DUMP_AMP_CSS=1 is explicitly set, so this has no effect in normal use.
+  if (process.env.DEBUG_DUMP_AMP_CSS === '1') {
+    writeFileSync(`/tmp/${variant}-emotion-css.css`, emotionCss);
+    writeFileSync(`/tmp/${variant}-amp-lite-css.css`, ampLiteCss);
+    writeFileSync(`/tmp/${variant}-combined-css.css`, combinedCss);
+    if (optimisedCss !== undefined) {
+      writeFileSync(`/tmp/${variant}-optimised-css.css`, optimisedCss);
+    }
+  }
+};
 
 
 export default class AppDocument extends Document<DocProps> {
@@ -169,7 +217,16 @@ export default class AppDocument extends Document<DocProps> {
 
     switch (true) {
       case isAmp && pageType === 'article': {
-        const ampCss = optimiseAmpCss(css + getAmpLiteCss(getNextData()));
+        const ampLiteCss = getAmpLiteCss(getNextData());
+        const combinedCss = pruneUnusedCssCustomProperties(css + ampLiteCss);
+        const ampCss = optimiseAmpCss(combinedCss);
+        logCssSizeMetric({
+          variant: 'amp',
+          emotionCss: css,
+          ampLiteCss,
+          combinedCss,
+          optimisedCss: ampCss,
+        });
         return (
           <AmpRenderer
             bodyContent={<Main />}
@@ -184,7 +241,14 @@ export default class AppDocument extends Document<DocProps> {
         );
       }
       case isLite: {
-        const liteCss = css + getAmpLiteCss(getNextData());
+        const ampLiteCss = getAmpLiteCss(getNextData());
+        const liteCss = pruneUnusedCssCustomProperties(css + ampLiteCss);
+        logCssSizeMetric({
+          variant: 'lite',
+          emotionCss: css,
+          ampLiteCss,
+          combinedCss: liteCss,
+        });
         return (
           <LiteRenderer
             bodyContent={<Main />}

--- a/ws-nextjs-app/utilities/getAmpLiteCss/pruneUnusedCssCustomProperties.test.ts
+++ b/ws-nextjs-app/utilities/getAmpLiteCss/pruneUnusedCssCustomProperties.test.ts
@@ -1,0 +1,47 @@
+import pruneUnusedCssCustomProperties from './pruneUnusedCssCustomProperties';
+
+describe('pruneUnusedCssCustomProperties', () => {
+  it('returns the CSS unchanged when there are no :root blocks', () => {
+    const css = '.foo{color:red}';
+    expect(pruneUnusedCssCustomProperties(css)).toBe(css);
+  });
+
+  it('removes a custom property that is never referenced', () => {
+    const css = ':root{--used:red;--unused:blue}.foo{color:var(--used)}';
+    expect(pruneUnusedCssCustomProperties(css)).toBe(
+      ':root{--used:red}.foo{color:var(--used)}',
+    );
+  });
+
+  it('keeps all custom properties that are referenced', () => {
+    const css =
+      ':root{--a:1px;--b:2px}.foo{width:var(--a)}.bar{height:var(--b)}';
+    expect(pruneUnusedCssCustomProperties(css)).toBe(css);
+  });
+
+  it('drops the :root block entirely when none of its properties are used', () => {
+    const css = ':root{--unused:red}.foo{color:blue}';
+    expect(pruneUnusedCssCustomProperties(css)).toBe('.foo{color:blue}');
+  });
+
+  it('merges multiple :root blocks into one, keeping only used properties', () => {
+    const css =
+      ':root{--font:sans-serif}:root{--used:red;--unused:blue}.foo{font-family:var(--font);color:var(--used)}';
+    expect(pruneUnusedCssCustomProperties(css)).toBe(
+      ':root{--font:sans-serif;--used:red}.foo{font-family:var(--font);color:var(--used)}',
+    );
+  });
+
+  it('recognises usage with a fallback value, e.g. var(--name, fallback)', () => {
+    const css = ':root{--used:red}.foo{color:var(--used, blue)}';
+    expect(pruneUnusedCssCustomProperties(css)).toBe(css);
+  });
+
+  it('does not false-match a property name that is a prefix of another', () => {
+    const css =
+      ':root{--font-size-pica:1rem;--font-size-pica-large:2rem}.foo{font-size:var(--font-size-pica-large)}';
+    expect(pruneUnusedCssCustomProperties(css)).toBe(
+      ':root{--font-size-pica-large:2rem}.foo{font-size:var(--font-size-pica-large)}',
+    );
+  });
+});

--- a/ws-nextjs-app/utilities/getAmpLiteCss/pruneUnusedCssCustomProperties.ts
+++ b/ws-nextjs-app/utilities/getAmpLiteCss/pruneUnusedCssCustomProperties.ts
@@ -1,0 +1,45 @@
+/**
+ * Public API for this module: pruneUnusedCssCustomProperties (default export)
+ *
+ * Removes `:root` custom property declarations that are not referenced by
+ * `var(--name)` anywhere else in the supplied CSS.
+ *
+ * Context: theme SCSS emits the entire design-token set (e.g. the full
+ * font-size/line-height scale across every size group) into `:root` on every
+ * AMP/Lite request, regardless of which components are actually rendered on
+ * that page. Since AMP/Lite CSS is inlined per-request (rather than cached as
+ * an external stylesheet), unused tokens are pure dead weight in every
+ * response. This strips them before the CSS is inlined.
+ */
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const ROOT_BLOCK_REGEX = /:root\{([^}]*)\}/g;
+
+const isCustomPropertyUsed = (name: string, cssWithoutRootBlocks: string): boolean =>
+  new RegExp(`var\\(\\s*${escapeRegExp(name)}\\s*[,)]`).test(cssWithoutRootBlocks);
+
+const pruneUnusedCssCustomProperties = (css: string): string => {
+  const declarations = [...css.matchAll(ROOT_BLOCK_REGEX)].flatMap(([, body]) =>
+    body
+      .split(';')
+      .map(declaration => declaration.trim())
+      .filter(Boolean),
+  );
+
+  if (declarations.length === 0) return css;
+
+  const cssWithoutRootBlocks = css.replace(ROOT_BLOCK_REGEX, '');
+
+  const usedDeclarations = declarations.filter(declaration => {
+    const name = declaration.slice(0, declaration.indexOf(':')).trim();
+    return isCustomPropertyUsed(name, cssWithoutRootBlocks);
+  });
+
+  if (usedDeclarations.length === 0) return cssWithoutRootBlocks;
+
+  return `:root{${usedDeclarations.join(';')}}${cssWithoutRootBlocks}`;
+};
+
+export default pruneUnusedCssCustomProperties;


### PR DESCRIPTION
- Introduced a new launch configuration for profiling Next.js production builds.
- Enhanced logging with AMP/Lite CSS size metrics.
- Implemented `pruneUnusedCssCustomProperties` to remove unused CSS custom properties.
- Added tests for `pruneUnusedCssCustomProperties` to ensure correct functionality. [copilot]
