### PR TITLE
WS-3119 Introduced new toggle for followd topics and its related changes

### DIFF
--- a/src/app/components/FollowTopicButton/index.test.tsx
+++ b/src/app/components/FollowTopicButton/index.test.tsx
@@ -1,0 +1,43 @@
+import mockIdctaConfig from '#app/contexts/AccountContext/mocks';
+import {
+  render,
+  screen,
+} from '#app/components/react-testing-library-with-providers';
+import FollowTopicButton from '.';
+
+const topicData = {
+  topicId: 'cw90edn9kw4t',
+  title: 'India',
+  service: 'hindi' as const,
+  url: 'https://www.bbc.com/hindi/topics/cw90edn9kw4t',
+};
+
+describe('FollowTopicButton', () => {
+  it('does not render when topicUasPersonalization is disabled', () => {
+    render(<FollowTopicButton topicData={topicData} />, {
+      service: 'hindi',
+      idctaConfig: mockIdctaConfig,
+      toggles: {
+        uasPersonalization: { enabled: true, value: 'hindi' },
+        topicUasPersonalization: { enabled: false },
+      },
+    });
+
+    expect(
+      screen.queryByTestId('follow-topic-btn-guest'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders when topicUasPersonalization is enabled', () => {
+    render(<FollowTopicButton topicData={topicData} />, {
+      service: 'hindi',
+      idctaConfig: mockIdctaConfig,
+      toggles: {
+        uasPersonalization: { enabled: false },
+        topicUasPersonalization: { enabled: true, value: 'hindi' },
+      },
+    });
+
+    expect(screen.getByTestId('follow-topic-btn-guest')).toBeInTheDocument();
+  });
+});

--- a/src/app/components/FollowTopicButton/index.tsx
+++ b/src/app/components/FollowTopicButton/index.tsx
@@ -12,10 +12,14 @@ export interface FollowTopicButtonProps {
 const FOLLOW_TOPIC_BUTTON_ID = 'follow-topic-button';
 
 const FollowTopicButton = ({ topicData }: FollowTopicButtonProps) => {
-  const { isPersonalizationAvailable, isPersonalizationEnabled } =
-    use(AccountContext);
+  const {
+    isTopicUasPersonalizationAvailable,
+    isTopicUasPersonalizationEnabled,
+  } = use(AccountContext);
 
-  if (!isPersonalizationAvailable) return null;
+  if (!isTopicUasPersonalizationAvailable) {
+    return null;
+  }
 
   return (
     <>
@@ -23,7 +27,7 @@ const FollowTopicButton = ({ topicData }: FollowTopicButtonProps) => {
         <style>{`#${FOLLOW_TOPIC_BUTTON_ID} { display: none; }`}</style>
       </noscript>
       <div css={styles.buttonWrapper} id={FOLLOW_TOPIC_BUTTON_ID}>
-        {isPersonalizationEnabled ? (
+        {isTopicUasPersonalizationEnabled ? (
           <FollowTopicButtonAuthenticated topicData={topicData} />
         ) : (
           <FollowTopicButtonGuest topicId={topicData.topicId} />

--- a/src/app/contexts/AccountContext/index.tsx
+++ b/src/app/contexts/AccountContext/index.tsx
@@ -40,6 +40,10 @@ export const AccountProvider = ({
   const { service } = use(ServiceContext);
   const { enabled: isPersonalizationToggleEnabled, value: accountService } =
     useToggle('uasPersonalization');
+  const {
+    enabled: topicUasPersonalizationEnabled,
+    value: topicAccountService,
+  } = useToggle('topicUasPersonalization');
 
   useEffect(() => {
     setPageToReturnTo(window.location.href);
@@ -79,6 +83,7 @@ export const AccountProvider = ({
     isIdctaAvailable &&
     Boolean(initialConfig?.initialIsSignedIn || signedInToken);
 
+  // Personalization for saved articles
   const isPersonalizationAvailable =
     isIdctaAvailable &&
     isPersonalizationToggleEnabled &&
@@ -87,6 +92,17 @@ export const AccountProvider = ({
       : true);
 
   const isPersonalizationEnabled = isPersonalizationAvailable && isSignedIn;
+
+  // Personalization for followed topics
+  const isTopicUasPersonalizationAvailable =
+    isIdctaAvailable &&
+    topicUasPersonalizationEnabled &&
+    (isLocal()
+      ? topicAccountService?.toString().split('|').includes(service)
+      : true);
+
+  const isTopicUasPersonalizationEnabled =
+    isTopicUasPersonalizationAvailable && isSignedIn;
 
   const isRefreshAvailable =
     isIdctaAvailable && initialConfig?.availability?.refresh === 'GREEN';
@@ -104,6 +120,8 @@ export const AccountProvider = ({
       forYouUrl,
       isPersonalizationAvailable,
       isPersonalizationEnabled,
+      isTopicUasPersonalizationAvailable,
+      isTopicUasPersonalizationEnabled,
     }),
     [
       hashedUserId,
@@ -117,6 +135,8 @@ export const AccountProvider = ({
       signOutUrl,
       isPersonalizationAvailable,
       isPersonalizationEnabled,
+      isTopicUasPersonalizationAvailable,
+      isTopicUasPersonalizationEnabled,
     ],
   );
 

--- a/src/app/lib/config/toggles/__snapshots__/index.test.js.snap
+++ b/src/app/lib/config/toggles/__snapshots__/index.test.js.snap
@@ -88,6 +88,9 @@ exports[`Toggles Config when application environment is live should contain corr
   "topBarOJs": {
     "enabled": true,
   },
+  "topicUasPersonalization": {
+    "enabled": false,
+  },
   "uasPersonalization": {
     "enabled": false,
   },
@@ -192,6 +195,10 @@ exports[`Toggles Config when application environment is local should contain cor
   "topBarOJs": {
     "enabled": true,
   },
+  "topicUasPersonalization": {
+    "enabled": true,
+    "value": "hindi|mundo|portuguese",
+  },
   "uasPersonalization": {
     "enabled": true,
     "value": "hindi|mundo|portuguese",
@@ -292,6 +299,9 @@ exports[`Toggles Config when application environment is test should contain corr
   },
   "topBarOJs": {
     "enabled": true,
+  },
+  "topicUasPersonalization": {
+    "enabled": false,
   },
   "uasPersonalization": {
     "enabled": false,

--- a/src/app/lib/config/toggles/liveConfig.js
+++ b/src/app/lib/config/toggles/liveConfig.js
@@ -85,6 +85,9 @@ export default {
   topBarOJs: {
     enabled: true,
   },
+  topicUasPersonalization: {
+    enabled: false,
+  },
   variantCookie: {
     enabled: true,
   },

--- a/src/app/lib/config/toggles/localConfig.js
+++ b/src/app/lib/config/toggles/localConfig.js
@@ -89,6 +89,10 @@ export default {
   topBarOJs: {
     enabled: true,
   },
+  topicUasPersonalization: {
+    enabled: true,
+    value: 'hindi|mundo|portuguese',
+  },
   variantCookie: {
     enabled: true,
   },

--- a/src/app/lib/config/toggles/testConfig.js
+++ b/src/app/lib/config/toggles/testConfig.js
@@ -85,6 +85,9 @@ export default {
   topBarOJs: {
     enabled: true,
   },
+  topicUasPersonalization: {
+    enabled: false,
+  },
   variantCookie: {
     enabled: true,
   },

--- a/src/app/models/types/account.ts
+++ b/src/app/models/types/account.ts
@@ -30,4 +30,6 @@ export type AccountContextProps = {
   hashedUserId?: string;
   isPersonalizationEnabled: boolean;
   isPersonalizationAvailable: boolean;
+  isTopicUasPersonalizationEnabled: boolean;
+  isTopicUasPersonalizationAvailable: boolean;
 };


### PR DESCRIPTION
**Tickets:**
https://bbc.atlassian.net/browse/WS-3119
https://bbc.atlassian.net/browse/WS-3134

**Note:**
The parent PR for this is [#14274](https://github.com/bbc/simorgh/pull/14274), which has not yet been merged into the `latest` branch. We are productionizing this parent PR by creating smaller, subtask PRs.

Summary
======
This pull request introduces support for a new feature toggle, `topicUasPersonalization`, which controls whether users can personalize their experience by following topics. The changes ensure that the `FollowTopicButton` component and related logic respect this toggle, and update the context, configuration, and tests accordingly.

Code changes
======
**Feature toggle and configuration:**

* Added the `topicUasPersonalization` toggle to the local, live, and test configuration files, allowing it to be enabled or disabled per environment. 
**Context and types:**

* Extended the `AccountContext` and its provider to include `isTopicUasPersonalizationAvailable` and `isTopicUasPersonalizationEnabled`, which derive their values from the new toggle and user sign-in status.

**Component logic and tests:**

* Updated the `FollowTopicButton` component to use the new context properties, rendering the button only when topic personalization is available and enabled.
* Added tests for `FollowTopicButton` to verify correct rendering behavior based on the `topicUasPersonalization` toggle state.


Testing
======
Visit any topic page locally .
MAke sure , button is present based on toggle 's ON/OFF 
