### PR TITLE
Use getTopicPageUrl for Topic Discovery More About link (same method topic tags uses)

### DIFF
--- a/src/app/components/TopicDiscovery/index.test.tsx
+++ b/src/app/components/TopicDiscovery/index.test.tsx
@@ -11,6 +11,7 @@ import { ServiceConfig } from '#app/models/types/serviceConfig';
 import { service as portugueseConfig } from '#app/lib/config/services/portuguese';
 import { service as turkceConfig } from '#app/lib/config/services/turkce';
 import { service as arabicConfig } from '#app/lib/config/services/arabic';
+import { service as cymrufywConfig } from '#app/lib/config/services/cymrufyw';
 import {
   BLACK,
   GREY_2,
@@ -229,6 +230,47 @@ describe('TopicDiscovery', () => {
     expect(moreAbout).toHaveAttribute(
       'href',
       `/portuguese/topics/${topicTagsFixture[1].topicId}`,
+    );
+  });
+
+  it('falls back to a constructed href with custom topicsPath when topicUrl is empty', async () => {
+    const cymrufywTopic = {
+      topicId: 'test-topic-id',
+      topicName: 'Test Pwnc',
+      topicUrl: '',
+    };
+
+    const config: ServiceConfig = { ...cymrufywConfig.default };
+    render(
+      <ServiceContext.Provider value={config}>
+        <TopicDiscovery topics={[cymrufywTopic]} />
+      </ServiceContext.Provider>,
+    );
+
+    const moreAbout = await screen.findByTestId('topic-discovery-more-about');
+    // cymrufyw uses 'pynciau' as topicsPath instead of 'topics'
+    expect(moreAbout).toHaveAttribute(
+      'href',
+      `/cymrufyw/pynciau/${cymrufywTopic.topicId}`,
+    );
+  });
+
+  it('falls back to a constructed href with variant when topicUrl is empty', async () => {
+    const uzbekTopicWithoutUrl = {
+      topicId: 'test-uzbek-id',
+      topicName: 'Test Uzbek',
+      topicUrl: '',
+    };
+
+    render(<TopicDiscovery topics={[uzbekTopicWithoutUrl]} />, {
+      service: 'uzbek',
+      variant: 'cyr',
+    });
+
+    const moreAbout = await screen.findByTestId('topic-discovery-more-about');
+    expect(moreAbout).toHaveAttribute(
+      'href',
+      `/uzbek/topics/${uzbekTopicWithoutUrl.topicId}/cyr`,
     );
   });
 

--- a/src/app/components/TopicDiscovery/index.test.tsx
+++ b/src/app/components/TopicDiscovery/index.test.tsx
@@ -182,6 +182,56 @@ describe('TopicDiscovery', () => {
     await screen.findByText(`More about ${topicTagsFixture[0].topicName}`);
   });
 
+  it('renders the "more about" link href using topicUrl when present', async () => {
+    render(<TopicDiscovery topics={topicTagsFixture} />, {
+      service: 'portuguese',
+    });
+
+    const moreAbout = await screen.findByTestId('topic-discovery-more-about');
+    expect(moreAbout).toHaveAttribute('href', topicTagsFixture[0].topicUrl);
+  });
+
+  it('falls back to a constructed href when topicUrl is empty', async () => {
+    const topicsWithMissingUrl = [
+      { ...topicTagsFixture[0], topicUrl: '' },
+      ...topicTagsFixture.slice(1),
+    ];
+
+    render(<TopicDiscovery topics={topicsWithMissingUrl} />, {
+      service: 'portuguese',
+    });
+
+    const moreAbout = await screen.findByTestId('topic-discovery-more-about');
+    expect(moreAbout).toHaveAttribute(
+      'href',
+      `/portuguese/topics/${topicTagsFixture[0].topicId}`,
+    );
+  });
+
+  it('updates the "more about" href with a fallback when switching to a tab with a missing topicUrl', async () => {
+    const topicsWithMissingUrl = [
+      topicTagsFixture[0],
+      { ...topicTagsFixture[1], topicUrl: '' },
+      ...topicTagsFixture.slice(2),
+    ];
+
+    render(<TopicDiscovery topics={topicsWithMissingUrl} />, {
+      service: 'portuguese',
+    });
+
+    await screen.findByTestId('topic-discovery-more-about');
+
+    fireEvent.click(
+      screen.getByRole('tab', { name: topicTagsFixture[1].topicName }),
+    );
+
+    const moreAbout = await screen.findByTestId('topic-discovery-more-about');
+    expect(moreAbout).toHaveAttribute(
+      'href',
+      `/portuguese/topics/${topicTagsFixture[1].topicId}`,
+    );
+  });
+
   it('should not render when there are no valid topics', () => {
     const { container } = render(<TopicDiscovery topics={[]} />, {
       service: 'portuguese',

--- a/src/app/components/TopicDiscovery/index.tsx
+++ b/src/app/components/TopicDiscovery/index.tsx
@@ -5,6 +5,8 @@ import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import { ComponentExperimentProps } from '#app/models/types/global';
 import { TopicTag } from '#app/models/types/metadata';
 import { ServiceContext } from '#app/contexts/ServiceContext';
+import { RequestContext } from '#app/contexts/RequestContext';
+import getTopicPageUrl from '#app/lib/utilities/getTopicPageUrl';
 import ScrollableTabs from './ScrollableTabs';
 import styles from './index.styles';
 import useFetchTopicPromos from './useFetchTopicPromos';
@@ -27,12 +29,21 @@ const TopicDiscovery = ({
   className,
   experimentProps,
 }: TopicDiscoveryProps) => {
-  const { translations, dir } = use(ServiceContext);
+  const { service, translations, dir } = use(ServiceContext);
+  const { variant } = use(RequestContext);
   const {
     heading = 'Discover more',
     moreAboutTopic = 'More about {topic}',
     fetchErrorMessage = 'Failed to load. Please try again later.',
   } = translations.topicDiscovery || {};
+
+  const buildTopicPageUrl = (topicId: string) =>
+    getTopicPageUrl({
+      service,
+      topicId,
+      variant,
+      topicsPath: translations?.topicsPath,
+    });
 
   const [activeTabId, setActiveTabId] = useState(topics?.[0]?.topicId || '');
   const [shouldFocusPromos, setShouldFocusPromos] = useState(false);
@@ -139,6 +150,8 @@ const TopicDiscovery = ({
 
   if (!topics || topics.length === 0) return null;
   const selectedTopic = currentTopic as ExtractedTopic;
+  const selectedTopicUrl =
+    selectedTopic.topicUrl || buildTopicPageUrl(selectedTopic.topicId);
 
   const showLoadingState = Boolean(isLoading && !isError);
   const showErrorMessage = Boolean(!isLoading && isError);
@@ -217,7 +230,7 @@ const TopicDiscovery = ({
                       groupTracker: {
                         name: selectedTopic.topicName,
                         type: 'topic-discovery-curation-grid',
-                        link: selectedTopic.topicUrl,
+                        link: selectedTopicUrl,
                         resourceId: selectedTopic.topicId,
                         ...(topicPromos?.length > 0 && {
                           itemCount: topicPromos.length,
@@ -227,7 +240,7 @@ const TopicDiscovery = ({
                   />
                   <a
                     css={styles.moreAboutLink}
-                    href={selectedTopic.topicUrl}
+                    href={selectedTopicUrl}
                     data-testid="topic-discovery-more-about"
                     onKeyDown={handleMoreLinkKeyDown}
                     {...moreAboutLinkClickTracker}

--- a/src/app/components/TopicTags/index.tsx
+++ b/src/app/components/TopicTags/index.tsx
@@ -6,6 +6,7 @@ import { TopicTag } from '#app/models/types/metadata';
 import { EventTrackingData } from '#app/lib/analyticsUtils/types';
 import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import useViewTracker from '#app/hooks/useViewTracker';
+import getTopicPageUrl from '#app/lib/utilities/getTopicPageUrl';
 import styles from './index.styles';
 
 interface TopicTagsProps {
@@ -62,13 +63,14 @@ export const TopicTags = ({ tags, experimentProps }: TopicTagsProps) => {
 
   if (tags?.length === 0) return null;
 
-  const getTopicPageUrl = (id: string) => {
-    const isPublicService = ['news', 'cymrufyw', 'naidheachdan'];
-    const hostname = `https://www.bbc.${isPublicService.includes(service) ? 'co.uk' : 'com'}`;
-    const topicsPath = translations?.topicsPath ?? 'topics';
-
-    return `${hostname}/${service}/${topicsPath}/${id}${variant ? `/${variant}` : ''}`;
-  };
+  const buildTopicPageUrl = (topicId: string) =>
+    getTopicPageUrl({
+      service,
+      topicId,
+      variant,
+      topicsPath: translations?.topicsPath,
+      absolute: true,
+    });
 
   const hasMultiple = tags.length > 1;
 
@@ -83,7 +85,7 @@ export const TopicTags = ({ tags, experimentProps }: TopicTagsProps) => {
         <li key={tag.topicId} css={styles.topicTagItem}>
           <TopicTagLink
             tag={tag}
-            href={getTopicPageUrl(tag.topicId)}
+            href={buildTopicPageUrl(tag.topicId)}
             position={index + 1}
             eventTrackingData={eventTrackingData}
           />
@@ -99,7 +101,7 @@ export const TopicTags = ({ tags, experimentProps }: TopicTagsProps) => {
       <div css={styles.topicTagItem}>
         <TopicTagLink
           tag={tags[0]}
-          href={getTopicPageUrl(tags[0].topicId)}
+          href={buildTopicPageUrl(tags[0].topicId)}
           position={1}
           eventTrackingData={eventTrackingData}
         />

--- a/src/app/lib/utilities/getTopicPageUrl/index.test.ts
+++ b/src/app/lib/utilities/getTopicPageUrl/index.test.ts
@@ -1,0 +1,60 @@
+import getTopicPageUrl from '.';
+
+describe('getTopicPageUrl', () => {
+  it('builds a relative path by default', () => {
+    expect(
+      getTopicPageUrl({ service: 'pidgin', topicId: 'c123456789t' }),
+    ).toBe('/pidgin/topics/c123456789t');
+  });
+
+  it('appends the variant when provided', () => {
+    expect(
+      getTopicPageUrl({
+        service: 'uzbek',
+        topicId: 'c123456789t',
+        variant: 'cyr',
+      }),
+    ).toBe('/uzbek/topics/c123456789t/cyr');
+  });
+
+  it('uses a custom topicsPath when provided', () => {
+    expect(
+      getTopicPageUrl({
+        service: 'cymrufyw',
+        topicId: 'c123456789t',
+        topicsPath: 'pynciau',
+      }),
+    ).toBe('/cymrufyw/pynciau/c123456789t');
+  });
+
+  it('builds an absolute bbc.com url for non-public services', () => {
+    expect(
+      getTopicPageUrl({
+        service: 'pidgin',
+        topicId: 'c123456789t',
+        absolute: true,
+      }),
+    ).toBe('https://www.bbc.com/pidgin/topics/c123456789t');
+  });
+
+  it('builds an absolute bbc.co.uk url for public services', () => {
+    expect(
+      getTopicPageUrl({
+        service: 'news',
+        topicId: 'c123456789t',
+        absolute: true,
+      }),
+    ).toBe('https://www.bbc.co.uk/news/topics/c123456789t');
+  });
+
+  it('builds an absolute url with a variant', () => {
+    expect(
+      getTopicPageUrl({
+        service: 'uzbek',
+        topicId: 'c123456789t',
+        variant: 'cyr',
+        absolute: true,
+      }),
+    ).toBe('https://www.bbc.com/uzbek/topics/c123456789t/cyr');
+  });
+});

--- a/src/app/lib/utilities/getTopicPageUrl/index.test.ts
+++ b/src/app/lib/utilities/getTopicPageUrl/index.test.ts
@@ -2,9 +2,9 @@ import getTopicPageUrl from '.';
 
 describe('getTopicPageUrl', () => {
   it('builds a relative path by default', () => {
-    expect(
-      getTopicPageUrl({ service: 'pidgin', topicId: 'c123456789t' }),
-    ).toBe('/pidgin/topics/c123456789t');
+    expect(getTopicPageUrl({ service: 'pidgin', topicId: 'c123456789t' })).toBe(
+      '/pidgin/topics/c123456789t',
+    );
   });
 
   it('appends the variant when provided', () => {

--- a/src/app/lib/utilities/getTopicPageUrl/index.ts
+++ b/src/app/lib/utilities/getTopicPageUrl/index.ts
@@ -1,0 +1,29 @@
+import { Services, Variants } from '#app/models/types/global';
+
+const PUBLIC_SERVICES = ['news', 'cymrufyw', 'naidheachdan'];
+
+type GetTopicPageUrlProps = {
+  service: Services;
+  topicId: string;
+  variant?: Variants | null;
+  topicsPath?: string;
+  absolute?: boolean;
+};
+
+const getTopicPageUrl = ({
+  service,
+  topicId,
+  variant,
+  topicsPath = 'topics',
+  absolute = false,
+}: GetTopicPageUrlProps) => {
+  const path = `/${service}/${topicsPath}/${topicId}${variant ? `/${variant}` : ''}`;
+
+  if (!absolute) return path;
+
+  const hostname = `https://www.bbc.${PUBLIC_SERVICES.includes(service) ? 'co.uk' : 'com'}`;
+
+  return `${hostname}${path}`;
+};
+
+export default getTopicPageUrl;


### PR DESCRIPTION

Fix for bug spotted https://bbc-tpg.slack.com/archives/C03RMKNL7GC/p1787236298096979


```
It looks like we were getting the href with topicUrl from pageData.metadata.topics which was data from the BFF fetch. It seems that sometimes this topicUrl field is missing and sometimes it is populated. This could be a BFF bug.

However, I saw that the original topic tags component dealt with getting the URL in a different way that doesn't rely on this field from the BFF. So I have changed the way the code works so that the new Topic Discovery component uses the same function to construct the 'More about' href as the old Topic Tags component does.

We could look into why there are missing URLs in the BFF, but this is a quicker fix for now and also fits with already-existing methods of doing things.
```




This pull request introduces a new utility function, `getTopicPageUrl`, to centralize and standardize the construction of topic page URLs across the application. The function is now used in both the `TopicDiscovery` and `TopicTags` components, replacing previously duplicated or inconsistent URL-building logic. Comprehensive tests have also been added to ensure correct URL generation for various scenarios.

**Refactoring and Code Reuse:**

* Added a new utility function `getTopicPageUrl` in `src/app/lib/utilities/getTopicPageUrl/index.ts` to generate both relative and absolute topic URLs, supporting custom `topicsPath`, variants, and public/private service domains.
* Updated `TopicDiscovery` and `TopicTags` components to use the new `getTopicPageUrl` utility, replacing their local URL-building logic with calls to this shared function for consistency and maintainability. [[1]](diffhunk://#diff-d62980872f82cb4c5e728873faa9e7788854f4b1e854079e3d4e8342b852996bR8-R9) [[2]](diffhunk://#diff-d62980872f82cb4c5e728873faa9e7788854f4b1e854079e3d4e8342b852996bL30-R47) [[3]](diffhunk://#diff-8111a690b5a8706d72f37c22b904ca16bdf3eedc92f1f859e46cff8273fdd621R9) [[4]](diffhunk://#diff-8111a690b5a8706d72f37c22b904ca16bdf3eedc92f1f859e46cff8273fdd621L65-R73)

**Component Logic Updates:**

* Refactored `TopicDiscovery` to use `buildTopicPageUrl` for constructing topic URLs, ensuring consistent link generation in both UI and analytics tracking. [[1]](diffhunk://#diff-d62980872f82cb4c5e728873faa9e7788854f4b1e854079e3d4e8342b852996bR153-R154) [[2]](diffhunk://#diff-d62980872f82cb4c5e728873faa9e7788854f4b1e854079e3d4e8342b852996bL220-R233) [[3]](diffhunk://#diff-d62980872f82cb4c5e728873faa9e7788854f4b1e854079e3d4e8342b852996bL230-R243)
* Refactored `TopicTags` to use `buildTopicPageUrl` for all topic tag links, removing the previous inline URL logic and ensuring absolute URLs where needed. [[1]](diffhunk://#diff-8111a690b5a8706d72f37c22b904ca16bdf3eedc92f1f859e46cff8273fdd621L86-R88) [[2]](diffhunk://#diff-8111a690b5a8706d72f37c22b904ca16bdf3eedc92f1f859e46cff8273fdd621L102-R104)

**Absolute or relative link paths**

I retained the ability for Topic Tags to use an absolute link as this component is used on AMP pages and if we used a relative link on an AMP cache it could resolve to a different domain. This is how it was in the code already.

Topic Discovery does not show on AMP pages so we do not need an absolute link and a relative link is _supposed_ to make testing on other environments easier due to being able to stay on the same environment when clicking (however if the renderer_env query disappears then this doesn't work anyway...)


**Testing:**

* Added a new test suite for `getTopicPageUrl` covering relative and absolute URLs, public/private domains, custom topic paths, and variant handling.…ared utility


Looking at the page this bug was found on http://localhost:7081/romania/articles/cp8xgjgrykjo?renderer_env=live
you will see that the More About links all have hrefs and lead to topic pages now. If you look on live, the 3rd and 4th Topic Tab More About links do not have an href and do not work.

Resolves JIRA: 

Summary
======
_A very high-level summary of easily-reproducible changes that can be understood by non-devs, and why these changes where made._

Code changes
======
- _List key code changes that have been made._

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
