### PR TITLE
WS-3156: Resolve experiment activation data discrepancy

### DIFF
--- a/src/app/components/ATIAnalytics/atiUrl/index.client.test.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.client.test.ts
@@ -1,6 +1,10 @@
 import { Platforms } from '#app/models/types/global';
 import * as genericLabelHelpers from '../../../lib/analyticsUtils';
-import { buildReverbAnalyticsModel, buildReverbEventModel } from '.';
+import {
+  buildActivationEventModel,
+  buildReverbAnalyticsModel,
+  buildReverbEventModel,
+} from '.';
 
 const mockAndSet = ({ name, source }, response) => {
   source[name] = jest.fn(); // eslint-disable-line no-param-reassign
@@ -16,18 +20,18 @@ const analyticsUtilFunctions = [
 ];
 
 describe('atiUrl', () => {
+  beforeEach(() => {
+    analyticsUtilFunctions.forEach(func => {
+      mockAndSet(func, func.name);
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   describe('Reverb', () => {
     describe('buildReverbAnalyticsModel', () => {
-      beforeEach(() => {
-        analyticsUtilFunctions.forEach(func => {
-          mockAndSet(func, func.name);
-        });
-      });
-
       const input = {
         appName: 'news',
         campaigns: [
@@ -400,6 +404,77 @@ describe('atiUrl', () => {
               engine_id: ['optimizely.dummy_experiment.variant_1'],
             },
           });
+        });
+      });
+    });
+
+    describe('buildActivationEventModel', () => {
+      const input = {
+        pageIdentifier: 'mundo.page',
+        platform: 'canonical' as unknown as Platforms,
+        appName: 'news-mundo',
+        producerName: 'MUNDO',
+        statsDestination: 'statsDestination',
+        experimentName: 'dummy_experiment',
+        experimentVariant: 'variant_1',
+        isSignedIn: false,
+        hashedId: null,
+      };
+
+      it('should return the correct Reverb page section activation event model', () => {
+        const reverbExperimentActivationEventModel =
+          buildActivationEventModel(input);
+
+        const experimentActivationEventParams = {
+          destination: 'statsDestination',
+          name: 'mundo.page',
+          producer: 'MUNDO',
+          additionalProperties: {
+            type: 'AT',
+            app_name: 'news-mundo',
+            app_type: 'getAppType',
+          },
+        };
+
+        expect(reverbExperimentActivationEventModel.params.page).toEqual(
+          experimentActivationEventParams,
+        );
+      });
+
+      it('should return the correct Reverb user object configuration', () => {
+        const reverbExperimentActivationEventModel = buildActivationEventModel({
+          ...input,
+          isSignedIn: true,
+          hashedId: 'hashed-id',
+        });
+
+        expect(reverbExperimentActivationEventModel.params.user).toEqual({
+          isSignedIn: true,
+          hashedId: 'hashed-id',
+        });
+      });
+
+      it('should return the correct Reverb event details configuration', () => {
+        const reverbExperimentActivationEventModel =
+          buildActivationEventModel(input);
+
+        expect(reverbExperimentActivationEventModel.eventDetails).toEqual({
+          eventName: 'activation',
+          eventPublisher: 'viewability',
+          event: {
+            category: 'viewability',
+            action: 'serve',
+            interaction_type: 'optimizely_activation',
+            spec_id: '829257ce-28c6-4bbd-8e87-bdacba05de82',
+            spec_version: '1.0.1',
+          },
+          group: {
+            type: 'experiment',
+            name: 'optimizely',
+          },
+          experience: {
+            engine_id: ['optimizely.dummy_experiment.variant_1'],
+          },
         });
       });
     });

--- a/src/app/pages/ArticlePage/ArticlePage.tsx
+++ b/src/app/pages/ArticlePage/ArticlePage.tsx
@@ -5,7 +5,6 @@ import {
   useCallback,
   use,
   useEffect,
-  useRef,
 } from 'react';
 import { useTheme } from '@emotion/react';
 import useToggle from '#hooks/useToggle';
@@ -15,7 +14,6 @@ import useOptimizelyVariation, {
   ExperimentType,
 } from '#hooks/useOptimizelyVariation';
 import useScrollDepthTracker from '#hooks/useScrollDepthTracker';
-import useCustomEventTracker from '#hooks/useCustomEventTracker';
 import { GROUP_4_MIN_WIDTH_BP } from '#app/components/ThemeProvider/mediaQueries';
 import { singleTextBlock } from '#app/models/blocks';
 import { BylineLinkedData } from '#app/components/LinkedData/types';
@@ -118,7 +116,6 @@ import SearchOjExperiment from './SearchOjExperiment';
 import {
   isSearchOjVariant,
   MID_ARTICLE_OJ_EXPERIMENT_TRIGGER_ID,
-  SEARCH_OJ_ACTIVATION_EVENT_NAME,
   SEARCH_OJ_EXPERIMENT_NAME,
   SearchOjVariant,
 } from './SearchOjExperiment/config';
@@ -134,27 +131,14 @@ const ActivateSearchOjExperiment = ({
     experimentName: SEARCH_OJ_EXPERIMENT_NAME,
     experimentType: ExperimentType.CLIENT_SIDE,
   });
-  // this sends piano the same experiment and variation chosen by optimizely
-  const trackActivation = useCustomEventTracker({
-    eventName: SEARCH_OJ_ACTIVATION_EVENT_NAME,
-    experimentName: SEARCH_OJ_EXPERIMENT_NAME,
-    experimentVariant: variation ?? undefined,
-  });
-  // this makes sure rerenders do not send the activation event again
-  const hasTrackedActivation = useRef(false);
 
   useEffect(() => {
     if (variation !== null) {
       const validVariation = isSearchOjVariant(variation) ? variation : null;
 
       onDecision(validVariation);
-
-      if (validVariation && !hasTrackedActivation.current) {
-        hasTrackedActivation.current = true;
-        trackActivation();
-      }
     }
-  }, [onDecision, trackActivation, variation]);
+  }, [onDecision, variation]);
 
   return null;
 };

--- a/src/app/pages/ArticlePage/searchReferrerComponentOrder.test.ts
+++ b/src/app/pages/ArticlePage/searchReferrerComponentOrder.test.ts
@@ -142,28 +142,6 @@ describe('useMobileOJComponentOrder', () => {
     });
   };
 
-  describe('Search OJ activation tracking', () => {
-    it('sends one activation event for a valid variation', async () => {
-      renderArticlePageWithDecision('control');
-
-      await waitFor(() => expect(mockTrackActivation).toHaveBeenCalledTimes(1));
-
-      expect(mockUseCustomEventTracker).toHaveBeenCalledWith({
-        eventName: SEARCH_OJ_ACTIVATION_EVENT_NAME,
-        experimentName: SEARCH_OJ_EXPERIMENT_NAME,
-        experimentVariant: 'control',
-      });
-    });
-
-    it('does not send an activation event for an invalid variation', async () => {
-      renderArticlePageWithDecision('invalid_variation');
-
-      await waitFor(() => expect(mockUseCustomEventTracker).toHaveBeenCalled());
-
-      expect(mockTrackActivation).not.toHaveBeenCalled();
-    });
-  });
-
   describe('Desktop behavior', () => {
     it('should return null regardless of variant when on desktop', () => {
       matchMediaMock.mockReturnValue({

--- a/src/app/pages/ArticlePage/searchReferrerComponentOrder.test.ts
+++ b/src/app/pages/ArticlePage/searchReferrerComponentOrder.test.ts
@@ -19,10 +19,6 @@ import {
   SEARCH_MID_ARTICLE_COMPONENT,
   SearchVariant,
 } from './searchReferrerComponentOrder';
-import {
-  SEARCH_OJ_ACTIVATION_EVENT_NAME,
-  SEARCH_OJ_EXPERIMENT_NAME,
-} from './SearchOjExperiment/config';
 
 jest.mock('#app/components/ThemeProvider');
 jest.mock('#app/components/ChartbeatAnalytics', () => {


### PR DESCRIPTION
Resolves JIRA: WS-3156

Relates to: https://github.com/bbc/simorgh/pull/14293

Summary
======
Use the central experiment activation tracking logic.

Code changes
======
- Remove use of `useCustomEventTracker` for tracking experiment
activation in Piano.

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
