### PR TITLE
WS-NA: Uses double 'scroll into view' to try reduce Most Read flakes

### DIFF
--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/featuresAnalysis.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/featuresAnalysis.ts
@@ -38,8 +38,6 @@ export const assertFeaturesAnalysisComponentClick = ({
     interceptATIAnalyticsBeacons();
     cy.visit(path);
 
-    // This duplicate line of code has been added intentionally to get cypress to scroll to the bottom.
-    cy.get('[data-testid="features"]').scrollIntoView({ duration: 1000 });
     cy.get('[data-testid="features"]').scrollIntoView({ duration: 1000 });
 
     // Click on first item

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/featuresAnalysis.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/featuresAnalysis.ts
@@ -38,6 +38,8 @@ export const assertFeaturesAnalysisComponentClick = ({
     interceptATIAnalyticsBeacons();
     cy.visit(path);
 
+    // This duplicate line of code has been added intentionally to get cypress to scroll to the bottom.
+    cy.get('[data-testid="features"]').scrollIntoView({ duration: 1000 });
     cy.get('[data-testid="features"]').scrollIntoView({ duration: 1000 });
 
     // Click on first item

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/mostRead.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/mostRead.ts
@@ -54,6 +54,8 @@ export const assertMostReadComponentClick = ({
     interceptATIAnalyticsBeacons();
     cy.visit(path);
 
+    // This duplicate line of code has been added intentionally to get cypress to scroll to the bottom.
+    cy.get('[data-e2e="most-read"]').scrollIntoView({ duration: 1000 });
     cy.get('[data-e2e="most-read"]').scrollIntoView({ duration: 1000 });
 
     // Click on first item


### PR DESCRIPTION
Resolves JIRA: WS-NA

Summary
======
Uses double 'scroll into view' for Most Read 'click' test, copying method used by view event tests

Code changes
======
- _List key code changes that have been made._

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
