### PR TITLE
Adds overflow hidden to menu button

### DIFF
--- a/src/app/components/Navigation/__snapshots__/index.amp.test.tsx.snap
+++ b/src/app/components/Navigation/__snapshots__/index.amp.test.tsx.snap
@@ -239,6 +239,7 @@ exports[`AMP Navigation Snapshots should correctly render AMP navigation 1`] = `
   width: 2.75rem;
   background-color: #B80000;
   color: #FFFFFF;
+  overflow: hidden;
   width: 2.75rem;
   height: 2.75rem;
 }

--- a/src/app/components/Navigation/__snapshots__/index.canonical.test.tsx.snap
+++ b/src/app/components/Navigation/__snapshots__/index.canonical.test.tsx.snap
@@ -226,6 +226,7 @@ exports[`Navigation - Canonical snapshots should correctly render Canonical navi
   width: 2.75rem;
   background-color: #B80000;
   color: #FFFFFF;
+  overflow: hidden;
   width: 2.75rem;
   height: 2.75rem;
 }

--- a/src/app/components/Navigation/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Navigation/__snapshots__/index.test.tsx.snap
@@ -439,6 +439,7 @@ exports[`Navigation should correctly render amp navigation 1`] = `
   width: 2.75rem;
   background-color: #B80000;
   color: #FFFFFF;
+  overflow: hidden;
   width: 2.75rem;
   height: 2.75rem;
 }
@@ -1253,6 +1254,7 @@ exports[`Navigation should correctly render amp navigation on a URL not associat
   width: 2.75rem;
   background-color: #B80000;
   color: #FFFFFF;
+  overflow: hidden;
   width: 2.75rem;
   height: 2.75rem;
 }
@@ -2154,6 +2156,7 @@ exports[`Navigation should correctly render amp navigation on non-home navigatio
   width: 2.75rem;
   background-color: #B80000;
   color: #FFFFFF;
+  overflow: hidden;
   width: 2.75rem;
   height: 2.75rem;
 }
@@ -3043,6 +3046,7 @@ exports[`Navigation should correctly render canonical navigation 1`] = `
   width: 2.75rem;
   background-color: #B80000;
   color: #FFFFFF;
+  overflow: hidden;
   width: 2.75rem;
   height: 2.75rem;
 }
@@ -3843,6 +3847,7 @@ exports[`Navigation should correctly render canonical navigation on a URL not as
   width: 2.75rem;
   background-color: #B80000;
   color: #FFFFFF;
+  overflow: hidden;
   width: 2.75rem;
   height: 2.75rem;
 }
@@ -4730,6 +4735,7 @@ exports[`Navigation should correctly render canonical navigation on non-home nav
   width: 2.75rem;
   background-color: #B80000;
   color: #FFFFFF;
+  overflow: hidden;
   width: 2.75rem;
   height: 2.75rem;
 }

--- a/src/app/components/Navigation/index.styles.ts
+++ b/src/app/components/Navigation/index.styles.ts
@@ -224,6 +224,7 @@ export default {
     css({
       backgroundColor: palette.POSTBOX,
       color: palette.WHITE,
+      overflow: 'hidden',
 
       width: `${pixelsToRem(MAX_NAV_ITEM_HEIGHT)}rem`,
       height: `${pixelsToRem(MAX_NAV_ITEM_HEIGHT)}rem`,


### PR DESCRIPTION
Resolves https://bbc-tpg.slack.com/archives/C03S8UQJZ6U/p1785150405360539

Summary
======
The VisuallHidden span is causing the burger menu button to be 38px wide, causing a misalignment with the rest of the page, enabling a horizontal scrollbar. This hides the overflow on the button so it's not calculated as part of the rendered width.

Code changes
======
- Add overflow hidden css to burger menu nav button

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
