### PR TITLE
Cleanup of redundant npm ignored advisories

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -23,8 +23,6 @@ supportedArchitectures:
 npmAuditExcludePackages: []
 
 npmAuditIgnoreAdvisories:
-  - 1112686 # https://github.com/advisories/GHSA-p5wg-g6qr-c7cg
-  - 1116970 # https://github.com/advisories/GHSA-w5hq-g745-h8pq
   - 1124170 # https://github.com/advisories/GHSA-6gpp-xcg3-4w24 (next) - temporary, remove when upgrading to next@16.2.11
   - 1124171 # https://github.com/advisories/GHSA-m99w-x7hq-7vfj (next) - temporary, remove when upgrading to next@16.2.11
   - 1124184 # https://github.com/advisories/GHSA-89xv-2m56-2m9x (next) - temporary, remove when upgrading to next@16.2.11


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Removes redundant npm ignore advisories

Code changes
======
- Removal of uuid advisory as we have upgraded to the patched version
- Removal of eslint advisory that was withdrawn

Testing
======
N/A

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
