### PR TITLE
Temporarily ignore next security advisories pending 7-day upgrade

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -25,6 +25,15 @@ npmAuditExcludePackages: []
 npmAuditIgnoreAdvisories:
   - 1112686 # https://github.com/advisories/GHSA-p5wg-g6qr-c7cg
   - 1116970 # https://github.com/advisories/GHSA-w5hq-g745-h8pq
+  - 1124170 # https://github.com/advisories/GHSA-6gpp-xcg3-4w24 (next) - temporary, remove when upgrading to next@16.2.11
+  - 1124171 # https://github.com/advisories/GHSA-m99w-x7hq-7vfj (next) - temporary, remove when upgrading to next@16.2.11
+  - 1124184 # https://github.com/advisories/GHSA-89xv-2m56-2m9x (next) - temporary, remove when upgrading to next@16.2.11
+  - 1124186 # https://github.com/advisories/GHSA-68g3-v927-f742 (next) - temporary, remove when upgrading to next@16.2.11
+  - 1124188 # https://github.com/advisories/GHSA-4633-3j49-mh5q (next) - temporary, remove when upgrading to next@16.2.11
+  - 1124190 # https://github.com/advisories/GHSA-4c39-4ccg-62r3 (next) - temporary, remove when upgrading to next@16.2.11
+  - 1124192 # https://github.com/advisories/GHSA-p9j2-gv94-2wf4 (next) - temporary, remove when upgrading to next@16.2.11
+  - 1124194 # https://github.com/advisories/GHSA-q8wf-6r8g-63ch (next) - temporary, remove when upgrading to next@16.2.11
+  - 1124196 # https://github.com/advisories/GHSA-955p-x3mx-jcvp (next) - temporary, remove when upgrading to next@16.2.11
 
 plugins:
   - checksum: 5e73a1acbb9741fce1e8335e243c9480ea2107b9b4b65ed7643785ddea9e3019aee254a92a853b1cd71023b16fff5b7d3afd5256fe57cd35a54f8785b8c30281


### PR DESCRIPTION
Issue : CI build failing due to these security advisores
https://github.com/bbc/simorgh/actions/runs/29988067812/job/89144303177?pr=14242

Resolves JIRA: N/A

Summary
======
Added  to npmAuditIgnoreAdvisories  based on review comment
https://github.com/bbc/simorgh/pull/14252#issuecomment-5056425427

