### PR TITLE
WS-3088: Enable IDCTA and UAS user actions for Brazil and Mundo in the test environment

### DIFF
--- a/src/app/components/SaveArticleButton/SaveArticleButtonGuest/index.tsx
+++ b/src/app/components/SaveArticleButton/SaveArticleButtonGuest/index.tsx
@@ -35,6 +35,8 @@ const SaveArticleButtonGuest = () => {
     },
   });
 
+  if (!saveArticleButton) return null;
+
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     onClickTrack?.(e);
     setIsModalOpen(true);

--- a/src/app/lib/config/services/mundo.ts
+++ b/src/app/lib/config/services/mundo.ts
@@ -143,6 +143,62 @@ export const service: DefaultServiceConfig = {
         title: 'File Download',
       },
       gist: 'Sumario',
+      account: {
+        signIn: 'Sign In',
+        signInAccessibleLabel: 'Sign in to My News',
+        forYou: 'Your Account',
+        register: 'Register',
+      },
+      accountPromoBanner: {
+        title: 'Your very own BBC',
+        description: 'Sign In or create an account for free',
+        closeLabel: 'Close',
+        buttonSeparatorText: 'or',
+      },
+      accountSignInModal: {
+        title: 'Sign in to save to My News',
+        description: 'Save stories and read them at your convenience',
+        closeLabel: 'Close',
+      },
+      saveArticleButton: {
+        loading: 'Loading',
+        save: 'Save for later',
+        saving: 'Saving',
+        saved: 'Saved to My News',
+        remove: 'Remove',
+        removeAccessible: 'Saved. Remove from My News',
+        removing: 'Removing',
+      },
+      myNews: {
+        title: 'My News',
+        guestTitle: 'Welcome to My News',
+        description: 'My saved articles',
+        guestDescription:
+          'Sign in to save articles to My News, and read them at your convenience.',
+        noArticles: 'You haven’t saved any articles yet',
+        errorText:
+          'This content doesn’t seem to be loading. Please try again later.',
+        loading: 'Loading',
+        noJsDescription:
+          'Please enable JavaScript or use another browser to view this content.',
+      },
+      actionTooltip: {
+        success: {
+          titleBefore: 'This article is now saved to',
+          titleAfter: '',
+        },
+        error: {
+          title: 'Sorry, something went wrong',
+          body: 'Check your connection, refresh the page and try again',
+        },
+        removed: {
+          titleBefore: 'This article has now been removed from',
+          titleAfter: '',
+        },
+        myNewsLinkText: 'My News',
+        myNewsUrl: 'https://www.bbc.com/mundo/my-news',
+        closeLabel: 'Close',
+      },
       error: {
         404: {
           statusCode: '404',

--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -141,6 +141,62 @@ export const service: DefaultServiceConfig = {
         title: 'File Download',
       },
       gist: 'Pontos-chave',
+      account: {
+        signIn: 'Sign In',
+        signInAccessibleLabel: 'Sign in to My News',
+        forYou: 'Your Account',
+        register: 'Register',
+      },
+      accountPromoBanner: {
+        title: 'Your very own BBC',
+        description: 'Sign In or create an account for free',
+        closeLabel: 'Close',
+        buttonSeparatorText: 'or',
+      },
+      accountSignInModal: {
+        title: 'Sign in to save to My News',
+        description: 'Save stories and read them at your convenience',
+        closeLabel: 'Close',
+      },
+      saveArticleButton: {
+        loading: 'Loading',
+        save: 'Save for later',
+        saving: 'Saving',
+        saved: 'Saved to My News',
+        remove: 'Remove',
+        removeAccessible: 'Saved. Remove from My News',
+        removing: 'Removing',
+      },
+      myNews: {
+        title: 'My News',
+        guestTitle: 'Welcome to My News',
+        description: 'My saved articles',
+        guestDescription:
+          'Sign in to save articles to My News, and read them at your convenience.',
+        noArticles: 'You haven’t saved any articles yet',
+        errorText:
+          'This content doesn’t seem to be loading. Please try again later.',
+        loading: 'Loading',
+        noJsDescription:
+          'Please enable JavaScript or use another browser to view this content.',
+      },
+      actionTooltip: {
+        success: {
+          titleBefore: 'This article is now saved to',
+          titleAfter: '',
+        },
+        error: {
+          title: 'Sorry, something went wrong',
+          body: 'Check your connection, refresh the page and try again',
+        },
+        removed: {
+          titleBefore: 'This article has now been removed from',
+          titleAfter: '',
+        },
+        myNewsLinkText: 'My News',
+        myNewsUrl: 'https://www.bbc.com/portuguese/my-news',
+        closeLabel: 'Close',
+      },
       error: {
         404: {
           statusCode: '404',

--- a/src/app/lib/config/toggles/__snapshots__/index.test.js.snap
+++ b/src/app/lib/config/toggles/__snapshots__/index.test.js.snap
@@ -105,7 +105,7 @@ exports[`Toggles Config when application environment is local should contain cor
   "_environment": "local",
   "account": {
     "enabled": true,
-    "value": "hindi",
+    "value": "hindi|mundo|portuguese",
   },
   "ads": {
     "enabled": true,
@@ -194,7 +194,7 @@ exports[`Toggles Config when application environment is local should contain cor
   },
   "uasPersonalization": {
     "enabled": true,
-    "value": "hindi",
+    "value": "hindi|mundo|portuguese",
   },
   "variantCookie": {
     "enabled": true,

--- a/src/app/lib/config/toggles/localConfig.js
+++ b/src/app/lib/config/toggles/localConfig.js
@@ -4,7 +4,7 @@ export default {
   _environment: 'local',
   account: {
     enabled: true,
-    value: 'hindi',
+    value: 'hindi|mundo|portuguese',
   },
   ads: {
     enabled: true,
@@ -94,7 +94,7 @@ export default {
   },
   uasPersonalization: {
     enabled: true,
-    value: 'hindi',
+    value: 'hindi|mundo|portuguese',
   },
   webVitalsMonitoring: {
     enabled: true,


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-3088

Summary
======
- Enable IDCTA and UAS user actions for Brazil and Mundo in the test environment
- Enabled local feature toggles for Brazil/Mundo
- Added English translations (temp solution)

Code changes
======
<img width="390" height="674" alt="Screenshot 2026-08-07 at 11 37 34" src="https://github.com/user-attachments/assets/9e040ccd-97b1-465f-b801-85dcc0fa99a9" />


Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
