### PR TITLE
[WS-NA] - Change toggles endpoint url in cypress tests

### DIFF
--- a/ws-nextjs-app/cypress/support/commands.ts
+++ b/ws-nextjs-app/cypress/support/commands.ts
@@ -5,6 +5,7 @@ import defaultToggles from '#app/lib/config/toggles';
 import testResponseCodeAndRetry from './helpers/testResponseCodeAndRetry';
 import getAppEnv from './helpers/getAppEnv';
 import handleContinueReadingButton from './helpers/handleContinueReadingButton';
+import envConfig from './config/envs';
 
 interface TestResponseCodeAndRetry {
   url: string;
@@ -48,7 +49,7 @@ const getToggles = memoizeWith(keyGenFn, service => {
     cy.writeFile(togglesFixture, defaultToggles.local);
   } else {
     cy.request({
-      url: `${process.env.TOGGLES_BFF_PATH}?service=${service}&application=simorgh`,
+      url: `${envConfig.togglesUrl}?service=${service}&application=simorgh`,
     }).then(response => {
       cy.writeFile(togglesFixture, response.body.toggles);
     });

--- a/ws-nextjs-app/cypress/support/commands.ts
+++ b/ws-nextjs-app/cypress/support/commands.ts
@@ -44,12 +44,15 @@ const getPageDataFromWindow = () => {
 const keyGenFn = identity as (...v: unknown[]) => string;
 const getToggles = memoizeWith(keyGenFn, service => {
   const togglesFixture = `cypress/fixtures/toggles/${service}.json`;
+  const togglesEndpoint = new URL(`${envConfig.togglesUrl}/fd/ws-toggles`);
+  togglesEndpoint.searchParams.set('service', service);
+  togglesEndpoint.searchParams.set('application', 'simorgh');
 
   if (getAppEnv() === 'local') {
     cy.writeFile(togglesFixture, defaultToggles.local);
   } else {
     cy.request({
-      url: `${envConfig.togglesUrl}?service=${service}&application=simorgh`,
+      url: togglesEndpoint.toString(),
     }).then(response => {
       cy.writeFile(togglesFixture, response.body.toggles);
     });

--- a/ws-nextjs-app/cypress/support/config/envs.ts
+++ b/ws-nextjs-app/cypress/support/config/envs.ts
@@ -9,6 +9,7 @@ export type EnvironmentConfigType = {
   avEmbedBaseUrlAmp: string;
   standaloneErrorPages: boolean;
   alwaysCheckForFallback: boolean;
+  togglesUrl: string;
 };
 
 export type Environment = 'live' | 'test' | 'local';
@@ -29,6 +30,7 @@ const config = {
     avEmbedBaseUrlAmp: 'https://web-cdn.api.bbci.co.uk',
     standaloneErrorPages: false,
     alwaysCheckForFallback: true,
+    togglesUrl: 'https://web-cdn.api.bbci.co.uk',
   },
   test: {
     baseUrl: 'https://www.test.bbc.com',
@@ -41,6 +43,7 @@ const config = {
     avEmbedBaseUrlAmp: 'https://web-cdn.test.api.bbci.co.uk',
     standaloneErrorPages: false,
     alwaysCheckForFallback: true,
+    togglesUrl: 'https://web-cdn.test.api.bbci.co.uk',
   },
   local: {
     baseUrl: 'http://localhost.bbc.com:7080',
@@ -51,6 +54,7 @@ const config = {
     reverbAtiUrl: 'https://logw363.ati-host.net/hit.xiti?',
     avEmbedBaseUrlCanonical: 'https://www.test.bbc.com',
     avEmbedBaseUrlAmp: 'https://web-cdn.test.api.bbci.co.uk',
+    togglesUrl: 'https://web-cdn.test.api.bbci.co.uk',
     standaloneErrorPages: true,
     alwaysCheckForFallback: false,
   },


### PR DESCRIPTION
Resolves JIRA: N/A

Summary
======
Cypress can't fetch toggles via the usual simorgh-bff endpoint directly when run on simorgh-cd-envtest so this has been changed to the web-cdn endpoint.

Code changes
======
- _List key code changes that have been made._

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
