### PR TITLE
WS-2782: Fix failing darkUI checks 

### DIFF
--- a/src/app/components/MediaLoader/Placeholder/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/MediaLoader/Placeholder/__snapshots__/index.test.tsx.snap
@@ -211,6 +211,13 @@ exports[`Media Player: Placeholder should render a video placeholder 1`] = `
   fill: currentColor;
   width: 0.75rem;
   height: 0.75rem;
+  color: #222222;
+}
+
+@media (max-width: 24.9375rem) {
+  .emotion-6 {
+    color: #222222;
+  }
 }
 
 .emotion-8 {
@@ -567,6 +574,13 @@ exports[`Media Player: Placeholder should render a video placeholder with guidan
   fill: currentColor;
   width: 0.75rem;
   height: 0.75rem;
+  color: #222222;
+}
+
+@media (max-width: 24.9375rem) {
+  .emotion-7 {
+    color: #222222;
+  }
 }
 
 .emotion-9 {
@@ -899,6 +913,13 @@ exports[`Media Player: Placeholder should render a video placeholder without dur
   fill: currentColor;
   width: 0.75rem;
   height: 0.75rem;
+  color: #222222;
+}
+
+@media (max-width: 24.9375rem) {
+  .emotion-6 {
+    color: #222222;
+  }
 }
 
 .emotion-8 {
@@ -1859,6 +1880,13 @@ exports[`Media Player: Placeholder should render no-js styles when noJsClassName
   fill: currentColor;
   width: 0.75rem;
   height: 0.75rem;
+  color: #222222;
+}
+
+@media (max-width: 24.9375rem) {
+  .emotion-7 {
+    color: #222222;
+  }
 }
 
 .emotion-9 {

--- a/src/app/contexts/RequestContext/index.test.tsx
+++ b/src/app/contexts/RequestContext/index.test.tsx
@@ -88,6 +88,7 @@ const expectedOutput = {
   serverSideExperiments: input.serverSideExperiments,
   nonce: null,
   cspHeader: null,
+  primaryMediaType: null,
 };
 
 describe('RequestContext', () => {
@@ -135,6 +136,24 @@ describe('RequestContext', () => {
       isAmp: false,
       isApp: true,
       platform: 'app',
+    });
+  });
+
+  it('should return expected values for Topic Pages where primaryMediaType is set', () => {
+    const primaryMediaTypeInput = {
+      ...input,
+      primaryMediaType: 'video',
+    };
+
+    render(
+      <RequestContextProvider {...primaryMediaTypeInput}>
+        <Component />
+      </RequestContextProvider>,
+    );
+
+    expect(use).toHaveReturnedWith({
+      ...expectedOutput,
+      primaryMediaType: 'video',
     });
   });
 

--- a/src/app/contexts/RequestContext/index.tsx
+++ b/src/app/contexts/RequestContext/index.tsx
@@ -152,7 +152,7 @@ export const RequestContextProvider = ({
       country,
       nonce,
       cspHeader,
-      primaryMediaType
+      primaryMediaType,
     }),
     [
       derivedPageType,

--- a/src/app/legacy/containers/StoryPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/StoryPromo/__snapshots__/index.test.jsx.snap
@@ -8615,6 +8615,13 @@ exports[`StoryPromo Container should render multiple Index Alsos correctly for c
   fill: currentColor;
   width: 0.75rem;
   height: 0.75rem;
+  color: #222222;
+}
+
+@media (max-width: 24.9375rem) {
+  .emotion-33 {
+    color: #222222;
+  }
 }
 
 <div>
@@ -13985,6 +13992,13 @@ exports[`StoryPromo Container should render video correctly for amp 1`] = `
   fill: currentColor;
   width: 0.75rem;
   height: 0.75rem;
+  color: #222222;
+}
+
+@media (max-width: 24.9375rem) {
+  .emotion-13 {
+    color: #222222;
+  }
 }
 
 .emotion-15 {
@@ -14426,6 +14440,13 @@ exports[`StoryPromo Container should render video correctly for canonical 1`] = 
   fill: currentColor;
   width: 0.75rem;
   height: 0.75rem;
+  color: #222222;
+}
+
+@media (max-width: 24.9375rem) {
+  .emotion-14 {
+    color: #222222;
+  }
 }
 
 .emotion-16 {
@@ -15050,6 +15071,13 @@ exports[`StoryPromo Container should render video promoType leading on amp 1`] =
   fill: currentColor;
   width: 0.75rem;
   height: 0.75rem;
+  color: #222222;
+}
+
+@media (max-width: 24.9375rem) {
+  .emotion-25 {
+    color: #222222;
+  }
 }
 
 .emotion-27 {
@@ -15321,6 +15349,13 @@ exports[`StoryPromo Container should render video promoType top on amp 1`] = `
   fill: currentColor;
   width: 0.75rem;
   height: 0.75rem;
+  color: #222222;
+}
+
+@media (max-width: 24.9375rem) {
+  .emotion-13 {
+    color: #222222;
+  }
 }
 
 .emotion-15 {

--- a/ws-nextjs-app/integration/pages/articles/afrique/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/afrique/__snapshots__/canonical.test.ts.snap
@@ -38,7 +38,7 @@ exports[`Canonical Articles Media Loader renders a figure caption 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 ew59ay91"
+        class="css-1ggua7q e18bzkgp1"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -115,7 +115,7 @@ exports[`Canonical Articles Media Loader renders a placeholder 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 ew59ay91"
+        class="css-1ggua7q e18bzkgp1"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -200,7 +200,7 @@ exports[`Canonical Articles Media Loader renders a valid container 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="css-vja2s5 ew59ay91"
+            class="css-1ggua7q e18bzkgp1"
             focusable="false"
             height="12"
             viewBox="0 0 12 12"

--- a/ws-nextjs-app/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/articles/persianMediaPlayer/__snapshots__/canonical.test.ts.snap
@@ -181,7 +181,7 @@ exports[`Canonical Articles Media Loader renders a figure caption 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 ew59ay91"
+        class="css-1ggua7q e18bzkgp1"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -258,7 +258,7 @@ exports[`Canonical Articles Media Loader renders a placeholder 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 ew59ay91"
+        class="css-1ggua7q e18bzkgp1"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -343,7 +343,7 @@ exports[`Canonical Articles Media Loader renders a valid container 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="css-vja2s5 ew59ay91"
+            class="css-1ggua7q e18bzkgp1"
             focusable="false"
             height="12"
             viewBox="0 0 12 12"

--- a/ws-nextjs-app/integration/pages/av-embeds/russian/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/av-embeds/russian/__snapshots__/canonical.test.ts.snap
@@ -34,7 +34,7 @@ exports[`Canonical Av-embeds Media Loader renders a figure caption 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 ew59ay91"
+        class="css-1ggua7q e18bzkgp1"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -111,7 +111,7 @@ exports[`Canonical Av-embeds Media Loader renders a placeholder 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 ew59ay91"
+        class="css-1ggua7q e18bzkgp1"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -196,7 +196,7 @@ exports[`Canonical Av-embeds Media Loader renders a valid container 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="css-vja2s5 ew59ay91"
+            class="css-1ggua7q e18bzkgp1"
             focusable="false"
             height="12"
             viewBox="0 0 12 12"

--- a/ws-nextjs-app/integration/pages/onDemandTVPage/hausa/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/onDemandTVPage/hausa/__snapshots__/canonical.test.ts.snap
@@ -166,7 +166,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a figure caption 1`] 
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 ew59ay91"
+        class="css-q8pkrf e18bzkgp1"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -243,7 +243,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a placeholder 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 ew59ay91"
+        class="css-q8pkrf e18bzkgp1"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -328,7 +328,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a valid container 1`]
         >
           <svg
             aria-hidden="true"
-            class="css-vja2s5 ew59ay91"
+            class="css-q8pkrf e18bzkgp1"
             focusable="false"
             height="12"
             viewBox="0 0 12 12"

--- a/ws-nextjs-app/integration/pages/onDemandTVPage/pashtoBrand/__snapshots__/canonical.test.ts.snap
+++ b/ws-nextjs-app/integration/pages/onDemandTVPage/pashtoBrand/__snapshots__/canonical.test.ts.snap
@@ -169,7 +169,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a figure caption 1`] 
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 ew59ay91"
+        class="css-q8pkrf e18bzkgp1"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -246,7 +246,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a placeholder 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-vja2s5 ew59ay91"
+        class="css-q8pkrf e18bzkgp1"
         focusable="false"
         height="12"
         viewBox="0 0 12 12"
@@ -331,7 +331,7 @@ exports[`Canonical On Demand T V Page Media Loader renders a valid container 1`]
         >
           <svg
             aria-hidden="true"
-            class="css-vja2s5 ew59ay91"
+            class="css-q8pkrf e18bzkgp1"
             focusable="false"
             height="12"
             viewBox="0 0 12 12"


### PR DESCRIPTION
Resolves JIRA: WS-2782

Summary
======
Resolve and update failing PR checks in https://github.com/bbc/simorgh/pull/14372

Code changes
======
- Update snapshots to reflect styling changes made on the video media icon.
- Update `src/app/contexts/RequestContext/index.tsx` to assert passing of `primaryMediaType`.

<img width="816" height="188" alt="Screenshot 2026-09-11 at 10 50 46" src="https://github.com/user-attachments/assets/50431af7-e00e-45e3-be53-8cf3bca280c4" />

Testing
======
1. N/A

## Useful Links
 - [Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)
 - [Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- _Add Links to useful resources related to this PR if applicable._
