### PR TITLE
[WS-NA] - Fix PV carousel heading link

### DIFF
--- a/src/app/components/PortraitVideoCarousel/index.test.tsx
+++ b/src/app/components/PortraitVideoCarousel/index.test.tsx
@@ -52,6 +52,25 @@ describe('PortraitVideoCarousel', () => {
     expect(linkElement).toHaveAttribute('href', link);
   });
 
+  it('Should render the heading with a URI link correctly', async () => {
+    const uriLink = 'https://www.bbc.com/news';
+    await act(async () => {
+      render(
+        <Component
+          {...fixture}
+          link={uriLink}
+          eventTrackingData={eventTrackingData}
+        />,
+      );
+    });
+
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading).toHaveTextContent(fixture.title);
+
+    const linkElement = screen.getByRole('link', { name: fixture.title });
+    expect(linkElement).toHaveAttribute('href', uriLink);
+  });
+
   it('Should render without a title', async () => {
     await act(async () => {
       render(

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -101,6 +101,7 @@ const HomePage = ({ pageData }: HomePageProps) => {
                   link,
                   position,
                   visualStyle,
+                  associatedContent: { uri } = {},
                   ...curationProps
                 }: Curation,
                 index: number,
@@ -123,7 +124,7 @@ const HomePage = ({ pageData }: HomePageProps) => {
                       title={curationTitle}
                       topStoriesTitle={topStoriesTitle}
                       position={position}
-                      link={link}
+                      link={link || uri}
                       curationLength={curations?.length}
                       nthCurationByStyleAndProminence={
                         nthCurationByStyleAndProminence

--- a/src/app/pages/HomePage/index.test.tsx
+++ b/src/app/pages/HomePage/index.test.tsx
@@ -1076,6 +1076,99 @@ describe('Home Page', () => {
   });
 });
 
+describe('associatedContent', () => {
+  it('should use associatedContent.uri as link fallback for curations without a link property', () => {
+    const testUri = 'https://www.bbc.com/test-associated-content';
+
+    const testCuration = {
+      curationId: 'test-curation-with-associated-content',
+      position: 999,
+      title: 'Test Associated Content',
+      visualStyle: 'grid',
+      visualProminence: 'NORMAL',
+      summaries: [
+        {
+          type: 'article',
+          title: 'Test Article',
+          link: 'https://www.bbc.com/article',
+          id: 'test-article-1',
+        },
+      ],
+      link: undefined,
+      associatedContent: {
+        uri: testUri,
+      },
+    };
+
+    const testHomePageData = {
+      ...pidginHomePageData,
+      curations: [...pidginHomePageData.curations, testCuration],
+    };
+
+    // @ts-expect-error suppress pageData prop type conflicts
+    const { container } = render(<HomePage pageData={testHomePageData} />, {
+      service: 'pidgin',
+    });
+
+    const subheadingLinks = Array.from(container.querySelectorAll('h2 a'));
+    const associatedContentLink = subheadingLinks.find(link =>
+      link.getAttribute('href')?.includes(testUri),
+    );
+
+    expect(associatedContentLink).toBeInTheDocument();
+    expect(associatedContentLink?.textContent).toContain(
+      'Test Associated Content',
+    );
+  });
+
+  it('should prioritize link over associatedContent.uri when both are provided', () => {
+    const testLink = 'https://www.bbc.com/test-link';
+    const testUri = 'https://www.bbc.com/test-associated-uri';
+
+    const testCuration = {
+      curationId: 'test-curation-with-both-links',
+      position: 999,
+      title: 'Test Both Links',
+      visualStyle: 'grid',
+      visualProminence: 'NORMAL',
+      summaries: [
+        {
+          type: 'article',
+          title: 'Test Article',
+          link: 'https://www.bbc.com/article',
+          id: 'test-article-2',
+        },
+      ],
+      link: testLink,
+      associatedContent: {
+        uri: testUri,
+      },
+    };
+
+    const testHomePageData = {
+      ...pidginHomePageData,
+      curations: [...pidginHomePageData.curations, testCuration],
+    };
+
+    // @ts-expect-error suppress pageData prop type conflicts
+    const { container } = render(<HomePage pageData={testHomePageData} />, {
+      service: 'pidgin',
+    });
+
+    const subheadingLinks = Array.from(container.querySelectorAll('h2 a'));
+    const linkElement = subheadingLinks.find(link =>
+      link.getAttribute('href')?.includes(testLink),
+    );
+    const associatedLink = subheadingLinks.find(link =>
+      link.getAttribute('href')?.includes(testUri),
+    );
+
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement?.textContent).toContain('Test Both Links');
+    expect(associatedLink).toBeFalsy();
+  });
+});
+
 describe('Linked Data', () => {
   it('should correctly render linked data for home pages', () => {
     // @ts-expect-error suppress pageData prop type conflicts due to missing imageAlt on selected historical test data for curations


### PR DESCRIPTION
Resolves JIRA: 

Summary
======
Fixes PV carousel heading links that use a `uri` from `associatedContent` rather than a `link` property in the data.

Code changes
======
- Re-adds removed logic to handle `uri` when `link` is falsy
- Adds tests

Testing
======
1. Visit http://localhost:7081/arabic?renderer_env=live and ensure the **second** PV carousel has a clickable link. It should not be present in the first.

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
