### PR TITLE
WS-1348-kyrgyz-redirects-to-belfrage

### DIFF
--- a/ws-nextjs-app/next.config.js
+++ b/ws-nextjs-app/next.config.js
@@ -56,20 +56,6 @@ module.exports = {
       },
     ];
   },
-  async redirects() {
-    return [
-      {
-        source: '/kyrgyz/bbc_kyrgyz_radio/live_radio',
-        destination: '/kyrgyz',
-        permanent: true,
-      },
-      {
-        source: '/kyrgyz/bbc_kyrgyz_radio/liveradio',
-        destination: '/kyrgyz',
-        permanent: true,
-      },
-    ];
-  },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
Resolves JIRA: [WS-1348](https://bbc.atlassian.net/jira/software/c/projects/WS/boards/1253?selectedIssue=WS-1348)

Summary
======
These redirects are moving to Belfrage for consistency with other redirect handling.

Previously, two redirects for the Kyrgyz live radio page were handled directly in the Simorgh Next.js config. This PR removes them from `next.config.js` now that they are being handled by Belfrage instead, so that all redirect logic is managed consistently in one place rather than being split across two systems.

Code changes
======
- Removed the `/kyrgyz/bbc_kyrgyz_radio/live_radio` and `/kyrgyz/bbc_kyrgyz_radio/liveradio` redirects from the `redirects()` function in `ws-nextjs-app/next.config.js`.

Testing
======
1. Confirm the equivalent redirects have been added and deployed in Belfrage before merging this PR.
2. Test on Simorgh Preview Environment: visit `/kyrgyz/bbc_kyrgyz_radio/live_radio` and `/kyrgyz/bbc_kyrgyz_radio/liveradio` and confirm they still redirect correctly to `/kyrgyz`, now via Belfrage rather than Next.js.
3. Pull this branch and run the app locally.
4. Visit the same two paths locally and confirm they no longer redirect via Next.js.
5. Confirm no other pages or tests reference these redirects.

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

[WS-1348]: https://bbc.atlassian.net/browse/WS-1348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ