### PR TITLE
[WS-3080] Fix signed-in-page-views Optimzely tracking 

### DIFF
--- a/src/app/components/Account/AccountPromotionalBanner/useAccountPromoBannerEligibility/index.ts
+++ b/src/app/components/Account/AccountPromotionalBanner/useAccountPromoBannerEligibility/index.ts
@@ -3,21 +3,28 @@ import { AccountContext } from '#contexts/AccountContext';
 import { ServiceContext } from '#app/contexts/ServiceContext';
 import useToggle from '#app/hooks/useToggle';
 
-// Server-side-knowable eligibility for the account promotional banner. Shared by
-// the experiment wrapper (to gate both the control and "on" arms before either
-// view event can fire) and the banner itself. The localStorage frequency-cap and
-// in-session dismissal checks are deliberately excluded here: they are client
-// only and handled separately via the inline script and component state.
-const useAccountPromoBannerEligibility = (): boolean => {
+type UseAccountPromoBannerEligibilityOptions = {
+  excludeSignedInUsers?: boolean;
+};
+
+// Server-side-knowable eligibility for the account promotional banner. Excludes
+// the client-only frequency-cap/dismissal checks, handled separately.
+//
+// `excludeSignedInUsers` lets the experiment wrapper activate Optimizely for
+// signed-in users while still gating the banner/view tracking to signed-out users.
+const useAccountPromoBannerEligibility = ({
+  excludeSignedInUsers = true,
+}: UseAccountPromoBannerEligibilityOptions = {}): boolean => {
   const { enabled: accountEnabled } = useToggle('account');
   const { isSignedIn, isIdctaAvailable, signInUrl, registerUrl } =
     use(AccountContext);
   const { translations } = use(ServiceContext);
   const accountPromoBannerTranslations = translations?.accountPromoBanner;
+  const passesSignInCheck = !excludeSignedInUsers || !isSignedIn;
 
   return Boolean(
     accountEnabled &&
-    !isSignedIn &&
+    passesSignInCheck &&
     isIdctaAvailable &&
     signInUrl &&
     registerUrl &&

--- a/src/app/components/Account/AccountPromotionalBannerExperiment/index.tsx
+++ b/src/app/components/Account/AccountPromotionalBannerExperiment/index.tsx
@@ -1,3 +1,5 @@
+import { use } from 'react';
+import { AccountContext } from '#contexts/AccountContext';
 import useOptimizelyVariation, {
   ExperimentType,
 } from '#app/hooks/useOptimizelyVariation';
@@ -34,14 +36,18 @@ const AccountPromotionalBannerControlTracker = ({
 };
 
 const EligibleAccountPromotionalBannerExperiment = () => {
-  // useOptimizelyVariation both resolves the variation and activates the
-  // experiment. Activation therefore happens regardless of whether the banner is
-  // dismissed, but view events are still suppressed for dismissed banners by the
-  // shared inline-script + CSS visibility gate.
+  const { isSignedIn } = use(AccountContext);
+
+  // Activates regardless of sign-in status so signed-in page views are tracked;
+  // signed-in users are excluded below from the banner/view tracking.
   const experimentVariant = useOptimizelyVariation({
     experimentName: ACCOUNT_PROMO_BANNER_EXPERIMENT_NAME,
     experimentType: ExperimentType.SERVER_SIDE,
   });
+
+  if (isSignedIn) {
+    return null;
+  }
 
   if (experimentVariant === 'on') {
     return (
@@ -64,11 +70,10 @@ const EligibleAccountPromotionalBannerExperiment = () => {
 };
 
 const AccountPromotionalBannerExperiment = () => {
-  const isEligible = useAccountPromoBannerEligibility();
+  const isEligible = useAccountPromoBannerEligibility({
+    excludeSignedInUsers: false,
+  });
 
-  // Server-knowable eligibility gate: ineligible users render nothing and are
-  // never activated. Client-side visibility (dismissal / frequency cap) is handled
-  // per arm below.
   if (!isEligible) {
     return null;
   }


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-3080

Summary
======
- `signed-in-page-views` (Introduced by https://github.com/bbc/simorgh/pull/14283) (used as a proxy conversion metric on the `newswb_ws_article_account_promo_banner` experiment) is only tracked from inside the Optimizely DECISION notification listener in `withOptimizelyProvider`. Activation was gated[ behind the banner's eligibility check](https://github.com/bbc/simorgh/blob/latest/src/app/components/Account/AccountPromotionalBannerExperiment/index.tsx#L67), which required the user to be signed out. So as soon as a user signed in (e.g. returning via the sign-in/register PTRT redirect to the same article), the experiment stopped activating for them - meaning signed-in-page-views could never fire for exactly the users the metric was meant to measure.

Code changes
======
- `useAccountPromoBannerEligibility` now accepts an optional `excludeSignedInUsers` option (defaults to true, so `AccountPromotionalBanner` usage on the homepage is unaffected).
- `AccountPromotionalBannerExperiment` now calls the hook with `excludeSignedInUsers: false`, so the experiment still activates (and signed-in-page-views still tracks) for signed-in users.
- `isSignedIn` is now checked inside `EligibleAccountPromotionalBannerExperiment`, after `useOptimizelyVariation` has run, so activation always happens but the banner/control view tracking is only rendered for signed-out users.

Testing
======
1. Use Charles to enable the experiment/control group. (i.e. header rewrite with `mvt-newswb_ws_article_account_promo_banner: on`)
2. Use `ckns_id` to mock the signed-in state and confirm signed-in-page-views is tracked.


## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
