### PR TITLE
Revert "WS-NA: Uses double 'scroll into view' to try reduce Most Read flakes"

### DIFF
--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/mostRead.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/mostRead.ts
@@ -54,8 +54,6 @@ export const assertMostReadComponentClick = ({
     interceptATIAnalyticsBeacons();
     cy.visit(path);
 
-    // This duplicate line of code has been added intentionally to get cypress to scroll to the bottom.
-    cy.get('[data-e2e="most-read"]').scrollIntoView({ duration: 1000 });
     cy.get('[data-e2e="most-read"]').scrollIntoView({ duration: 1000 });
 
     // Click on first item


### PR DESCRIPTION
Reverts bbc/simorgh#14298

Was trying to fix flakes on e2e tests on live env

But I wonder if this has caused other flakes - including ones on github actions (which is more annoying)