### PR TITLE
WS-NA: Fixes Clip Images

### DIFF
--- a/src/app/lib/utilities/ichefURL/index.js
+++ b/src/app/lib/utilities/ichefURL/index.js
@@ -31,7 +31,12 @@ const buildPlaceholderSrc = (src, resolution) => {
   const urlParts = imageSrc.replace(/https?:\/\//g, '').split('/');
   const [domain, mediaType, imgService, ...remainingUrlParts] = urlParts;
   const remainingUrlPartsWithoutResolution = remainingUrlParts.slice(1);
-  const newResolution = `${resolution}xn`;
+  let newResolution;
+  if (mediaType === 'ace') {
+    newResolution = `${resolution}`;
+  } else {
+    newResolution = `${resolution}xn`;
+  }
   const newUrl = [
     domain,
     mediaType,

--- a/src/app/lib/utilities/ichefURL/index.js
+++ b/src/app/lib/utilities/ichefURL/index.js
@@ -31,12 +31,8 @@ const buildPlaceholderSrc = (src, resolution) => {
   const urlParts = imageSrc.replace(/https?:\/\//g, '').split('/');
   const [domain, mediaType, imgService, ...remainingUrlParts] = urlParts;
   const remainingUrlPartsWithoutResolution = remainingUrlParts.slice(1);
-  let newResolution;
-  if (mediaType === 'ace') {
-    newResolution = `${resolution}`;
-  } else {
-    newResolution = `${resolution}xn`;
-  }
+  const newResolution =
+    mediaType === 'ace' ? `${resolution}` : `${resolution}xn`;
   const newUrl = [
     domain,
     mediaType,
@@ -53,6 +49,7 @@ const buildIChefURL = ({
   resolution,
   ichefSubdomain = 'ace/ws',
 }) => {
+  console.log('originCode', originCode);
   if (originCode === 'mpv' || originCode === 'pips') {
     return buildPlaceholderSrc(locator, resolution);
   }

--- a/src/app/lib/utilities/ichefURL/index.js
+++ b/src/app/lib/utilities/ichefURL/index.js
@@ -49,7 +49,6 @@ const buildIChefURL = ({
   resolution,
   ichefSubdomain = 'ace/ws',
 }) => {
-  console.log('originCode', originCode);
   if (originCode === 'mpv' || originCode === 'pips') {
     return buildPlaceholderSrc(locator, resolution);
   }

--- a/src/app/lib/utilities/ichefURL/index.test.js
+++ b/src/app/lib/utilities/ichefURL/index.test.js
@@ -113,6 +113,19 @@ describe('getIchefURL', () => {
     );
   });
 
+  it('keeps the resolution without xn for ace placeholder urls', () => {
+    const locator =
+      'https://ichef.bbci.co.uk/ace/standard/{width}/galileo/p0p4qjjk.jpg';
+    const originCode = 'pips';
+    const resolution = '512';
+    const expectedOutput =
+      'https://ichef.bbci.co.uk/ace/standard/512/galileo/p0p4qjjk.jpg.webp';
+
+    expect(getIChefURL({ locator, originCode, resolution })).toEqual(
+      expectedOutput,
+    );
+  });
+
   it('return urn scheme unmodified', () => {
     const locator = 'urn:bbc:pips:pid:p054n8j6';
     const originCode = 'pips';

--- a/src/app/lib/utilities/ichefURL/index.test.js
+++ b/src/app/lib/utilities/ichefURL/index.test.js
@@ -113,7 +113,7 @@ describe('getIchefURL', () => {
     );
   });
 
-  it('keeps the resolution without xn for ace placeholder urls', () => {
+  it('keeps the resolution without xn for ace placeholder urls as width and height are not required for ace ichef', () => {
     const locator =
       'https://ichef.bbci.co.uk/ace/standard/{width}/galileo/p0p4qjjk.jpg';
     const originCode = 'pips';


### PR DESCRIPTION
Resolves JIRA: WS-NA - see Ops ticket and context in this thread: https://bbc-tpg.slack.com/archives/C03RA53JX0D/p1787056833152789

Summary
======
Forward fix - does not include xn in the ichef url if the ichef project is /ace/

Code changes
======
- Updates `buildPlaceholderSrc` function
- Adds unit test

Testing
======
1. Pull down and run locally
2. Go to http://localhost:7081/dari/live/cq998l41e74nt?renderer_env=live - see clip images render
3. Check other page types for regression. E.g.:
- http://localhost:7081/dari?renderer_env=live
- http://localhost:7081/mundo/articles/ckgd8pzkyzxo?renderer_env=live
- http://localhost:7081/hindi/topics/cw9kv0kpxydt?renderer_env=live
- http://localhost:7081/hindi/articles/cgljj6kpkz8o?renderer_env=live
- http://localhost:7081/hindi/bbc_hindi_tv/tv_programmes/w13xttlw?renderer_env=live

(I'm not seeing any issues - though we're a little lite on test support - so feel free to check out a couple other URLs too).

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
