### PR TITLE
WS-NA - Bug Fix - Use correct Tipo Image for in-situ promos

### DIFF
--- a/src/app/components/Curation/HierarchicalGrid/index.test.tsx
+++ b/src/app/components/Curation/HierarchicalGrid/index.test.tsx
@@ -246,6 +246,7 @@ describe('Hierarchical Grid Curation', () => {
         blocks: aresMediaBlocks,
         uniqueId: `in-situ-${inSituPromo.id}`,
         loadPlayerOnInitialRender: true,
+        holdingImageURL: inSituPromo.imageUrl,
       }),
       undefined,
     );

--- a/src/app/components/Curation/HierarchicalGrid/index.tsx
+++ b/src/app/components/Curation/HierarchicalGrid/index.tsx
@@ -205,6 +205,7 @@ const HiearchicalGrid = ({
                       blocks={inSituMediaBlocks}
                       uniqueId={`in-situ-${promo.id || i}`}
                       loadPlayerOnInitialRender
+                      holdingImageURL={promo.imageUrl}
                     />
                   </div>
                   <div className="promo-text">{promoText}</div>

--- a/src/app/components/MediaLoader/configs/aresMedia.ts
+++ b/src/app/components/MediaLoader/configs/aresMedia.ts
@@ -29,6 +29,7 @@ export default ({
   showAdsBasedOnLocation = false,
   embedded,
   lang,
+  holdingImageURL: holdingImageURLOverride,
 }: ConfigBuilderProps): ConfigBuilderReturnProps => {
   const { model: aresMedia }: AresMediaBlock =
     filterForBlockType(blocks, 'aresMedia') ?? {};
@@ -87,13 +88,15 @@ export default ({
   // Referred to as 'clip PID', 'episode PID' or 'parent PID'
   const parentPID = aresMediaMetadata?.id;
 
-  const holdingImageURL = rawImage
-    ? buildIChefURL({
-        originCode,
-        locator,
-        resolution: DEFAULT_WIDTH,
-      })
-    : aresMediaMetadata?.imageUrl;
+  const holdingImageURL =
+    holdingImageURLOverride?.replace('{width}', String(DEFAULT_WIDTH)) ||
+    (rawImage
+      ? buildIChefURL({
+          originCode,
+          locator,
+          resolution: DEFAULT_WIDTH,
+        })
+      : aresMediaMetadata?.imageUrl);
 
   const isLive = aresMediaMetadata?.live ?? false;
 
@@ -116,8 +119,10 @@ export default ({
     guidanceMessage,
     holdingImageURL,
     translations,
-    placeholderImageOriginCode: originCode,
-    placeholderImageLocator: locator,
+    placeholderImageOriginCode: holdingImageURLOverride
+      ? undefined
+      : originCode,
+    placeholderImageLocator: holdingImageURLOverride ? undefined : locator,
   });
 
   const ampIframeUrl = getAmpIframeUrl({ id, parentPID, versionPID, lang });

--- a/src/app/components/MediaLoader/index.test.tsx
+++ b/src/app/components/MediaLoader/index.test.tsx
@@ -385,6 +385,25 @@ describe('MediaLoader', () => {
         );
       },
     );
+
+    it('passes a supplied holding image to the player configuration', async () => {
+      const buildConfigSpy = jest.spyOn(buildConfig, 'default');
+      const holdingImageURL =
+        'https://ichef.bbci.co.uk/ace/ws/{width}/cpsprodpb/promo-image.jpg.webp';
+
+      await act(async () => {
+        render(
+          <MediaPlayer
+            blocks={aresMediaBlocks as MediaBlock[]}
+            holdingImageURL={holdingImageURL}
+          />,
+        );
+      });
+
+      expect(buildConfigSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ holdingImageURL }),
+      );
+    });
   });
 
   describe('AMP', () => {

--- a/src/app/components/MediaLoader/index.tsx
+++ b/src/app/components/MediaLoader/index.tsx
@@ -218,6 +218,7 @@ type Props = {
   uniqueId?: string;
   eventMapping?: EventMapping;
   loadPlayerOnInitialRender?: boolean;
+  holdingImageURL?: string;
 };
 
 const MediaLoader = ({
@@ -227,6 +228,7 @@ const MediaLoader = ({
   uniqueId,
   eventMapping,
   loadPlayerOnInitialRender = false,
+  holdingImageURL,
 }: Props) => {
   const { lang, service, translations, defaultImage } = use(ServiceContext);
   const { pageIdentifier } = use(EventTrackingContext);
@@ -268,6 +270,7 @@ const MediaLoader = ({
     showAdsBasedOnLocation,
     embedded,
     defaultImage,
+    holdingImageURL,
   });
 
   if (!config) return null;

--- a/src/app/components/MediaLoader/types.ts
+++ b/src/app/components/MediaLoader/types.ts
@@ -124,6 +124,7 @@ export type ConfigBuilderProps = {
   embedded?: boolean;
   lang: string;
   defaultImage: string;
+  holdingImageURL?: string;
 };
 
 export type Orientations = 'landscape' | 'portrait';
@@ -382,4 +383,5 @@ export type BuildConfigProps = {
   showAdsBasedOnLocation?: boolean;
   embedded?: boolean;
   defaultImage: string;
+  holdingImageURL?: string;
 };

--- a/src/app/components/MediaLoader/utils/buildSettings.client.test.ts
+++ b/src/app/components/MediaLoader/utils/buildSettings.client.test.ts
@@ -412,6 +412,24 @@ describe('buildSettings', () => {
   });
 
   describe('AresMedia', () => {
+    it('uses a supplied holding image instead of the Ares media image', () => {
+      const holdingImageURL =
+        'https://ichef.bbci.co.uk/ace/ws/{width}/cpsprodpb/promo-image.jpg.webp';
+      const result = buildSettings({
+        ...baseSettings,
+        blocks: aresMediaBlocks as MediaBlock[],
+        holdingImageURL,
+      });
+
+      expect(result?.playerConfig.playlistObject?.holdingImageURL).toBe(
+        holdingImageURL.replace('{width}', '512'),
+      );
+      expect(result?.placeholderConfig).toMatchObject({
+        placeholderSrc: holdingImageURL.replace('{width}', '512'),
+        placeholderSrcset: '',
+      });
+    });
+
     it('Should process an AresMedia block into a valid playlist item for an "article" page.', () => {
       const result = buildSettings({
         ...baseSettings,

--- a/src/app/components/MediaLoader/utils/buildSettings.ts
+++ b/src/app/components/MediaLoader/utils/buildSettings.ts
@@ -40,6 +40,7 @@ const buildSettings = ({
   showAdsBasedOnLocation = false,
   embedded,
   defaultImage,
+  holdingImageURL,
 }: BuildConfigProps) => {
   const { model: mediaOverrides } =
     filterForBlockType(blocks, 'mediaOverrides') || {};
@@ -86,6 +87,7 @@ const buildSettings = ({
     embedded,
     lang,
     defaultImage,
+    holdingImageURL,
   });
 
   if (!config) return null;


### PR DESCRIPTION
Summary
======
- Fixes in-situ players showing the original Ares/Castaway image instead of the editorial promo image
- Uses the resolved promo image already supplied by the BFF
- Supports Tipo overriding the Optimo promo image
- Retains the Ares/Castaway image as a fallback
- Verified locally with distinct Optimo and Tipo images (currently only enabled on Arabic)

Before:
<img width="1286" height="490" alt="image" src="https://github.com/user-attachments/assets/4d1550c5-9a25-47ab-9308-7d0a10636be6" />

After:
<img width="1232" height="811" alt="image" src="https://github.com/user-attachments/assets/6501c8e2-82fb-4864-b9c1-23f9902d14b1" />



Code changes
======
- _List key code changes that have been made._

Testing
======
1. _List the steps required to test this PR._

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
