### PR TITLE
WS-2949: Corrresponding resonance values added

### DIFF
--- a/src/app/components/ATIAnalytics/atiUrl/index.client.test.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.client.test.ts
@@ -98,24 +98,24 @@ describe('atiUrl', () => {
       //   expect(result.baseProperties.app.type).toBe('getAppType');
       // });
 
-      // it('should omit optional parity fields when provided as empty strings', () => {
-      //   const result = buildResonanceAnalyticsModel({
-      //     ...input,
-      //     pageTitle: '',
-      //     timePublished: '',
-      //     timeUpdated: '',
-      //     ldpThingLabels: '',
-      //     ldpThingIds: '',
-      //     categoryName: '',
-      //   });
+      it('should omit optional fields when no value is provided', () => {
+        const result = buildResonanceAnalyticsModel({
+          ...input,
+          pageTitle: undefined,
+          timePublished: '',
+          timeUpdated: '',
+          ldpThingLabels: '',
+          ldpThingIds: '',
+          categoryName: '',
+        });
 
-      //   expect(result.pageviewProperties).not.toHaveProperty('pageTitle');
-      //   expect(result.pageviewProperties).not.toHaveProperty('publicationDate');
-      //   expect(result.pageviewProperties).not.toHaveProperty('pubUpdateDate');
-      //   expect(result.pageviewProperties).not.toHaveProperty('ldpTags');
-      //   expect(result.pageviewProperties).not.toHaveProperty('ldpIds');
-      //   expect(result.pageviewProperties).not.toHaveProperty('section');
-      // });
+        expect(result.pageviewProperties).not.toHaveProperty('pageTitle');
+        expect(result.pageviewProperties).not.toHaveProperty('publicationDate');
+        expect(result.pageviewProperties).not.toHaveProperty('pubUpdateDate');
+        expect(result.pageviewProperties).not.toHaveProperty('ldpTags');
+        expect(result.pageviewProperties).not.toHaveProperty('ldpIds');
+        expect(result.pageviewProperties).not.toHaveProperty('section');
+      });
 
       it('should suffix app name with "-app" when platform is app', () => {
         const result = buildResonanceAnalyticsModel({

--- a/src/app/components/ATIAnalytics/atiUrl/index.client.test.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.client.test.ts
@@ -46,6 +46,14 @@ describe('atiUrl', () => {
         pageIdentifier: 'pidgin.articles.c0000000001o.page',
         producerName: 'PIDGIN',
         platform: 'canonical' as Platforms,
+        categoryName: 'categoryName',
+        ldpThingIds: 'ldpThingIds',
+        ldpThingLabels: 'ldpThingLabels',
+        libraryVersion: 'libraryVersion',
+        pageTitle: 'pageTitle',
+        nationsProducer: '',
+        timePublished: 'timePublished',
+        timeUpdated: 'timeUpdated',
       };
 
       it('should return the correct Resonance analytics model', () => {
@@ -68,8 +76,46 @@ describe('atiUrl', () => {
           language: 'pcm',
           destination: 'statsDestination',
           producer: 'PIDGIN',
+          ldpIds: 'ldpThingIds',
+          ldpTags: 'ldpThingLabels',
+          pageTitle: 'sanitise',
+          pubUpdateDate: 'timeUpdated',
+          publicationDate: 'timePublished',
+          section: 'categoryName',
         });
       });
+
+      // it('should return url and referrerUrl using getHref and getReferrer', () => {
+      //   const result = buildResonanceAnalyticsModel(input);
+
+      //   expect(result.pageviewProperties.url).toBe('getHref');
+      //   expect(result.pageviewProperties.referrerUrl).toBe('getReferrer');
+      // });
+
+      // it('should populate app.type using getAppType', () => {
+      //   const result = buildResonanceAnalyticsModel(input);
+
+      //   expect(result.baseProperties.app.type).toBe('getAppType');
+      // });
+
+      // it('should omit optional parity fields when provided as empty strings', () => {
+      //   const result = buildResonanceAnalyticsModel({
+      //     ...input,
+      //     pageTitle: '',
+      //     timePublished: '',
+      //     timeUpdated: '',
+      //     ldpThingLabels: '',
+      //     ldpThingIds: '',
+      //     categoryName: '',
+      //   });
+
+      //   expect(result.pageviewProperties).not.toHaveProperty('pageTitle');
+      //   expect(result.pageviewProperties).not.toHaveProperty('publicationDate');
+      //   expect(result.pageviewProperties).not.toHaveProperty('pubUpdateDate');
+      //   expect(result.pageviewProperties).not.toHaveProperty('ldpTags');
+      //   expect(result.pageviewProperties).not.toHaveProperty('ldpIds');
+      //   expect(result.pageviewProperties).not.toHaveProperty('section');
+      // });
 
       it('should suffix app name with "-app" when platform is app', () => {
         const result = buildResonanceAnalyticsModel({

--- a/src/app/components/ATIAnalytics/atiUrl/index.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.ts
@@ -34,17 +34,29 @@ const RESONANCE_MODE = { LIVE: 'live', TEST: 'test' } as const;
 
 export const buildResonanceAnalyticsModel = ({
   appName,
+  categoryName,
   contentId,
   contentType,
-  language,
-  statsDestination,
   destinationSiteId,
   hashedId,
+  language,
+  ldpThingIds,
+  ldpThingLabels,
   pageIdentifier,
-  producerName,
+  pageTitle,
   platform,
+  producerName,
+  statsDestination,
+  timePublished,
+  timeUpdated,
 }: ATIPageTrackingProps): ResonanceBeaconConfig => {
   const env = getEnvConfig().SIMORGH_APP_ENV;
+  // const href = getHref(platform);
+  // const referrer = getReferrer(platform);
+
+  // const aggregatedCampaigns = (Array.isArray(campaigns) ? campaigns : [])
+  //   .map(({ campaignName }) => campaignName)
+  //   .join('~');
 
   return {
     resonanceProperties: {
@@ -66,6 +78,14 @@ export const buildResonanceAnalyticsModel = ({
       language,
       destination: statsDestination,
       producer: producerName,
+      // ...(href && { url: href }),
+      // ...(referrerUrl && { referrerUrl: referrer }),
+      ...(pageTitle && { pageTitle: sanitise(pageTitle) }),
+      ...(timePublished && { publicationDate: timePublished }),
+      ...(timeUpdated && { pubUpdateDate: timeUpdated }),
+      ...(ldpThingLabels && { ldpTags: ldpThingLabels }),
+      ...(ldpThingIds && { ldpIds: ldpThingIds }),
+      ...(categoryName && { section: categoryName }),
     },
   } as ResonanceBeaconConfig;
 };
@@ -249,12 +269,6 @@ type ActivationEventProps = {
   hashedId?: string | null;
 };
 
-/**
- * Builds the standalone Piano/Reverb "activation" beacon fired when a user is
- * activated into an Optimizely experiment, decoupled from any view/click event.
- * Follows the "Activation (v1.0.1) on Web" event-catalogue spec (viewability model),
- * spec ID ACTIVATION_EVENT_SPEC_ID - see https://broxy.tools.bbc.co.uk/bbc-event-catalogue/xbbc/viewability-events/specs/experiment/activation-web/1.0.1/
- */
 export const buildActivationEventModel = ({
   pageIdentifier,
   platform,
@@ -288,7 +302,6 @@ export const buildActivationEventModel = ({
     event: {
       category: 'viewability',
       action: ACTIVATION_EVENT_SERVE_ACTION,
-      // Identifies this 'serve' event as an activation event, pending a dedicated event_action value in the spec
       interaction_type: ACTIVATION_EVENT_INTERACTION_TYPE,
       spec_id: ACTIVATION_EVENT_SPEC_ID,
       spec_version: ACTIVATION_EVENT_SPEC_VERSION,

--- a/src/app/components/ATIAnalytics/atiUrl/index.ts
+++ b/src/app/components/ATIAnalytics/atiUrl/index.ts
@@ -269,6 +269,12 @@ type ActivationEventProps = {
   hashedId?: string | null;
 };
 
+/**
+ * Builds the standalone Piano/Reverb "activation" beacon fired when a user is
+ * activated into an Optimizely experiment, decoupled from any view/click event.
+ * Follows the "Activation (v1.0.1) on Web" event-catalogue spec (viewability model),
+ * spec ID ACTIVATION_EVENT_SPEC_ID - see https://broxy.tools.bbc.co.uk/bbc-event-catalogue/xbbc/viewability-events/specs/experiment/activation-web/1.0.1/
+ */
 export const buildActivationEventModel = ({
   pageIdentifier,
   platform,
@@ -302,6 +308,7 @@ export const buildActivationEventModel = ({
     event: {
       category: 'viewability',
       action: ACTIVATION_EVENT_SERVE_ACTION,
+      // Identifies this 'serve' event as an activation event, pending a dedicated event_action value in the spec
       interaction_type: ACTIVATION_EVENT_INTERACTION_TYPE,
       spec_id: ACTIVATION_EVENT_SPEC_ID,
       spec_version: ACTIVATION_EVENT_SPEC_VERSION,

--- a/src/app/components/ATIAnalytics/index.client.test.tsx
+++ b/src/app/components/ATIAnalytics/index.client.test.tsx
@@ -959,7 +959,14 @@ describe('ATI Analytics Container', () => {
           contentType: 'article',
           destination: 'WS_NEWS_LANGUAGES_TEST',
           language: 'en-gb',
+          ldpIds:
+            '2351f2b2-ce36-4f44-996d-c3c4f7f90eaa~803eaeb9-c0c3-4f1b-9a66-90efac3df2dc',
+          ldpTags: 'Royal+Wedding+2018~Duchess+of+Sussex',
+          pageTitle: 'Article%20Headline%20for%20SEO',
           producer: 'ARABIC',
+          pubUpdateDate: '2018-01-01T14:00:00.000Z',
+          publicationDate: '2018-01-01T12:01:00.000Z',
+          section: 'Royal+Wedding+2018~Duchess+of+Sussex',
         },
         resonanceProperties: {
           mode: 'test',


### PR DESCRIPTION
Resolves JIRA: https://bbc.atlassian.net/browse/WS-2949

Summary
======
Unit tests fixed, Resonance values added to ATIAnalytics/atiUrl/index

Code changes
======
App Type Detection: Added type: getAppType(platform) to baseProperties.app.

New Pageview/Tracking Fields: Extended the builder parameters and populated additional properties onto the analytics model:

Navigation & Context: url (derived via getHref), referrerUrl (derived via getReferrer), and pageTitle (processed with sanitise).

Metadata & Timestamps: publicationDate (from timePublished) and pubUpdateDate (from timeUpdated).

Content Categorization: section (from categoryName), ldpIds (from ldpThingIds), and ldpTags (from ldpThingLabels).

Testing
======

Example testing steps
(note an article page is a bit more useful than a homepage

Live -
Open network tab
Go to https://www.bbc.com/arabic/articles/c6y9z5z353w8o
Look (or filter) for event POST event

Open events object, you will see the current response

```app_name
:
"news-arabic"
browser_language
:
"en-GB"
content_id
:
"urn:bbc:optimo:asset:c6y9z5z353w8o"
content_type
:
"article"
destination
:
"WS_NEWS_LANGUAGES"
event_id
:
"35b44c53-15ae-4945-8344-4864840e731b"
event_name
:
"page.display"
event_time
:
"2026-09-15T10:42:50Z"
event_ts
:
1789468970
language
:
"ar"
page_name
:
"arabic.articles.c6y9z5z353w8o.page"
page_title
:
"السعودية تتعهّد بالرد \"بحزم\" على هجمات الحوثيين وطهران تنفي أي دور في تجدّد الصراع - BBC News عربي"
producer
:
"ARABIC"
site_id
:
598342
url
:
"https://www.bbc.com/arabic/articles/c6y9z5z353w8o"

```

Compare this to local (includes changes in this PR) -
Checkout branch WS-2949-parity-resonance-reverb
Run yarn dev
Open network tab
Visit http://localhost:7081/arabic/articles/c6y9z5z353w8o?renderer_env=live

Do the steps above to find the events object

```app_name
:
"news-arabic"
app_type
:
"responsive"
browser_language
:
"en-GB"
content_id
:
"urn:bbc:optimo:asset:c6y9z5z353w8o"
content_type
:
"article"
destination
:
"WS_NEWS_LANGUAGES_TEST"
event_id
:
"23c5223e-cf8d-4de8-ba8e-647d244c1915"
event_name
:
"page.display"
event_time
:
"2026-09-15T10:41:59Z"
event_ts
:
1789468919
language
:
"ar"
ldp_ids
:
"06b98038-9d81-4518-9b2b-61ff388e058c~1e3ec16d-8ae2-4194-a461-ac7e7d4a00da~3d9ca6eb-a694-4880-88db-de4ed05d42cc~4f310b5f-0157-47e7-b107-5849738851da~511accd7-6ee6-4dfb-8e2b-b236be8cb14c~532c6b2f-f59c-4d31-afef-b6d62f53f49e~78080d81-2849-497e-bc3a-bf364626456b~82857f8e-8134-462a-bb32-b7b14f4eab75~9519c450-d886-406a-8fc3-aaa847a2cf88~dc27493c-d8e8-4fe2-9fbd-150564b5b959~dd4fa30e-dec8-479a-8881-b480af10392c"
ldp_tags
:
"Strait+of+Hormuz~Houthis~Yemen~Abdul+Fattah+al-Sisi~Iran~Mohammed+bin+Salman~Donald+Trump~United+States~Egypt~Middle+East~Saudi+Arabia"
page_name
:
"arabic.articles.c6y9z5z353w8o.page"
page_title
:
"السعودية تتعهّد بالرد \"بحزم\" على هجمات الحوثيين وطهران تنفي أي دور في تجدّد الصراع - BBC News عربي"
producer
:
"ARABIC"
pub_update_date
:
"2026-09-15T10:15:25.226Z"
publication_date
:
"2026-09-15T03:10:04.838Z"
site_id
:
598343
url
:
"http://localhost:7081/arabic/articles/c6y9z5z353w8o?renderer_env=live"
```

See addition of app_type, ldp_ids, ldp_tags, pub_update_date, publication_date.

--
You can repeat for more page types. Note some fields are only applicable to certain page types

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
