### PR TITLE
WS-NA: Try to fix/ debug flakey Most Read Click E2E test [copilot]

### DIFF
--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.ts
@@ -133,7 +133,20 @@ const assertReverbViewabilityComponentEventParamsExist = ({
 const fieldIsValidString = field =>
   typeof field === 'string' && field.trim().length > 0;
 
+// Temporary debug - identify if long localised item text is producing invalid JSON.
+const assertEventsPayloadNotTruncated = (payload: string) => {
+  const trimmedPayload = payload.trim();
+  const lastChar = trimmedPayload[trimmedPayload.length - 1];
+
+  if (lastChar !== ']' && lastChar !== '}') {
+    throw new Error(
+      `ATI events payload appears truncated (length=${payload.length})`,
+    );
+  }
+};
+
 const validateViewabilityEventDetails = ({ payload, actionType }) => {
+  assertEventsPayloadNotTruncated(payload);
   const arr = JSON.parse(payload);
 
   return arr.some(event => {
@@ -285,6 +298,7 @@ const getMatchingViewabilityEventData = ({
   component,
   expectedItemText,
 }) => {
+  assertEventsPayloadNotTruncated(payload);
   const arr = JSON.parse(payload);
 
   const matchingEvents = arr.filter(

--- a/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.ts
+++ b/ws-nextjs-app/cypress/e2e/specialFeatures/atiAnalytics/assertions/index.ts
@@ -30,6 +30,21 @@ const getAppName = service => {
     : `[news-${service}]`;
 };
 
+const getATIParamsFromInterception = request => {
+  const queryParams = request?.query as Record<string, string | string[]>;
+
+  if (!queryParams || typeof queryParams !== 'object') {
+    return getATIParamsFromURL(request?.url || '');
+  }
+
+  return Object.fromEntries(
+    Object.entries(queryParams).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? value[0] : value,
+    ]),
+  );
+};
+
 const assertATIPageViewEventParamsExist = ({
   params,
   contentType,
@@ -341,7 +356,7 @@ const findMatchingEventDataFromInterceptions = ({
   interceptions.forEach(interception => {
     if (matched) return;
 
-    const params = getATIParamsFromURL(interception.request.url);
+    const params = getATIParamsFromInterception(interception.request);
 
     if (!params.events) return;
 
@@ -372,27 +387,25 @@ export const assertATIComponentViewEvent = ({
   const requestAlias = `@${component}-viewability-view`;
 
   if (!expectedItemText) {
-    cy.wait(requestAlias)
-      .its('request.url')
-      .then(url => {
-        const params = getATIParamsFromURL(url);
+    cy.wait(requestAlias).then(({ request }) => {
+      const params = getATIParamsFromInterception(request);
 
-        assertViewabilityModelViewEvent({
-          pageIdentifier,
-          params,
-          applicationType,
-          siteId,
-        });
-
-        assertItemAndGroupTaxonomy({
-          payload: params.events,
-          actionType: VIEW_EVENT,
-          component,
-          expectedItemType,
-          expectedGroupType,
-          expectedItemText: undefined,
-        });
+      assertViewabilityModelViewEvent({
+        pageIdentifier,
+        params,
+        applicationType,
+        siteId,
       });
+
+      assertItemAndGroupTaxonomy({
+        payload: params.events,
+        actionType: VIEW_EVENT,
+        component,
+        expectedItemType,
+        expectedGroupType,
+        expectedItemText: undefined,
+      });
+    });
     return;
   }
 
@@ -493,15 +506,14 @@ export const assertATIComponentClickEvent = ({
 }) => {
   const requestAlias = `@${component}-viewability-click`;
 
-  cy.wait(requestAlias)
-    .its('request.url')
-    .then(url => {
-      const params = getATIParamsFromURL(url);
-      assertViewabilityModelClickEvent({
-        pageIdentifier,
-        params,
-        applicationType,
-        siteId,
-      });
+  cy.wait(requestAlias).then(({ request }) => {
+    const params = getATIParamsFromInterception(request);
+
+    assertViewabilityModelClickEvent({
+      pageIdentifier,
+      params,
+      applicationType,
+      siteId,
     });
+  });
 };


### PR DESCRIPTION
Resolves JIRA: WS-NA

Summary
======
Applies some suggested "cleaning" to Click test assertions and adds a debug for truncated text. These are copilot suggestions.

The current theory is that there is something in Reverb and/or the browser which is truncating the JSON. Afrique also runs this test, but Kyrgyz is more effected since Cyrillic text expands when URL-encoded. Changing/longer headlines could cause this to flake intermittently.

(This seems probable, since I was able to get the test to fail locally if I replaced one of the Most Read headlines with a really long headline in Cyrillic text). I suggest merging in the debug still - getting examples on live - then removing and running this test on a non-Cyrillic service instead).

Code changes
======
- Adds a general robustness/cleanup improvement (reads from the intercepted request's parsed query instead of re-parsing the URL). Unlikely to fix anything.
- Adds a debug check that detects an unterminated JSON string (e.g. does not end in ]/}) and throws a clear error like "ATI events payload appears truncated (length=X) instead of a generic SyntaxError.
- The debug should add barely any time to tests — it's just trim and a single character check (O(1)), no extra network calls or waits. Won't measurably affect test duration.

Testing
======
1. Ran against live env locally
2. Check github actions pass
3. Monitor on pipeline.

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
